### PR TITLE
Add product trust stats dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,8 @@ dist-ssr
 # Git worktrees
 .worktrees/
 
+# Local brainstorming companion artifacts
+.superpowers/
+
 # Local TLS certs (mkcert)
 .certs/

--- a/docs/superpowers/plans/2026-05-02-product-trust-stats-dashboard.md
+++ b/docs/superpowers/plans/2026-05-02-product-trust-stats-dashboard.md
@@ -1,0 +1,562 @@
+# Product + Trust Stats Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an in-app Product + Trust pulse and Stats & Trends page to relay-manager without changing `divine-funnelcake`.
+
+**Architecture:** Add a relay-manager worker aggregate endpoint that composes existing Funnelcake REST reads, relay WebSocket queries, and report queue data into one dashboard payload. The frontend fetches that payload through `adminApi`, renders a compact top pulse in `RelayManager`, and exposes a `/stats` tab for details.
+
+**Tech Stack:** Cloudflare Workers TypeScript, React 18, TanStack Query, React Router, Tailwind/shadcn UI, Vitest.
+
+---
+
+## File Structure
+
+- Create `worker/src/dashboard-stats.ts`
+  - Owns dashboard stat types, Funnelcake proxy reads, relay queries for recent video posts, report queue aggregation, partial-data statuses, and `handleDashboardStats`.
+- Create `worker/src/dashboard-stats.test.ts`
+  - Unit tests for aggregation behavior and partial failures.
+- Modify `worker/src/index.ts`
+  - Add `/api/dashboard-stats` route and import handler.
+- Modify `src/lib/adminApi.ts`
+  - Add dashboard stats response types and `fetchDashboardStats(apiUrl)`.
+- Modify `src/hooks/useAdminApi.ts`
+  - Bind `fetchDashboardStats`.
+- Create `src/components/DashboardPulse.tsx`
+  - Compact top strip with Active users, Video posts, Views / loops, Pending reports, and link to `/stats`.
+- Create `src/components/DashboardPulse.test.tsx`
+  - Render live, partial, and unavailable states.
+- Create `src/components/StatsTrends.tsx`
+  - Detail page for KPI cards, top videos, top creators, and data-source status.
+- Create `src/components/StatsTrends.test.tsx`
+  - Route-level rendering tests for fetched dashboard payload.
+- Modify `src/components/RelayManager.tsx`
+  - Add `stats` tab, render `DashboardPulse`, wire `StatsTrends`.
+- Modify `src/AppRouter.tsx`
+  - Add `/stats` route.
+
+## Chunk 1: Worker Aggregate Endpoint
+
+### Task 1: Define Dashboard Stats Contract
+
+**Files:**
+- Create: `worker/src/dashboard-stats.ts`
+- Test: `worker/src/dashboard-stats.test.ts`
+
+- [ ] **Step 1: Write failing tests for payload shape**
+
+Add tests that import pure helpers from `dashboard-stats.ts`:
+
+```ts
+it('summarizes video activity from recent relay events', () => {
+  const now = 1_800_000_000;
+  const events = [
+    { id: 'a', pubkey: 'alice', kind: 34236, created_at: now - 100, tags: [], content: '', sig: '' },
+    { id: 'b', pubkey: 'alice', kind: 34235, created_at: now - 5000, tags: [], content: '', sig: '' },
+    { id: 'c', pubkey: 'bob', kind: 22, created_at: now - 50, tags: [], content: '', sig: '' },
+  ];
+
+  expect(summarizeVideoActivity(events, now)).toEqual({
+    postsLastHour: 2,
+    postsLastDay: 3,
+    activePublishersLastDay: 2,
+  });
+});
+
+it('marks auth telemetry unavailable without failing dashboard stats', () => {
+  expect(buildUnavailableAuthTelemetry()).toMatchObject({
+    registrations: { status: 'unavailable' },
+    logins: { status: 'unavailable' },
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `npx vitest run worker/src/dashboard-stats.test.ts`
+
+Expected: FAIL because `dashboard-stats.ts` and helpers do not exist.
+
+- [ ] **Step 3: Implement minimal types and helpers**
+
+Create:
+
+```ts
+export type MetricStatus = 'live' | 'partial' | 'unavailable' | 'error';
+
+export interface DashboardMetric<T> {
+  value: T;
+  status: MetricStatus;
+  message?: string;
+}
+
+export interface VideoActivitySummary {
+  postsLastHour: number;
+  postsLastDay: number;
+  activePublishersLastDay: number;
+}
+
+export function summarizeVideoActivity(events: Array<{ pubkey: string; created_at: number }>, now: number): VideoActivitySummary {
+  const oneHourAgo = now - 60 * 60;
+  const oneDayAgo = now - 24 * 60 * 60;
+  const dayPublishers = new Set<string>();
+
+  let postsLastHour = 0;
+  let postsLastDay = 0;
+
+  for (const event of events) {
+    if (event.created_at >= oneDayAgo) {
+      postsLastDay += 1;
+      dayPublishers.add(event.pubkey);
+    }
+    if (event.created_at >= oneHourAgo) {
+      postsLastHour += 1;
+    }
+  }
+
+  return {
+    postsLastHour,
+    postsLastDay,
+    activePublishersLastDay: dayPublishers.size,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run: `npx vitest run worker/src/dashboard-stats.test.ts`
+
+Expected: PASS for helper tests.
+
+### Task 2: Fetch Existing Funnelcake Sources
+
+**Files:**
+- Modify: `worker/src/dashboard-stats.ts`
+- Test: `worker/src/dashboard-stats.test.ts`
+
+- [ ] **Step 1: Write failing tests for existing Funnelcake reads**
+
+Mock `fetch` so:
+
+- `https://relay.test.com/api/stats` returns `{ total_events: 100, total_videos: 25, vine_videos: 10 }`
+- `https://relay.test.com/api/leaderboard/videos?period=day&limit=10` returns one entry with `views` and `loops`
+- `https://relay.test.com/api/leaderboard/creators?period=day&limit=10` returns one creator
+
+Assert `fetchFunnelcakeDashboardSources('https://relay.test.com')` returns stats, top videos, top creators, and summed day views/loops from returned entries.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `npx vitest run worker/src/dashboard-stats.test.ts`
+
+Expected: FAIL because `fetchFunnelcakeDashboardSources` is missing.
+
+- [ ] **Step 3: Implement existing endpoint reads only**
+
+Use `deriveFunnelcakeApiUrl(env.RELAY_URL, env.FUNNELCAKE_API_URL)` from `./funnelcake-proxy`.
+
+Fetch only existing endpoints:
+
+```ts
+const [stats, videos, creators] = await Promise.allSettled([
+  fetchJson<PlatformStats>(`${baseUrl}/api/stats`),
+  fetchJson<LeaderboardResponse<LeaderboardVideo>>(`${baseUrl}/api/leaderboard/videos?period=day&limit=10`),
+  fetchJson<LeaderboardResponse<LeaderboardCreator>>(`${baseUrl}/api/leaderboard/creators?period=day&limit=10`),
+]);
+```
+
+If a source rejects, return that group with `status: 'error'` and keep the rest.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run: `npx vitest run worker/src/dashboard-stats.test.ts`
+
+Expected: PASS, including partial failure behavior.
+
+### Task 3: Add Relay and Trust Aggregation
+
+**Files:**
+- Modify: `worker/src/dashboard-stats.ts`
+- Test: `worker/src/dashboard-stats.test.ts`
+
+- [ ] **Step 1: Write failing tests for relay/trust aggregation**
+
+Stub `WebSocket` so it returns:
+
+- recent video events for `{ kinds: [21, 22, 34235, 34236], since: now - 86400 }`
+- report events for `{ kinds: [1984], limit: 200 }`
+- resolution labels for `{ kinds: [1985], '#L': ['moderation/resolution'], limit: 500 }`
+
+Assert pending report targets exclude resolved targets.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `npx vitest run worker/src/dashboard-stats.test.ts`
+
+Expected: FAIL because relay/trust aggregation is missing.
+
+- [ ] **Step 3: Implement relay query helper and trust summary**
+
+Use a local `queryRelayEvents(filter, relayUrl)` helper modeled on `queryRelay` in `worker/src/index.ts`. Keep timeout at 5 seconds.
+
+Trust summary:
+
+- Report target ID comes from first `e` tag, else first `p` tag.
+- Resolution target ID comes from first `e` tag, else first `p` tag.
+- Pending target count is unique report targets minus resolved targets.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run: `npx vitest run worker/src/dashboard-stats.test.ts`
+
+Expected: PASS.
+
+### Task 4: Expose `/api/dashboard-stats`
+
+**Files:**
+- Modify: `worker/src/index.ts`
+- Modify: `worker/src/dashboard-stats.ts`
+- Test: `worker/src/dashboard-stats.test.ts`
+
+- [ ] **Step 1: Write failing route test**
+
+Call worker fetch:
+
+```ts
+const request = new Request('http://localhost/api/dashboard-stats', {
+  headers: { 'Cf-Access-Jwt-Assertion': 'test' },
+});
+
+const response = await worker.fetch(request, env as never, mockCtx);
+expect(response.status).toBe(200);
+expect(await response.json()).toMatchObject({ success: true });
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `npx vitest run worker/src/dashboard-stats.test.ts`
+
+Expected: FAIL because route is not registered.
+
+- [ ] **Step 3: Register route**
+
+In `worker/src/index.ts`:
+
+```ts
+import { handleDashboardStats } from './dashboard-stats';
+```
+
+Inside the authenticated route block:
+
+```ts
+if (path === '/api/dashboard-stats' && request.method === 'GET') {
+  return handleDashboardStats(env, corsHeaders);
+}
+```
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run: `npx vitest run worker/src/dashboard-stats.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit worker endpoint**
+
+```bash
+git add worker/src/index.ts worker/src/dashboard-stats.ts worker/src/dashboard-stats.test.ts
+git commit -m "feat: add dashboard stats aggregate endpoint"
+```
+
+## Chunk 2: Frontend API Contract
+
+### Task 5: Add Admin API Client
+
+**Files:**
+- Modify: `src/lib/adminApi.ts`
+- Modify: `src/lib/adminApi.test.ts`
+- Modify: `src/hooks/useAdminApi.ts`
+
+- [ ] **Step 1: Write failing client test**
+
+Add to `src/lib/adminApi.test.ts`:
+
+```ts
+it('fetchDashboardStats calls /api/dashboard-stats', async () => {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ success: true, stats: { generatedAt: '2026-05-02T00:00:00.000Z' } }),
+  });
+
+  const result = await fetchDashboardStats(API_URL);
+
+  expect(mockFetch).toHaveBeenCalledWith(
+    `${API_URL}/api/dashboard-stats`,
+    expect.objectContaining({ method: 'GET' }),
+  );
+  expect(result.success).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `npx vitest run src/lib/adminApi.test.ts`
+
+Expected: FAIL because `fetchDashboardStats` is missing.
+
+- [ ] **Step 3: Add types and client function**
+
+Export `DashboardStatsResponse` and `fetchDashboardStats(apiUrl)`.
+
+```ts
+export async function fetchDashboardStats(apiUrl: string): Promise<DashboardStatsResponse> {
+  return apiRequest<DashboardStatsResponse>(apiUrl, '/api/dashboard-stats', 'GET');
+}
+```
+
+Bind it in `useAdminApi()`.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run: `npx vitest run src/lib/adminApi.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit API client**
+
+```bash
+git add src/lib/adminApi.ts src/lib/adminApi.test.ts src/hooks/useAdminApi.ts
+git commit -m "feat: add dashboard stats admin client"
+```
+
+## Chunk 3: Dashboard Pulse UI
+
+### Task 6: Build Pulse Component
+
+**Files:**
+- Create: `src/components/DashboardPulse.tsx`
+- Create: `src/components/DashboardPulse.test.tsx`
+
+- [ ] **Step 1: Write failing render tests**
+
+Mock `useAdminApi().fetchDashboardStats` to return:
+
+- active publishers `12`
+- video posts `3` last hour and `44` last day
+- views/loops `1200 / 950`
+- pending reports `7`
+
+Assert those labels and values render, and that the “Open Stats & Trends” link points to `/stats`.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `npx vitest run src/components/DashboardPulse.test.tsx`
+
+Expected: FAIL because component does not exist.
+
+- [ ] **Step 3: Implement `DashboardPulse`**
+
+Use `useQuery` with query key `['dashboard-stats']` and `useAdminApi().fetchDashboardStats`.
+
+Render four cards:
+
+- Active users
+- Video posts
+- Views / loops
+- Pending reports
+
+Render unavailable/partial badges from metric status. Keep cards compact and responsive:
+
+```tsx
+<div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+```
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run: `npx vitest run src/components/DashboardPulse.test.tsx`
+
+Expected: PASS.
+
+### Task 7: Wire Pulse Into RelayManager
+
+**Files:**
+- Modify: `src/components/RelayManager.tsx`
+
+- [ ] **Step 1: Write failing integration test or route smoke test**
+
+Add or extend a component test to render `RelayManager` in `TestApp` and assert `Product + Trust Pulse` appears.
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run: `npx vitest run src/components/DashboardPulse.test.tsx`
+
+Expected: FAIL until `RelayManager` renders pulse.
+
+- [ ] **Step 3: Add pulse above tabs**
+
+In `RelayManager`, import `DashboardPulse` and render it inside the main container before `Tabs`.
+
+Change the container layout from a single `Tabs` child to a column:
+
+```tsx
+<div className="flex-1 min-h-0 overflow-hidden container mx-auto px-4 py-4 flex flex-col gap-4">
+  <DashboardPulse />
+  <Tabs value={currentTab} onValueChange={handleTabChange} className="flex-1 min-h-0 flex flex-col">
+```
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run: `npx vitest run src/components/DashboardPulse.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit pulse**
+
+```bash
+git add src/components/DashboardPulse.tsx src/components/DashboardPulse.test.tsx src/components/RelayManager.tsx
+git commit -m "feat: add product trust dashboard pulse"
+```
+
+## Chunk 4: Stats & Trends Page
+
+### Task 8: Build Detail Page
+
+**Files:**
+- Create: `src/components/StatsTrends.tsx`
+- Create: `src/components/StatsTrends.test.tsx`
+
+- [ ] **Step 1: Write failing detail page test**
+
+Mock dashboard stats and assert the page renders:
+
+- `Stats & Trends`
+- `Top videos today`
+- `Top creators today`
+- `Data sources`
+- unavailable registration/login rows
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `npx vitest run src/components/StatsTrends.test.tsx`
+
+Expected: FAIL because component does not exist.
+
+- [ ] **Step 3: Implement `StatsTrends`**
+
+Use the same query contract as `DashboardPulse`.
+
+Render:
+
+- KPI card grid
+- Top videos list from `stats.funnelcake.topVideos.entries`
+- Top creators list from `stats.funnelcake.topCreators.entries`
+- Data-source status list
+
+Do not add charts until the worker returns real time series.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run: `npx vitest run src/components/StatsTrends.test.tsx`
+
+Expected: PASS.
+
+### Task 9: Add Route and Tab
+
+**Files:**
+- Modify: `src/AppRouter.tsx`
+- Modify: `src/components/RelayManager.tsx`
+
+- [ ] **Step 1: Write failing route/tab test**
+
+Render `/stats` and assert the Stats & Trends tab/page appears.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `npx vitest run src/components/StatsTrends.test.tsx`
+
+Expected: FAIL because `/stats` is not routed.
+
+- [ ] **Step 3: Wire route and tab**
+
+In `AppRouter.tsx` add:
+
+```tsx
+<Route path="/stats" element={<Index />} />
+```
+
+In `RelayManager.tsx`:
+
+- Add `{ id: 'stats', label: 'Stats', icon: BarChart3 }`
+- Update `getTabFromPath` for `/stats`
+- Change tab grid from `grid-cols-6` to `grid-cols-7`
+- Add:
+
+```tsx
+<TabsContent value="stats" className="flex-1 min-h-0 overflow-auto mt-4">
+  <StatsTrends />
+</TabsContent>
+```
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run: `npx vitest run src/components/StatsTrends.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit detail page**
+
+```bash
+git add src/components/StatsTrends.tsx src/components/StatsTrends.test.tsx src/AppRouter.tsx src/components/RelayManager.tsx
+git commit -m "feat: add stats trends page"
+```
+
+## Chunk 5: Verification
+
+### Task 10: Full Verification
+
+**Files:**
+- No new files.
+
+- [ ] **Step 1: Run focused tests**
+
+```bash
+npx vitest run worker/src/dashboard-stats.test.ts src/lib/adminApi.test.ts src/components/DashboardPulse.test.tsx src/components/StatsTrends.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run type check**
+
+```bash
+npx tsc -p tsconfig.app.json --noEmit
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full test command**
+
+```bash
+npm run test
+```
+
+Expected: PASS. This runs install, type-check, lint, Vitest, and Vite build.
+
+- [ ] **Step 4: Start dev server for manual check**
+
+```bash
+npm run dev -- --host 127.0.0.1
+```
+
+Open the printed local URL and verify:
+
+- The dashboard pulse appears above tabs
+- The pulse link opens `/stats`
+- The `Stats` tab opens the detail page
+- Missing registration/login telemetry is clearly labeled unavailable
+- Reports, Events, Users, Labels, Settings, and Debug tabs still work
+
+- [ ] **Step 5: Final status**
+
+```bash
+git status --short
+```
+
+Expected: only intentional changes or unrelated pre-existing untracked files.

--- a/docs/superpowers/specs/2026-05-02-product-trust-stats-dashboard-design.md
+++ b/docs/superpowers/specs/2026-05-02-product-trust-stats-dashboard-design.md
@@ -1,0 +1,101 @@
+# Product + Trust Stats Dashboard Design
+
+## Goal
+
+Give the relay admin team a quick sense of how diVine is going from inside the existing moderation dashboard: product activity, video publishing, views/loops, and current trust workload.
+
+## Constraints
+
+- Do not require changes to `divine-funnelcake`.
+- Use existing Funnelcake REST endpoints only.
+- Keep missing product telemetry visible but honest. Registrations and logins should not be fabricated.
+- Keep the feature inside `divine-relay-manager`; no new app.
+
+## Recommended Approach
+
+Add a relay-manager worker aggregate endpoint, then build two frontend surfaces from that one payload.
+
+The worker endpoint, tentatively `GET /api/dashboard-stats`, will normalize:
+
+- Existing Funnelcake `/api/stats`
+- Existing Funnelcake `/api/leaderboard/videos?period=day`
+- Existing Funnelcake `/api/leaderboard/creators?period=day`
+- Existing relay WebSocket queries for recent video posts
+- Existing reports and resolution-label queries for trust workload
+- Placeholder metadata for registrations/logins when no source is wired
+
+The frontend should not make multiple low-level stats calls directly. It should call the aggregate endpoint and render a consistent loading/error/partial-data state.
+
+## Dashboard Pulse
+
+Add `DashboardPulse` near the top of the existing admin shell, above tab content. It should summarize:
+
+- Active users: unique pubkeys with recent video publishing activity, plus view activity if a real source is available
+- Video posts: last hour and last 24 hours
+- Views / loops: last 24 hours from existing Funnelcake leaderboard/stat data where available
+- Pending reports: unresolved report targets from the current moderation queue
+
+Each card should show whether its data is live, partial, or unavailable. The top strip links to `/stats`.
+
+## Stats & Trends Page
+
+Add a new in-app tab/route named `Stats & Trends`.
+
+The detailed page should include:
+
+- KPI cards for the same product + trust metrics
+- A trend section for hourly/daily buckets when the worker can compute them from existing data
+- Top videos today from existing Funnelcake leaderboard data
+- Top creators today from existing Funnelcake leaderboard data
+- Data source status, including unavailable registrations/logins
+
+This page should be useful even if registration/login telemetry is not wired yet.
+
+## Data Definitions
+
+Video kinds should follow the app's existing NIP-71 convention: `21`, `22`, `34235`, `34236`.
+
+Recent publishing metrics can be computed from relay queries using `since` timestamps.
+
+Active users for v1 means unique pubkeys with recent video publishing activity. If kind `22236` view events are available through the relay without excessive cost, the worker may add unique viewers; otherwise the UI should label the metric as publishing activity.
+
+Views and loops should come from existing Funnelcake responses where they already exist. The relay-manager worker must not infer or backfill them from raw data in a way that changes Funnelcake semantics.
+
+Registrations and logins should render as unavailable until an existing auth telemetry source is identified.
+
+## Error Handling
+
+The aggregate endpoint should return partial results when one upstream source fails. Each metric group should include a status and optional message so the UI can show useful cards instead of a full-page failure.
+
+Suggested statuses:
+
+- `live`
+- `partial`
+- `unavailable`
+- `error`
+
+The UI should keep the moderation dashboard usable when stats fail.
+
+## Testing
+
+Worker tests should cover:
+
+- Proxies existing Funnelcake stats and leaderboards
+- Computes recent video post counts from mocked relay responses
+- Computes pending trust workload from mocked reports/resolution labels
+- Returns partial results when Funnelcake fails
+- Marks registrations/logins unavailable without failing the endpoint
+
+Frontend tests should cover:
+
+- Top pulse renders live metrics
+- Unavailable metrics render clearly
+- `/stats` route is available from the tab list and pulse link
+- Detailed page renders top videos/creators and data-source status
+
+## Out Of Scope
+
+- `divine-funnelcake` migrations, handlers, or schema changes
+- A separate product analytics app
+- New registration/login instrumentation
+- Raw ClickHouse access from relay-manager

--- a/src/AppRouter.test.tsx
+++ b/src/AppRouter.test.tsx
@@ -1,0 +1,62 @@
+// ABOUTME: Tests route registration for the detailed stats dashboard
+// ABOUTME: Verifies /stats opens the product and trust trends page inside the app shell
+
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import App from './App';
+
+const mocks = vi.hoisted(() => ({
+  fetchDashboardStats: vi.fn(),
+}));
+
+vi.mock('@/hooks/useAdminApi', () => ({
+  useAdminApi: () => ({
+    fetchDashboardStats: mocks.fetchDashboardStats,
+  }),
+}));
+
+const dashboardResponse = {
+  success: true,
+  stats: {
+    generatedAt: '2026-05-02T00:00:00.000Z',
+    platform: { value: { total_events: 120, total_videos: 30, vine_videos: 9 }, status: 'live' },
+    videoActivity: {
+      value: { postsLastHour: 2, postsLastDay: 12, activePublishersLastDay: 4 },
+      status: 'live',
+    },
+    engagement: {
+      value: {
+        viewsLastDay: 80,
+        uniqueViewersLastDay: 24,
+        loopsLastDay: 42,
+        source: 'leaderboard_top_day',
+      },
+      status: 'partial',
+    },
+    trust: { value: { pendingReports: 3, reportTargets: 6, resolvedTargets: 3 }, status: 'live' },
+    topVideos: { value: [], status: 'live' },
+    topCreators: { value: [], status: 'live' },
+    auth: {
+      registrations: { value: null, status: 'unavailable' },
+      logins: { value: null, status: 'unavailable' },
+    },
+  },
+};
+
+describe('AppRouter stats route', () => {
+  beforeEach(() => {
+    window.history.pushState({}, '', '/stats');
+    mocks.fetchDashboardStats.mockResolvedValue(dashboardResponse);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    window.history.pushState({}, '', '/');
+  });
+
+  it('renders Stats & Trends at /stats', async () => {
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { name: 'Stats & Trends' })).toBeInTheDocument();
+  });
+});

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -11,6 +11,7 @@ export function AppRouter() {
       <Routes>
         {/* Main tabs - each tab gets its own route */}
         <Route path="/" element={<Navigate to="/reports" replace />} />
+        <Route path="/stats" element={<Index />} />
         <Route path="/events" element={<Index />} />
         <Route path="/users" element={<Index />} />
         <Route path="/users/:pubkey" element={<Index />} />

--- a/src/components/DashboardPulse.test.tsx
+++ b/src/components/DashboardPulse.test.tsx
@@ -1,0 +1,72 @@
+// ABOUTME: Tests for the compact dashboard product and trust stats strip
+// ABOUTME: Verifies top-level pulse metrics and drill-down navigation
+
+import { render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import TestApp from '@/test/TestApp';
+import { DashboardPulse } from './DashboardPulse';
+
+const mocks = vi.hoisted(() => ({
+  fetchDashboardStats: vi.fn(),
+}));
+
+vi.mock('@/hooks/useAdminApi', () => ({
+  useAdminApi: () => ({
+    fetchDashboardStats: mocks.fetchDashboardStats,
+  }),
+}));
+
+const dashboardResponse = {
+  success: true,
+  stats: {
+    generatedAt: '2026-05-02T00:00:00.000Z',
+    platform: { value: { total_events: 120, total_videos: 30, vine_videos: 9 }, status: 'live' },
+    videoActivity: {
+      value: { postsLastHour: 2, postsLastDay: 12, activePublishersLastDay: 4 },
+      status: 'live',
+    },
+    engagement: {
+      value: {
+        viewsLastDay: 80,
+        uniqueViewersLastDay: 24,
+        loopsLastDay: 42,
+        source: 'leaderboard_top_day',
+      },
+      status: 'partial',
+    },
+    trust: { value: { pendingReports: 3, reportTargets: 6, resolvedTargets: 3 }, status: 'live' },
+    topVideos: { value: [], status: 'live' },
+    topCreators: { value: [], status: 'live' },
+    auth: {
+      registrations: { value: null, status: 'unavailable' },
+      logins: { value: null, status: 'unavailable' },
+    },
+  },
+};
+
+describe('DashboardPulse', () => {
+  beforeEach(() => {
+    mocks.fetchDashboardStats.mockResolvedValue(dashboardResponse);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders product and trust pulse metrics with a stats drill-down link', async () => {
+    render(
+      <TestApp>
+        <DashboardPulse />
+      </TestApp>
+    );
+
+    expect(await screen.findByText('Product + Trust Pulse')).toBeInTheDocument();
+    expect(within(screen.getByLabelText('Active users')).getByText('4')).toBeInTheDocument();
+    expect(within(screen.getByLabelText('Video posts')).getByText('30')).toBeInTheDocument();
+    expect(within(screen.getByLabelText('Videos last hour')).getByText('2')).toBeInTheDocument();
+    expect(within(screen.getByLabelText('Loops last day')).getByText('42')).toBeInTheDocument();
+    expect(within(screen.getByLabelText('Pending reports')).getByText('3')).toBeInTheDocument();
+
+    expect(screen.getByRole('link', { name: /Stats & trends/i })).toHaveAttribute('href', '/stats');
+  });
+});

--- a/src/components/DashboardPulse.tsx
+++ b/src/components/DashboardPulse.tsx
@@ -1,0 +1,146 @@
+// ABOUTME: Compact product and trust stats strip for the admin dashboard
+// ABOUTME: Shows key operational health signals with a link to detailed trends
+
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import type { ComponentType } from 'react';
+import { AlertTriangle, ArrowRight, Flag, Repeat2, Users, Video } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useAdminApi } from '@/hooks/useAdminApi';
+import { DASHBOARD_STATS_QUERY_KEY, formatCount, formatStatus, statusTone } from '@/lib/dashboardStatsFormat';
+import type { DashboardStats } from '@/lib/adminApi';
+
+interface PulseMetricProps {
+  label: string;
+  value: number;
+  icon: ComponentType<{ className?: string }>;
+}
+
+function PulseMetric({ label, value, icon: Icon }: PulseMetricProps) {
+  return (
+    <div
+      aria-label={label}
+      className="rounded-md border bg-background px-3 py-2 shadow-sm"
+    >
+      <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+        <Icon className="h-3.5 w-3.5 shrink-0" />
+        <span className="truncate">{label}</span>
+      </div>
+      <div className="mt-1 text-2xl font-semibold tabular-nums leading-none">
+        {formatCount(value)}
+      </div>
+    </div>
+  );
+}
+
+function PulseSkeleton() {
+  return (
+    <section className="rounded-lg border bg-white/85 p-3 shadow-sm dark:bg-gray-900/85">
+      <div className="flex items-center justify-between gap-3">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-8 w-28" />
+      </div>
+      <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
+        {Array.from({ length: 5 }).map((_, index) => (
+          <Skeleton key={index} className="h-16 rounded-md" />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function metricsFromStats(stats: DashboardStats) {
+  return [
+    {
+      label: 'Active users',
+      value: stats.videoActivity.value.activePublishersLastDay,
+      icon: Users,
+    },
+    {
+      label: 'Video posts',
+      value: stats.platform.value?.total_videos ?? 0,
+      icon: Video,
+    },
+    {
+      label: 'Videos last hour',
+      value: stats.videoActivity.value.postsLastHour,
+      icon: Video,
+    },
+    {
+      label: 'Loops last day',
+      value: stats.engagement.value.loopsLastDay,
+      icon: Repeat2,
+    },
+    {
+      label: 'Pending reports',
+      value: stats.trust.value.pendingReports,
+      icon: Flag,
+    },
+  ];
+}
+
+export function DashboardPulse() {
+  const adminApi = useAdminApi();
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: DASHBOARD_STATS_QUERY_KEY,
+    queryFn: adminApi.fetchDashboardStats,
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  });
+
+  if (isLoading) {
+    return <PulseSkeleton />;
+  }
+
+  if (isError || !data?.stats) {
+    return (
+      <section className="rounded-lg border border-red-200 bg-red-50 p-3 text-red-800 shadow-sm dark:border-red-900 dark:bg-red-950 dark:text-red-200">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <AlertTriangle className="h-4 w-4" />
+          <span>Stats unavailable</span>
+        </div>
+        <p className="mt-1 text-sm opacity-80">
+          {error instanceof Error ? error.message : 'Unable to load dashboard stats.'}
+        </p>
+      </section>
+    );
+  }
+
+  const stats = data.stats;
+
+  return (
+    <section className="rounded-lg border bg-white/85 p-3 shadow-sm backdrop-blur-sm dark:bg-gray-900/85">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-base font-semibold leading-none">Product + Trust Pulse</h2>
+            <span className={`rounded-full border px-2 py-0.5 text-xs font-medium ${statusTone(stats.videoActivity.status)}`}>
+              {formatStatus(stats.videoActivity.status)}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              Updated {new Date(stats.generatedAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}
+            </span>
+          </div>
+        </div>
+        <Button asChild variant="outline" size="sm" className="shrink-0 self-start lg:self-auto">
+          <Link to="/stats">
+            Stats & trends
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </Link>
+        </Button>
+      </div>
+
+      <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
+        {metricsFromStats(stats).map(metric => (
+          <PulseMetric
+            key={metric.label}
+            label={metric.label}
+            value={metric.value}
+            icon={metric.icon}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/RelayManager.tsx
+++ b/src/components/RelayManager.tsx
@@ -10,15 +10,18 @@ import { Labels } from "@/components/Labels";
 import { DebugPanel } from "@/components/DebugPanel";
 import { SettingsDashboard } from "@/components/SettingsDashboard";
 import { EnvironmentSelector } from "@/components/EnvironmentSelector";
+import { DashboardPulse } from "@/components/DashboardPulse";
+import { StatsTrends } from "@/components/StatsTrends";
 import { Card } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Server, FileText, Users, Settings, Flag, Tag, Bug, GripVertical } from "lucide-react";
+import { Server, FileText, Users, Settings, Flag, Tag, Bug, GripVertical, BarChart3 } from "lucide-react";
 import { useAppContext } from "@/hooks/useAppContext";
 import AdminBar from "@/components/AdminBar";
 
 // Tab definitions in default order (Reports first for moderation workflow)
 const TAB_DEFINITIONS = [
   { id: 'reports', label: 'Reports', icon: Flag },
+  { id: 'stats', label: 'Stats', icon: BarChart3 },
   { id: 'events', label: 'Events', icon: FileText },
   { id: 'users', label: 'Users', icon: Users },
   { id: 'labels', label: 'Labels', icon: Tag },
@@ -60,6 +63,7 @@ function saveTabOrder(order: TabId[]): void {
 
 // Map URL paths to tab values
 function getTabFromPath(pathname: string): string {
+  if (pathname.startsWith('/stats')) return 'stats';
   if (pathname.startsWith('/events')) return 'events';
   if (pathname.startsWith('/users')) return 'users';
   if (pathname.startsWith('/reports')) return 'reports';
@@ -165,9 +169,10 @@ export function RelayManager() {
         </div>
       </header>
 
-      <div className="flex-1 min-h-0 overflow-hidden container mx-auto px-4 py-4">
-        <Tabs value={currentTab} onValueChange={handleTabChange} className="h-full flex flex-col">
-          <TabsList className="shrink-0 grid w-full grid-cols-6">
+      <div className="flex-1 min-h-0 overflow-hidden container mx-auto px-4 py-4 flex flex-col gap-4">
+        <DashboardPulse />
+        <Tabs value={currentTab} onValueChange={handleTabChange} className="flex-1 min-h-0 flex flex-col">
+          <TabsList className="shrink-0 grid w-full grid-cols-7">
             {orderedTabs.map((tab) => {
               const Icon = tab.icon;
               const isDragOver = dragOverTab === tab.id;
@@ -203,6 +208,10 @@ export function RelayManager() {
 
           <TabsContent value="reports" className="flex-1 min-h-0 mt-4">
             <Reports relayUrl={config.relayUrl} selectedReportId={params.reportId} />
+          </TabsContent>
+
+          <TabsContent value="stats" className="flex-1 min-h-0 overflow-auto mt-4">
+            <StatsTrends />
           </TabsContent>
 
           <TabsContent value="labels" className="flex-1 min-h-0 mt-4">

--- a/src/components/StatsTrends.test.tsx
+++ b/src/components/StatsTrends.test.tsx
@@ -1,0 +1,85 @@
+// ABOUTME: Tests for the detailed product and trust stats dashboard page
+// ABOUTME: Verifies metric groups, leaderboard rows, and unavailable auth telemetry status
+
+import { render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import TestApp from '@/test/TestApp';
+import { StatsTrends } from './StatsTrends';
+
+const mocks = vi.hoisted(() => ({
+  fetchDashboardStats: vi.fn(),
+}));
+
+vi.mock('@/hooks/useAdminApi', () => ({
+  useAdminApi: () => ({
+    fetchDashboardStats: mocks.fetchDashboardStats,
+  }),
+}));
+
+const dashboardResponse = {
+  success: true,
+  stats: {
+    generatedAt: '2026-05-02T00:00:00.000Z',
+    platform: { value: { total_events: 120, total_videos: 30, vine_videos: 9 }, status: 'live' },
+    videoActivity: {
+      value: { postsLastHour: 2, postsLastDay: 12, activePublishersLastDay: 4 },
+      status: 'live',
+    },
+    engagement: {
+      value: {
+        viewsLastDay: 80,
+        uniqueViewersLastDay: 24,
+        loopsLastDay: 42,
+        source: 'leaderboard_top_day',
+      },
+      status: 'partial',
+    },
+    trust: { value: { pendingReports: 3, reportTargets: 6, resolvedTargets: 3 }, status: 'live' },
+    topVideos: {
+      value: [
+        { id: 'video-a', author: 'alice', views: 40, unique_viewers: 10, loops: 21 },
+        { id: 'video-b', author: 'bob', views: 20, unique_viewers: 8, loops: 12 },
+      ],
+      status: 'live',
+    },
+    topCreators: {
+      value: [
+        { pubkey: 'alice', views: 60, unique_viewers: 16, loops: 33, videos_with_views: 2 },
+      ],
+      status: 'live',
+    },
+    auth: {
+      registrations: { value: null, status: 'unavailable' },
+      logins: { value: null, status: 'unavailable' },
+    },
+  },
+};
+
+describe('StatsTrends', () => {
+  beforeEach(() => {
+    mocks.fetchDashboardStats.mockResolvedValue(dashboardResponse);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders detailed status and trends for product and trust', async () => {
+    render(
+      <TestApp>
+        <StatsTrends />
+      </TestApp>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Stats & Trends' })).toBeInTheDocument();
+    expect(within(screen.getByLabelText('Active users')).getByText('4')).toBeInTheDocument();
+    expect(within(screen.getByLabelText('Videos last day')).getByText('12')).toBeInTheDocument();
+    expect(within(screen.getByLabelText('Views last day')).getByText('80')).toBeInTheDocument();
+    expect(within(screen.getByLabelText('Pending reports')).getByText('3')).toBeInTheDocument();
+
+    expect(screen.getByText('video-a')).toBeInTheDocument();
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(within(screen.getByLabelText('Registrations')).getByText('Unavailable')).toBeInTheDocument();
+    expect(within(screen.getByLabelText('Logins')).getByText('Unavailable')).toBeInTheDocument();
+  });
+});

--- a/src/components/StatsTrends.tsx
+++ b/src/components/StatsTrends.tsx
@@ -1,0 +1,276 @@
+// ABOUTME: Detailed product and trust stats dashboard page
+// ABOUTME: Expands the top pulse into source status, engagement, and trust trend tables
+
+import { useQuery } from '@tanstack/react-query';
+import type { ComponentType } from 'react';
+import { AlertTriangle, BarChart3, Eye, Flag, Repeat2, Users, Video } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { useAdminApi } from '@/hooks/useAdminApi';
+import {
+  DASHBOARD_STATS_QUERY_KEY,
+  formatCount,
+  formatStatus,
+  shortId,
+  statusTone,
+} from '@/lib/dashboardStatsFormat';
+import type { DashboardMetric, DashboardStats, LeaderboardCreator, LeaderboardVideo } from '@/lib/adminApi';
+
+interface StatBoxProps {
+  label: string;
+  value: number;
+  icon: ComponentType<{ className?: string }>;
+}
+
+function StatusPill({ status }: { status: DashboardMetric<unknown>['status'] }) {
+  return (
+    <span className={`rounded-full border px-2 py-0.5 text-xs font-medium ${statusTone(status)}`}>
+      {formatStatus(status)}
+    </span>
+  );
+}
+
+function StatBox({ label, value, icon: Icon }: StatBoxProps) {
+  return (
+    <div aria-label={label} className="rounded-md border bg-background p-4 shadow-sm">
+      <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+        <Icon className="h-4 w-4 shrink-0" />
+        <span>{label}</span>
+      </div>
+      <div className="mt-2 text-3xl font-semibold tabular-nums leading-none">
+        {formatCount(value)}
+      </div>
+    </div>
+  );
+}
+
+function SourceStatus({
+  label,
+  metric,
+}: {
+  label: string;
+  metric: DashboardMetric<unknown>;
+}) {
+  return (
+    <div aria-label={label} className="flex items-center justify-between gap-3 rounded-md border bg-background px-3 py-2">
+      <span className="text-sm font-medium">{label}</span>
+      <StatusPill status={metric.status} />
+    </div>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-8 w-44" />
+        <Skeleton className="h-5 w-32" />
+      </div>
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Skeleton key={index} className="h-28 rounded-md" />
+        ))}
+      </div>
+      <div className="grid gap-4 xl:grid-cols-2">
+        <Skeleton className="h-64 rounded-md" />
+        <Skeleton className="h-64 rounded-md" />
+      </div>
+    </div>
+  );
+}
+
+function ErrorState({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-200">
+      <div className="flex items-center gap-2 font-medium">
+        <AlertTriangle className="h-4 w-4" />
+        <span>Stats unavailable</span>
+      </div>
+      <p className="mt-1 text-sm opacity-80">{message}</p>
+    </div>
+  );
+}
+
+function videoLabel(video: LeaderboardVideo): string {
+  return shortId(video.id || video.event_id, 'unknown video');
+}
+
+function authorLabel(video: LeaderboardVideo): string {
+  return shortId(video.author || video.pubkey, 'unknown author');
+}
+
+function TopVideosTable({ videos }: { videos: LeaderboardVideo[] }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg">Top videos</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Video</TableHead>
+              <TableHead className="text-right">Views</TableHead>
+              <TableHead className="text-right">Loops</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {videos.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={3} className="text-muted-foreground">No video leaderboard rows</TableCell>
+              </TableRow>
+            ) : videos.map(video => (
+              <TableRow key={video.id || video.event_id || `${video.author}-${video.views}`}>
+                <TableCell>
+                  <div className="font-medium">{videoLabel(video)}</div>
+                  <div className="text-xs text-muted-foreground">by {authorLabel(video)}</div>
+                </TableCell>
+                <TableCell className="text-right tabular-nums">{formatCount(video.views)}</TableCell>
+                <TableCell className="text-right tabular-nums">{formatCount(video.loops)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TopCreatorsTable({ creators }: { creators: LeaderboardCreator[] }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg">Top creators</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Creator</TableHead>
+              <TableHead className="text-right">Videos</TableHead>
+              <TableHead className="text-right">Loops</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {creators.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={3} className="text-muted-foreground">No creator leaderboard rows</TableCell>
+              </TableRow>
+            ) : creators.map(creator => (
+              <TableRow key={creator.pubkey}>
+                <TableCell className="font-medium">{shortId(creator.pubkey, 'unknown creator')}</TableCell>
+                <TableCell className="text-right tabular-nums">{formatCount(creator.videos_with_views)}</TableCell>
+                <TableCell className="text-right tabular-nums">{formatCount(creator.loops)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+function renderStats(stats: DashboardStats) {
+  const metrics = [
+    {
+      label: 'Active users',
+      value: stats.videoActivity.value.activePublishersLastDay,
+      icon: Users,
+    },
+    {
+      label: 'Videos last day',
+      value: stats.videoActivity.value.postsLastDay,
+      icon: Video,
+    },
+    {
+      label: 'Views last day',
+      value: stats.engagement.value.viewsLastDay,
+      icon: Eye,
+    },
+    {
+      label: 'Loops last day',
+      value: stats.engagement.value.loopsLastDay,
+      icon: Repeat2,
+    },
+    {
+      label: 'Pending reports',
+      value: stats.trust.value.pendingReports,
+      icon: Flag,
+    },
+    {
+      label: 'Report targets',
+      value: stats.trust.value.reportTargets,
+      icon: AlertTriangle,
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex items-center gap-3">
+          <div className="rounded-md bg-blue-600 p-2 text-white">
+            <BarChart3 className="h-5 w-5" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold tracking-normal">Stats & Trends</h1>
+            <p className="text-sm text-muted-foreground">
+              Updated {new Date(stats.generatedAt).toLocaleString()}
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <StatusPill status={stats.platform.status} />
+          <StatusPill status={stats.trust.status} />
+        </div>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-6">
+        {metrics.map(metric => (
+          <StatBox key={metric.label} {...metric} />
+        ))}
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <SourceStatus label="Platform stats" metric={stats.platform} />
+        <SourceStatus label="Video activity" metric={stats.videoActivity} />
+        <SourceStatus label="Registrations" metric={stats.auth.registrations} />
+        <SourceStatus label="Logins" metric={stats.auth.logins} />
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <TopVideosTable videos={stats.topVideos.value} />
+        <TopCreatorsTable creators={stats.topCreators.value} />
+      </div>
+    </div>
+  );
+}
+
+export function StatsTrends() {
+  const adminApi = useAdminApi();
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: DASHBOARD_STATS_QUERY_KEY,
+    queryFn: adminApi.fetchDashboardStats,
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  });
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (isError || !data?.stats) {
+    return (
+      <ErrorState message={error instanceof Error ? error.message : 'Unable to load dashboard stats.'} />
+    );
+  }
+
+  return renderStats(data.stats);
+}

--- a/src/hooks/useAdminApi.ts
+++ b/src/hooks/useAdminApi.ts
@@ -27,6 +27,9 @@ export function useAdminApi() {
     // Info
     getWorkerInfo: () => adminApi.getWorkerInfo(apiUrl),
 
+    // Product + trust dashboard
+    fetchDashboardStats: () => adminApi.fetchDashboardStats(apiUrl),
+
     // Event publishing
     publishEvent: (event: adminApi.UnsignedEvent) => adminApi.publishEvent(apiUrl, event),
 

--- a/src/lib/adminApi.test.ts
+++ b/src/lib/adminApi.test.ts
@@ -14,6 +14,7 @@ import {
   unbanPubkey,
   listBannedPubkeys,
   listBannedEvents,
+  fetchDashboardStats,
   fetchReports,
   fetchResolutionLabels,
   publishLabel,
@@ -128,6 +129,50 @@ describe('adminApi', () => {
       const result = await getWorkerInfo(API_URL);
 
       expect(result).toEqual(mockInfo);
+    });
+  });
+
+  describe('fetchDashboardStats', () => {
+    it('should call /api/dashboard-stats and return product trust stats', async () => {
+      const mockResponse = {
+        success: true,
+        stats: {
+          generatedAt: '2026-05-02T00:00:00.000Z',
+          platform: { value: { total_events: 120, total_videos: 30, vine_videos: 9 }, status: 'live' },
+          videoActivity: {
+            value: { postsLastHour: 2, postsLastDay: 12, activePublishersLastDay: 4 },
+            status: 'live',
+          },
+          engagement: {
+            value: {
+              viewsLastDay: 80,
+              uniqueViewersLastDay: 24,
+              loopsLastDay: 42,
+              source: 'leaderboard_top_day',
+            },
+            status: 'partial',
+          },
+          trust: { value: { pendingReports: 3, reportTargets: 6, resolvedTargets: 3 }, status: 'live' },
+          topVideos: { value: [], status: 'live' },
+          topCreators: { value: [], status: 'live' },
+          auth: {
+            registrations: { value: null, status: 'unavailable' },
+            logins: { value: null, status: 'unavailable' },
+          },
+        },
+      };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await fetchDashboardStats(API_URL);
+
+      expect(result).toEqual(mockResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${API_URL}/api/dashboard-stats`,
+        expect.objectContaining({ method: 'GET' })
+      );
     });
   });
 

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -49,6 +49,79 @@ interface InfoResponse {
   error?: string;
 }
 
+export type MetricStatus = 'live' | 'partial' | 'unavailable' | 'error';
+
+export interface DashboardMetric<T> {
+  value: T;
+  status: MetricStatus;
+  message?: string;
+}
+
+export interface PlatformStats {
+  total_events: number;
+  total_videos: number;
+  vine_videos: number;
+}
+
+export interface VideoActivitySummary {
+  postsLastHour: number;
+  postsLastDay: number;
+  activePublishersLastDay: number;
+}
+
+export interface EngagementSummary {
+  viewsLastDay: number;
+  uniqueViewersLastDay: number;
+  loopsLastDay: number;
+  source: 'leaderboard_top_day';
+}
+
+export interface TrustSummary {
+  pendingReports: number;
+  reportTargets: number;
+  resolvedTargets: number;
+}
+
+export interface LeaderboardVideo {
+  id?: string;
+  event_id?: string;
+  author?: string;
+  pubkey?: string;
+  views: number;
+  unique_viewers: number;
+  loops: number;
+  [key: string]: unknown;
+}
+
+export interface LeaderboardCreator {
+  pubkey: string;
+  views: number;
+  unique_viewers: number;
+  loops: number;
+  videos_with_views: number;
+  [key: string]: unknown;
+}
+
+export interface DashboardStats {
+  generatedAt: string;
+  platform: DashboardMetric<PlatformStats | null>;
+  videoActivity: DashboardMetric<VideoActivitySummary>;
+  engagement: DashboardMetric<EngagementSummary>;
+  trust: DashboardMetric<TrustSummary>;
+  topVideos: DashboardMetric<LeaderboardVideo[]>;
+  topCreators: DashboardMetric<LeaderboardCreator[]>;
+  auth: {
+    registrations: DashboardMetric<number | null>;
+    logins: DashboardMetric<number | null>;
+  };
+}
+
+export interface DashboardStatsResponse {
+  success: boolean;
+  stats: DashboardStats;
+  error?: string;
+}
+
 export interface LabelParams {
   targetType: 'event' | 'pubkey';
   targetValue: string;
@@ -113,6 +186,14 @@ async function _apiRequestWithValidation<T>(
 // Info endpoint
 export async function getWorkerInfo(apiUrl: string): Promise<InfoResponse> {
   return apiRequest<InfoResponse>(apiUrl, '/api/info', 'GET');
+}
+
+export async function fetchDashboardStats(apiUrl: string): Promise<DashboardStatsResponse> {
+  const data = await apiRequest<DashboardStatsResponse>(apiUrl, '/api/dashboard-stats', 'GET');
+  if (!data.success) {
+    throw new ApiError(data.error || 'Failed to fetch dashboard stats');
+  }
+  return data;
 }
 
 // Publish endpoint - for general event publishing

--- a/src/lib/dashboardStatsFormat.ts
+++ b/src/lib/dashboardStatsFormat.ts
@@ -1,0 +1,46 @@
+// ABOUTME: Shared formatting helpers for product and trust dashboard stats
+// ABOUTME: Keeps compact and detailed stats views consistent
+
+import type { MetricStatus } from './adminApi';
+
+export const DASHBOARD_STATS_QUERY_KEY = ['dashboard-stats'] as const;
+
+export function formatCount(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return '0';
+  return new Intl.NumberFormat('en', {
+    notation: value >= 10_000 ? 'compact' : 'standard',
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+export function formatStatus(status: MetricStatus): string {
+  switch (status) {
+    case 'live':
+      return 'Live';
+    case 'partial':
+      return 'Partial';
+    case 'unavailable':
+      return 'Unavailable';
+    case 'error':
+      return 'Error';
+  }
+}
+
+export function statusTone(status: MetricStatus): string {
+  switch (status) {
+    case 'live':
+      return 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300';
+    case 'partial':
+      return 'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300';
+    case 'unavailable':
+      return 'border-slate-200 bg-slate-50 text-slate-600 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300';
+    case 'error':
+      return 'border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300';
+  }
+}
+
+export function shortId(value: string | undefined, fallback: string): string {
+  if (!value) return fallback;
+  if (value.length <= 18) return value;
+  return `${value.slice(0, 10)}...${value.slice(-6)}`;
+}

--- a/worker/src/dashboard-stats.test.ts
+++ b/worker/src/dashboard-stats.test.ts
@@ -1,0 +1,233 @@
+// ABOUTME: Tests for product and trust dashboard stats aggregation
+// ABOUTME: Verifies read-only Funnelcake and relay data produce the admin pulse payload
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import worker from './index';
+import {
+  aggregateLeaderboardEngagement,
+  buildUnavailableAuthTelemetry,
+  summarizeTrustQueue,
+  summarizeVideoActivity,
+  type DashboardStatsResponse,
+  type LeaderboardVideo,
+  type RelayEvent,
+} from './dashboard-stats';
+
+type MockRelayFilter = {
+  kinds?: number[];
+  since?: number;
+  limit?: number;
+  '#L'?: string[];
+};
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static filters: MockRelayFilter[] = [];
+  static responses: Array<{ match: (filter: MockRelayFilter) => boolean; events: RelayEvent[] }> = [];
+
+  readyState = MockWebSocket.CONNECTING;
+  private listeners: Map<string, Array<(event: unknown) => void>> = new Map();
+
+  constructor(_url: string) {
+    setTimeout(() => {
+      this.readyState = MockWebSocket.OPEN;
+      this.emit('open', {});
+    }, 0);
+  }
+
+  addEventListener(type: string, listener: (event: unknown) => void): void {
+    if (!this.listeners.has(type)) this.listeners.set(type, []);
+    this.listeners.get(type)!.push(listener);
+  }
+
+  send(data: string): void {
+    const parsed = JSON.parse(data) as ['REQ', string, MockRelayFilter];
+    const [, subId, filter] = parsed;
+    MockWebSocket.filters.push(filter);
+    const response = MockWebSocket.responses.find(entry => entry.match(filter));
+
+    setTimeout(() => {
+      for (const event of response?.events || []) {
+        this.emit('message', { data: JSON.stringify(['EVENT', subId, event]) });
+      }
+      this.emit('message', { data: JSON.stringify(['EOSE', subId]) });
+    }, 0);
+  }
+
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.emit('close', {});
+  }
+
+  private emit(type: string, event: unknown): void {
+    for (const handler of this.listeners.get(type) || []) handler(event);
+  }
+}
+
+function relayEvent(overrides: Partial<RelayEvent>): RelayEvent {
+  return {
+    id: overrides.id || `event-${Math.random()}`,
+    pubkey: overrides.pubkey || 'publisher',
+    kind: overrides.kind || 21,
+    created_at: overrides.created_at || 1_700_000_000,
+    content: overrides.content || '',
+    tags: overrides.tags || [],
+    sig: overrides.sig || 'sig',
+  };
+}
+
+function createEnv() {
+  return {
+    NOSTR_NSEC: 'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5',
+    RELAY_URL: 'wss://relay.test.com',
+    ALLOWED_ORIGINS: 'http://localhost:5173',
+  };
+}
+
+describe('dashboard stats aggregation', () => {
+  const now = 1_700_000_000;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('summarizes recent video posts and active publishers', () => {
+    const summary = summarizeVideoActivity([
+      relayEvent({ id: 'recent-1', kind: 21, pubkey: 'alice', created_at: now - 60 }),
+      relayEvent({ id: 'recent-2', kind: 34235, pubkey: 'bob', created_at: now - 3_500 }),
+      relayEvent({ id: 'day-1', kind: 22, pubkey: 'alice', created_at: now - 7_200 }),
+      relayEvent({ id: 'old', kind: 21, pubkey: 'chuck', created_at: now - 90_000 }),
+      relayEvent({ id: 'note', kind: 1, pubkey: 'dana', created_at: now - 30 }),
+    ], now);
+
+    expect(summary).toEqual({
+      postsLastHour: 2,
+      postsLastDay: 3,
+      activePublishersLastDay: 2,
+    });
+  });
+
+  it('summarizes pending and resolved trust workload by target', () => {
+    const summary = summarizeTrustQueue([
+      relayEvent({ id: 'report-1', kind: 1984, tags: [['e', 'video-a']] }),
+      relayEvent({ id: 'report-2', kind: 1984, tags: [['e', 'video-b']] }),
+      relayEvent({ id: 'report-3', kind: 1984, tags: [['e', 'video-a']] }),
+    ], [
+      relayEvent({ id: 'resolution-1', kind: 1985, tags: [['L', 'moderation/resolution'], ['e', 'video-a']] }),
+    ]);
+
+    expect(summary).toEqual({
+      pendingReports: 1,
+      reportTargets: 2,
+      resolvedTargets: 1,
+    });
+  });
+
+  it('aggregates one-day leaderboard engagement totals', () => {
+    const videos: LeaderboardVideo[] = [
+      { id: 'video-a', author: 'alice', views: 10, unique_viewers: 4, loops: 7 },
+      { id: 'video-b', author: 'bob', views: 3, unique_viewers: 2, loops: 5 },
+    ];
+
+    expect(aggregateLeaderboardEngagement(videos)).toEqual({
+      viewsLastDay: 13,
+      uniqueViewersLastDay: 6,
+      loopsLastDay: 12,
+      source: 'leaderboard_top_day',
+    });
+  });
+
+  it('marks registration and login telemetry unavailable until an existing source is present', () => {
+    expect(buildUnavailableAuthTelemetry()).toEqual({
+      registrations: {
+        value: null,
+        status: 'unavailable',
+        message: 'Registration telemetry is not exposed by current read-only sources.',
+      },
+      logins: {
+        value: null,
+        status: 'unavailable',
+        message: 'Login telemetry is not exposed by current read-only sources.',
+      },
+    });
+  });
+
+  it('serves /api/dashboard-stats with product and trust signals', async () => {
+    const videos: LeaderboardVideo[] = [
+      { id: 'video-a', author: 'alice', views: 10, unique_viewers: 4, loops: 7 },
+      { id: 'video-b', author: 'bob', views: 3, unique_viewers: 2, loops: 5 },
+    ];
+    const creators = [
+      { pubkey: 'alice', views: 12, unique_viewers: 5, loops: 9, videos_with_views: 2 },
+    ];
+    const mockFetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.endsWith('/api/stats')) {
+        return Response.json({ total_events: 120, total_videos: 30, vine_videos: 9 });
+      }
+      if (url.includes('/api/leaderboard/videos')) {
+        return Response.json({ period: 'day', entries: videos });
+      }
+      if (url.includes('/api/leaderboard/creators')) {
+        return Response.json({ period: 'day', entries: creators });
+      }
+      return new Response('not found', { status: 404 });
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    MockWebSocket.filters = [];
+    MockWebSocket.responses = [
+      {
+        match: filter => filter.kinds?.some(kind => [21, 22, 34235, 34236].includes(kind)) ?? false,
+        events: [
+          relayEvent({ id: 'recent-1', kind: 21, pubkey: 'alice', created_at: now - 20 }),
+          relayEvent({ id: 'recent-2', kind: 34236, pubkey: 'bob', created_at: now - 40 }),
+          relayEvent({ id: 'day-1', kind: 22, pubkey: 'alice', created_at: now - 7_000 }),
+        ],
+      },
+      {
+        match: filter => filter.kinds?.includes(1984) ?? false,
+        events: [
+          relayEvent({ id: 'report-1', kind: 1984, tags: [['e', 'video-a']] }),
+          relayEvent({ id: 'report-2', kind: 1984, tags: [['e', 'video-c']] }),
+        ],
+      },
+      {
+        match: filter => filter.kinds?.includes(1985) ?? false,
+        events: [
+          relayEvent({ id: 'resolution-1', kind: 1985, tags: [['L', 'moderation/resolution'], ['e', 'video-a']] }),
+        ],
+      },
+    ];
+    vi.stubGlobal('WebSocket', MockWebSocket);
+
+    vi.spyOn(Date, 'now').mockReturnValue(now * 1_000);
+
+    const response = await worker.fetch(
+      new Request('http://localhost/api/dashboard-stats', {
+        headers: { 'Cf-Access-Jwt-Assertion': 'test' },
+      }),
+      createEnv() as never,
+      { waitUntil: vi.fn(), passThroughOnException: vi.fn() } as unknown as ExecutionContext,
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as DashboardStatsResponse;
+
+    expect(body.success).toBe(true);
+    expect(body.stats.platform.value).toEqual({ total_events: 120, total_videos: 30, vine_videos: 9 });
+    expect(body.stats.videoActivity.value).toEqual({
+      postsLastHour: 2,
+      postsLastDay: 3,
+      activePublishersLastDay: 2,
+    });
+    expect(body.stats.engagement.value.loopsLastDay).toBe(12);
+    expect(body.stats.trust.value.pendingReports).toBe(1);
+    expect(body.stats.auth.registrations.status).toBe('unavailable');
+    expect(body.stats.topVideos.value).toEqual(videos);
+    expect(body.stats.topCreators.value).toEqual(creators);
+  });
+});

--- a/worker/src/dashboard-stats.ts
+++ b/worker/src/dashboard-stats.ts
@@ -1,0 +1,422 @@
+// ABOUTME: Product and trust dashboard stats aggregation for the admin worker
+// ABOUTME: Composes existing read-only Funnelcake and relay sources without schema changes
+
+import { deriveFunnelcakeApiUrl } from './funnelcake-proxy';
+
+export const VIDEO_KINDS = [21, 22, 34235, 34236] as const;
+
+export type MetricStatus = 'live' | 'partial' | 'unavailable' | 'error';
+
+export interface DashboardMetric<T> {
+  value: T;
+  status: MetricStatus;
+  message?: string;
+}
+
+export interface RelayEvent {
+  id: string;
+  pubkey: string;
+  kind: number;
+  created_at: number;
+  content: string;
+  tags: string[][];
+  sig?: string;
+}
+
+export interface PlatformStats {
+  total_events: number;
+  total_videos: number;
+  vine_videos: number;
+}
+
+export interface LeaderboardVideo {
+  id?: string;
+  event_id?: string;
+  author?: string;
+  pubkey?: string;
+  views: number;
+  unique_viewers: number;
+  loops: number;
+  [key: string]: unknown;
+}
+
+export interface LeaderboardCreator {
+  pubkey: string;
+  views: number;
+  unique_viewers: number;
+  loops: number;
+  videos_with_views: number;
+  [key: string]: unknown;
+}
+
+export interface LeaderboardResponse<T> {
+  period: string;
+  entries: T[];
+}
+
+export interface VideoActivitySummary {
+  postsLastHour: number;
+  postsLastDay: number;
+  activePublishersLastDay: number;
+}
+
+export interface EngagementSummary {
+  viewsLastDay: number;
+  uniqueViewersLastDay: number;
+  loopsLastDay: number;
+  source: 'leaderboard_top_day';
+}
+
+export interface TrustSummary {
+  pendingReports: number;
+  reportTargets: number;
+  resolvedTargets: number;
+}
+
+export interface AuthTelemetry {
+  registrations: DashboardMetric<number | null>;
+  logins: DashboardMetric<number | null>;
+}
+
+export interface DashboardStats {
+  generatedAt: string;
+  platform: DashboardMetric<PlatformStats | null>;
+  videoActivity: DashboardMetric<VideoActivitySummary>;
+  engagement: DashboardMetric<EngagementSummary>;
+  trust: DashboardMetric<TrustSummary>;
+  topVideos: DashboardMetric<LeaderboardVideo[]>;
+  topCreators: DashboardMetric<LeaderboardCreator[]>;
+  auth: AuthTelemetry;
+}
+
+export interface DashboardStatsResponse {
+  success: boolean;
+  stats: DashboardStats;
+  error?: string;
+}
+
+export interface DashboardStatsEnv {
+  RELAY_URL: string;
+  FUNNELCAKE_API_URL?: string;
+}
+
+interface FunnelcakeSources {
+  platform: PlatformStats;
+  topVideos: LeaderboardVideo[];
+  topCreators: LeaderboardCreator[];
+}
+
+interface RelayQueryResult {
+  success: boolean;
+  events: RelayEvent[];
+  error?: string;
+}
+
+function numberValue(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function sourceUrl(baseUrl: string, path: string): string {
+  return `${baseUrl.replace(/\/$/, '')}${path}`;
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url, {
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`GET ${url} failed with ${response.status}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+function entriesFromResponse<T>(response: LeaderboardResponse<T>): T[] {
+  return Array.isArray(response.entries) ? response.entries : [];
+}
+
+export async function fetchFunnelcakeDashboardSources(baseUrl: string): Promise<FunnelcakeSources> {
+  const [platform, videoLeaderboard, creatorLeaderboard] = await Promise.all([
+    fetchJson<PlatformStats>(sourceUrl(baseUrl, '/api/stats')),
+    fetchJson<LeaderboardResponse<LeaderboardVideo>>(sourceUrl(baseUrl, '/api/leaderboard/videos?period=day&limit=10')),
+    fetchJson<LeaderboardResponse<LeaderboardCreator>>(sourceUrl(baseUrl, '/api/leaderboard/creators?period=day&limit=10')),
+  ]);
+
+  return {
+    platform,
+    topVideos: entriesFromResponse(videoLeaderboard),
+    topCreators: entriesFromResponse(creatorLeaderboard),
+  };
+}
+
+export function summarizeVideoActivity(events: RelayEvent[], nowSeconds: number): VideoActivitySummary {
+  const oneHourAgo = nowSeconds - 60 * 60;
+  const oneDayAgo = nowSeconds - 24 * 60 * 60;
+  const publishersLastDay = new Set<string>();
+  let postsLastHour = 0;
+  let postsLastDay = 0;
+
+  for (const event of events) {
+    if (!VIDEO_KINDS.includes(event.kind as (typeof VIDEO_KINDS)[number])) continue;
+    if (event.created_at < oneDayAgo || event.created_at > nowSeconds) continue;
+
+    postsLastDay += 1;
+    publishersLastDay.add(event.pubkey);
+
+    if (event.created_at >= oneHourAgo) {
+      postsLastHour += 1;
+    }
+  }
+
+  return {
+    postsLastHour,
+    postsLastDay,
+    activePublishersLastDay: publishersLastDay.size,
+  };
+}
+
+export function aggregateLeaderboardEngagement(videos: LeaderboardVideo[]): EngagementSummary {
+  return videos.reduce<EngagementSummary>((summary, video) => ({
+    viewsLastDay: summary.viewsLastDay + numberValue(video.views),
+    uniqueViewersLastDay: summary.uniqueViewersLastDay + numberValue(video.unique_viewers),
+    loopsLastDay: summary.loopsLastDay + numberValue(video.loops),
+    source: 'leaderboard_top_day',
+  }), {
+    viewsLastDay: 0,
+    uniqueViewersLastDay: 0,
+    loopsLastDay: 0,
+    source: 'leaderboard_top_day',
+  });
+}
+
+function targetIds(events: RelayEvent[]): Set<string> {
+  const ids = new Set<string>();
+  for (const event of events) {
+    for (const tag of event.tags || []) {
+      if ((tag[0] === 'e' || tag[0] === 'p') && tag[1]) {
+        ids.add(tag[1]);
+      }
+    }
+  }
+  return ids;
+}
+
+export function summarizeTrustQueue(reportEvents: RelayEvent[], resolutionEvents: RelayEvent[]): TrustSummary {
+  const reportedTargets = targetIds(reportEvents);
+  const resolvedTargets = targetIds(resolutionEvents);
+  let resolvedReportedTargets = 0;
+
+  for (const targetId of reportedTargets) {
+    if (resolvedTargets.has(targetId)) {
+      resolvedReportedTargets += 1;
+    }
+  }
+
+  return {
+    pendingReports: Math.max(0, reportedTargets.size - resolvedReportedTargets),
+    reportTargets: reportedTargets.size,
+    resolvedTargets: resolvedReportedTargets,
+  };
+}
+
+export function buildUnavailableAuthTelemetry(): AuthTelemetry {
+  return {
+    registrations: {
+      value: null,
+      status: 'unavailable',
+      message: 'Registration telemetry is not exposed by current read-only sources.',
+    },
+    logins: {
+      value: null,
+      status: 'unavailable',
+      message: 'Login telemetry is not exposed by current read-only sources.',
+    },
+  };
+}
+
+async function queryRelay(filter: object, relayUrl: string): Promise<RelayQueryResult> {
+  return new Promise((resolve) => {
+    try {
+      const ws = new WebSocket(relayUrl);
+      const events: RelayEvent[] = [];
+      const subId = `dashboard-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      let resolved = false;
+
+      const finish = (result: RelayQueryResult): void => {
+        if (resolved) return;
+        resolved = true;
+        clearTimeout(timeout);
+        try {
+          ws.close();
+        } catch {
+          // Ignore close errors from test doubles or already-closed sockets.
+        }
+        resolve(result);
+      };
+
+      const timeout = setTimeout(() => {
+        finish({ success: true, events });
+      }, 5_000);
+
+      ws.addEventListener('open', () => {
+        ws.send(JSON.stringify(['REQ', subId, filter]));
+      });
+
+      ws.addEventListener('message', (message) => {
+        try {
+          if (typeof message.data !== 'string') return;
+          const data = JSON.parse(message.data) as unknown[];
+          if (data[0] === 'EVENT' && data[1] === subId) {
+            events.push(data[2] as RelayEvent);
+          } else if (data[0] === 'EOSE' && data[1] === subId) {
+            finish({ success: true, events });
+          }
+        } catch {
+          // Ignore malformed relay frames and keep collecting valid events.
+        }
+      });
+
+      ws.addEventListener('error', () => {
+        finish({ success: false, events: [], error: 'WebSocket error' });
+      });
+
+      ws.addEventListener('close', () => {
+        finish({ success: true, events });
+      });
+    } catch (error) {
+      resolve({
+        success: false,
+        events: [],
+        error: error instanceof Error ? error.message : 'Unknown relay query error',
+      });
+    }
+  });
+}
+
+function zeroVideoActivity(): VideoActivitySummary {
+  return {
+    postsLastHour: 0,
+    postsLastDay: 0,
+    activePublishersLastDay: 0,
+  };
+}
+
+function zeroTrust(): TrustSummary {
+  return {
+    pendingReports: 0,
+    reportTargets: 0,
+    resolvedTargets: 0,
+  };
+}
+
+export async function collectDashboardStats(env: DashboardStatsEnv): Promise<DashboardStats> {
+  const nowSeconds = Math.floor(Date.now() / 1_000);
+  const funnelcakeBaseUrl = deriveFunnelcakeApiUrl(env.RELAY_URL, env.FUNNELCAKE_API_URL);
+
+  const [funnelcakeResult, videoEventsResult, reportsResult, resolutionsResult] = await Promise.allSettled([
+    fetchFunnelcakeDashboardSources(funnelcakeBaseUrl),
+    queryRelay({ kinds: [...VIDEO_KINDS], since: nowSeconds - 24 * 60 * 60, limit: 1_000 }, env.RELAY_URL),
+    queryRelay({ kinds: [1984], limit: 200 }, env.RELAY_URL),
+    queryRelay({ kinds: [1985], '#L': ['moderation/resolution'], limit: 500 }, env.RELAY_URL),
+  ] as const);
+
+  const funnelcakeSources = funnelcakeResult.status === 'fulfilled' ? funnelcakeResult.value : null;
+  const videoEvents = videoEventsResult.status === 'fulfilled' && videoEventsResult.value.success
+    ? videoEventsResult.value.events
+    : null;
+  const reportEvents = reportsResult.status === 'fulfilled' && reportsResult.value.success
+    ? reportsResult.value.events
+    : null;
+  const resolutionEvents = resolutionsResult.status === 'fulfilled' && resolutionsResult.value.success
+    ? resolutionsResult.value.events
+    : null;
+
+  const videoActivityError = videoEventsResult.status === 'fulfilled'
+    ? videoEventsResult.value.error
+    : errorMessage(videoEventsResult.reason);
+  const reportsError = reportsResult.status === 'fulfilled'
+    ? reportsResult.value.error
+    : errorMessage(reportsResult.reason);
+  const resolutionsError = resolutionsResult.status === 'fulfilled'
+    ? resolutionsResult.value.error
+    : errorMessage(resolutionsResult.reason);
+
+  const funnelcakeError = funnelcakeResult.status === 'rejected'
+    ? errorMessage(funnelcakeResult.reason)
+    : 'Funnelcake dashboard sources unavailable.';
+  const topVideos = funnelcakeSources?.topVideos ?? [];
+
+  return {
+    generatedAt: new Date(nowSeconds * 1_000).toISOString(),
+    platform: funnelcakeSources
+      ? { value: funnelcakeSources.platform, status: 'live' }
+      : {
+        value: null,
+        status: 'error',
+        message: funnelcakeError,
+      },
+    videoActivity: videoEvents
+      ? { value: summarizeVideoActivity(videoEvents, nowSeconds), status: 'live' }
+      : {
+        value: zeroVideoActivity(),
+        status: 'error',
+        message: videoActivityError || 'Relay video activity query failed.',
+      },
+    engagement: funnelcakeSources
+      ? { value: aggregateLeaderboardEngagement(topVideos), status: 'partial' }
+      : {
+        value: aggregateLeaderboardEngagement([]),
+        status: 'error',
+        message: funnelcakeError,
+      },
+    trust: reportEvents && resolutionEvents
+      ? { value: summarizeTrustQueue(reportEvents, resolutionEvents), status: 'live' }
+      : {
+        value: zeroTrust(),
+        status: 'error',
+        message: reportsError || resolutionsError || 'Trust relay queries failed.',
+      },
+    topVideos: funnelcakeSources
+      ? { value: topVideos, status: 'live' }
+      : {
+        value: [],
+        status: 'error',
+        message: funnelcakeError,
+      },
+    topCreators: funnelcakeSources
+      ? { value: funnelcakeSources.topCreators, status: 'live' }
+      : {
+        value: [],
+        status: 'error',
+        message: funnelcakeError,
+      },
+    auth: buildUnavailableAuthTelemetry(),
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error || 'Unknown error');
+}
+
+export async function handleDashboardStats(
+  env: DashboardStatsEnv,
+  corsHeaders: Record<string, string>,
+): Promise<Response> {
+  const stats = await collectDashboardStats(env);
+  const body: DashboardStatsResponse = { success: true, stats };
+
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'private, max-age=30',
+      ...corsHeaders,
+    },
+  });
+}

--- a/worker/src/funnelcake-proxy.test.ts
+++ b/worker/src/funnelcake-proxy.test.ts
@@ -49,7 +49,7 @@ describe('proxyFunnelcakeRequest', () => {
       expect(response.status).toBe(200);
       expect(response.headers.get('Cache-Control')).toBe('public, max-age=300');
       expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
-      const body = await response.json();
+      const body = await response.json() as { id: string };
       expect(body.id).toBe('abc123');
     } finally {
       globalThis.fetch = originalFetch;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -14,6 +14,7 @@ import {
 import { ensureSchema } from './db';
 import { generatePreAuthToken, verifyPreAuthToken, base64UrlEncode } from './zendesk-preauth';
 import { deriveFunnelcakeApiUrl, proxyFunnelcakeRequest } from './funnelcake-proxy';
+import { handleDashboardStats } from './dashboard-stats';
 
 let schemaReady = false;
 async function ensureSchemaOnce(db: D1Database): Promise<void> {
@@ -203,6 +204,7 @@ interface UnsignedEvent {
 interface ApiResponse {
   success: boolean;
   event?: object;
+  events?: object[];
   error?: string;
   pubkey?: string;
   // Moderation action responses
@@ -334,6 +336,10 @@ export default {
       // Report watcher management endpoints
       if (path.startsWith('/api/report-watcher/')) {
         return handleReportWatcherRoutes(request, path, env, corsHeaders);
+      }
+
+      if (path === '/api/dashboard-stats' && request.method === 'GET') {
+        return handleDashboardStats(env, corsHeaders);
       }
 
       // Funnelcake REST API proxy -- fast ClickHouse-backed reads


### PR DESCRIPTION
## Summary
- Adds a read-only /api/dashboard-stats worker endpoint that composes existing Funnelcake API data with relay video/report queries.
- Adds a top Product + Trust Pulse strip plus a detailed Stats & Trends tab/page in the relay manager.
- Surfaces registration and login telemetry as unavailable until an existing source exposes those events, without changing divine-funnelcake.

## Test Plan
- [x] npm test
- [x] (cd worker && npx tsc --noEmit)
- [x] (cd worker && npm run test:run)
- [x] Browser smoke check at http://127.0.0.1:53962/stats with mocked dashboard-stats payload, desktop and mobile viewport