### PR TITLE
fix: add blob: to media-src CSP for proxied video previews

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <meta property="og:description" content="Manage your Nostr relay with ease using NIP-07 signing" />
     <title>Nostr Relay Manager</title>
     <link rel="manifest" href="/manifest.json" />
-    <meta http-equiv="content-security-policy" content="default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'self' https:; font-src 'self'; base-uri 'self'; manifest-src 'self'; connect-src 'self' blob: https: wss:; img-src 'self' data: blob: https:; media-src 'self' https:">
+    <meta http-equiv="content-security-policy" content="default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'self' https:; font-src 'self'; base-uri 'self'; manifest-src 'self'; connect-src 'self' blob: https: wss:; img-src 'self' data: blob: https:; media-src 'self' blob: https:">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

Adds `blob:` to the `media-src` CSP directive in `index.html`. Proxied restricted media creates blob URLs that `media-src 'self' https:` was blocking. `img-src` and `connect-src` already allow `blob:` -- this aligns `media-src`.

## Motivation

Restricted video content loads through the admin media proxy (`/api/media-proxy/{sha256}`), which fetches from the media server's admin endpoint and creates a blob URL for the `<video>` element. CSP was blocking the blob URL, causing the AlertTriangle fallback instead of the video preview.

## Related Issue

- Relates to moderation media preview workflow

## Validation

- [x] `npm run test`
- [x] `npx tsc --noEmit`
- [x] `npx vite build`
- [x] No worker code changed

## Manual Test Plan / Notes

- [x] Playwright network capture: proxy requests return 200, no CSP console errors for blob URLs
- [x] Deployed to production Pages, opened NS-sexualContent report with age-restricted video -- video preview renders correctly through proxy chain
- [x] Non-restricted media still loads directly (verified on NS-spam report with external video)

## Visuals / API Examples

- [x] No visual change (CSP header only; video rendering was broken before, now works)

## Public Artifact Review

- [x] Titles, descriptions, branch names, and screenshots avoid partner, customer, brand, campaign, or other sensitive external names unless explicitly approved