### PR TITLE
chore: add repo contribution guardrails

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug Report
+description: Report a bug or regression
+title: "fix: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use generic descriptors for external partners, customers, brands, campaign names, and other sensitive identities unless a maintainer has approved naming them publicly.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: List the user flow, API call, or moderation action sequence needed to reproduce the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Result
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Result
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Include relevant environment details, logs, screenshots, or payloads. Redact secrets and sensitive external names.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature Request
+description: Propose a new feature or improvement
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use generic descriptors for external partners, customers, brands, campaign names, and other sensitive identities unless a maintainer has approved naming them publicly.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the feature or improvement.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: Explain why this work is needed.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Approach
+      description: Describe the intended behavior or implementation direction.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Include relevant UI flows, API examples, or deployment notes. Redact secrets and sensitive external names.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+
+-
+
+## Motivation
+
+-
+
+## Related Issue
+
+- Closes #
+
+## Validation
+
+- [ ] `npm run test`
+- [ ] `npx tsc --noEmit`
+- [ ] `npx vite build`
+- [ ] `cd worker && npx vitest run` if worker code changed
+- [ ] I could not run some validation locally, and I explained why below
+
+## Manual Test Plan / Notes
+
+-
+
+## Visuals / API Examples
+
+- [ ] No visual change
+- [ ] Screenshots, sample payloads, or logs attached if needed
+
+## Public Artifact Review
+
+- [ ] Titles, descriptions, branch names, and screenshots avoid partner, customer, brand, campaign, or other sensitive external names unless explicitly approved

--- a/.github/workflows/semantic_pr.yml
+++ b/.github/workflows/semantic_pr.yml
@@ -1,0 +1,12 @@
+name: Semantic PR
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-pull-request:
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@v1

--- a/.github/workflows/semantic_pr.yml
+++ b/.github/workflows/semantic_pr.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   semantic-pull-request:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@v1
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@c2e27845f65775943bc310b3ab89e5c5432b8d4d # v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Frontend application code lives under `src/`, including `components/`, `components/ui/`, `hooks/`, `lib/`, and `pages/`.
+- Cloudflare Worker code lives under `worker/src/`, with tests colocated as `*.test.ts`.
+- Environment and deploy configuration lives in `worker/wrangler.*.toml`, root `wrangler.toml`, and `.env.local` for Vite-only variables. Treat those files as the source of truth for domains and bindings.
+- Supporting docs live in `README.md`, `DEPLOYMENT.md`, `CONTEXT.md`, `NIP.md`, and `docs/`.
+
+## Build, Test, and Validation Commands
+- `npm run test`: primary repo test command.
+- `npx tsc --noEmit`: frontend and shared type-check.
+- `npx vite build`: frontend production build.
+- `cd worker && npx vitest run`: worker tests when touching worker code.
+- `cd worker && npx wrangler dev --config wrangler.local.toml`: local worker development. Never deploy with local config.
+
+## Coding Style & Naming Conventions
+- Keep frontend and worker changes scoped. Do not mix unrelated UI, worker, relay-integration, and deployment cleanup in one PR.
+- Follow the existing React, TypeScript, Tailwind, TanStack Query, and Cloudflare Worker patterns already established in the repo.
+- Verify domains, bindings, and env var names against wrangler config files before introducing or changing URLs. Do not hardcode environment-specific domains in application code.
+
+## Security & Operational Notes
+- Never commit secrets, CF Access credentials, API keys, service tokens, or screenshots/logs containing sensitive values.
+- Public issues, PRs, branch names, screenshots, and descriptions must not mention corporate partners, customers, brands, campaign names, or other sensitive external identities unless a maintainer explicitly approves it. Use generic descriptors instead.
+- If touching moderation workflows, trace side effects carefully and avoid fire-and-forget behavior.
+
+## Pull Request Guardrails
+- PR titles must use Conventional Commit format: `type(scope): summary` or `type: summary`.
+- Set the correct PR title when opening the PR. Do not rely on fixing it later.
+- If a PR title is edited after opening, verify that the semantic PR title check reruns successfully.
+- Keep PRs tightly scoped. Do not include unrelated formatting churn, dependency noise, or drive-by refactors.
+- Temporary or transitional code must include `TODO(#issue):` with a tracking issue.
+- UI or externally visible API changes should include screenshots, sample payloads, or an explicit note that there is no visual change.
+- PR descriptions must include a summary, motivation, linked issue, and manual validation plan.
+- Before requesting review, run the relevant checks for the files you changed, or note what you could not run.


### PR DESCRIPTION
## Summary
- add repo-local contributor and agent guardrails in AGENTS.md
- add semantic PR title enforcement plus PR and issue templates
- reinforce redaction of sensitive external names in public repo artifacts

## Motivation
- make repo-local contribution expectations explicit for humans and AI agents
- align this repo with the org standard without duplicating existing internal architecture docs

## Validation
- not run; docs and GitHub metadata changes only