### PR TITLE
fix: correct WORKER_URL default to use custom domain route

### DIFF
--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -1,7 +1,7 @@
 // ABOUTME: API client for the Divine Relay Admin Worker
 // ABOUTME: Handles signing, publishing events, and NIP-86 relay management via the server-side Worker
 
-const WORKER_URL = import.meta.env.VITE_WORKER_URL || 'https://divine-relay-admin-api.divine-video.workers.dev';
+const WORKER_URL = import.meta.env.VITE_WORKER_URL || 'https://relay.admin.divine.video';
 
 export interface UnsignedEvent {
   kind: number;


### PR DESCRIPTION
Changes the default WORKER_URL from the non-functional workers.dev subdomain to the actual custom domain route where the worker is deployed.

Problem:
- Worker is deployed to relay.admin.divine.video/api/* route
- Frontend was calling divine-relay-admin-api.divine-video.workers.dev
- That URL doesn't resolve (worker not published to workers.dev)
- All moderation actions (block media, delete event, ban user) failed silently

Solution:
- Update default WORKER_URL to https://relay.admin.divine.video
- Matches the actual worker deployment route
- Works out-of-the-box for production
- Can still override with VITE_WORKER_URL env var

Impact:
- Fixes all moderation actions on production
- Block media, delete events, ban users now work
- No environment variable needed for production deployment