### PR TITLE
feat: interim pending review queue for Osprey verdicts

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -16,6 +16,7 @@ export function AppRouter() {
         <Route path="/users/:pubkey" element={<Index />} />
         <Route path="/reports" element={<Index />} />
         <Route path="/reports/:reportId" element={<Index />} />
+        <Route path="/pending-review" element={<Index />} />
         <Route path="/labels" element={<Index />} />
         <Route path="/settings" element={<Index />} />
         <Route path="/debug" element={<Index />} />

--- a/src/components/PendingReview.tsx
+++ b/src/components/PendingReview.tsx
@@ -1,0 +1,261 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useAppContext } from "@/hooks/useAppContext";
+import { useToast } from "@/hooks/useToast";
+import { nip19 } from "nostr-tools";
+import { ClipboardCheck, Check, X, Clock, AlertTriangle } from "lucide-react";
+
+interface PendingVerdict {
+  id: number;
+  event_id: string | null;
+  pubkey: string | null;
+  verdict: string;
+  category: string | null;
+  rule_name: string | null;
+  source: string;
+  created_at: string;
+  status: string;
+  resolved_at: string | null;
+  resolved_by: string | null;
+}
+
+export function PendingReview() {
+  const { config } = useAppContext();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [showResolved, setShowResolved] = useState(false);
+
+  const status = showResolved ? "confirmed" : "pending";
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["pending-review", config.apiUrl, status],
+    queryFn: async () => {
+      const res = await fetch(
+        `${config.apiUrl}/api/pending-review?status=${status}`
+      );
+      if (!res.ok) throw new Error(`Failed to fetch: ${res.status}`);
+      const body = (await res.json()) as {
+        success: boolean;
+        verdicts: PendingVerdict[];
+      };
+      return body.verdicts;
+    },
+    refetchInterval: 15_000,
+    placeholderData: (prev) => prev,
+    retry: false,
+  });
+
+  const resolveMutation = useMutation({
+    mutationFn: async ({
+      id,
+      action,
+    }: {
+      id: number;
+      action: "confirm" | "dismiss";
+    }) => {
+      const res = await fetch(
+        `${config.apiUrl}/api/pending-review/${id}/resolve`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action }),
+        }
+      );
+      const body = (await res.json()) as {
+        success: boolean;
+        error?: string;
+      };
+      if (!res.ok || !body.success)
+        throw new Error(body.error || `Failed: ${res.status}`);
+    },
+    onSuccess: (_, vars) => {
+      queryClient.invalidateQueries({ queryKey: ["pending-review"] });
+      toast({
+        title: vars.action === "confirm" ? "Verdict confirmed" : "Verdict dismissed",
+      });
+    },
+    onError: (err: Error) => {
+      toast({
+        title: "Action failed",
+        description: err.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  function formatId(eventId: string | null, pubkey: string | null): string {
+    if (eventId) {
+      try {
+        const encoded = nip19.noteEncode(eventId);
+        return encoded.slice(0, 16) + "..." + encoded.slice(-6);
+      } catch {
+        return eventId.slice(0, 12) + "...";
+      }
+    }
+    if (pubkey) {
+      try {
+        const encoded = nip19.npubEncode(pubkey);
+        return encoded.slice(0, 16) + "..." + encoded.slice(-6);
+      } catch {
+        return pubkey.slice(0, 12) + "...";
+      }
+    }
+    return "unknown";
+  }
+
+  function timeAgo(dateStr: string): string {
+    const diff = Date.now() - new Date(dateStr).getTime();
+    const mins = Math.floor(diff / 60_000);
+    if (mins < 1) return "just now";
+    if (mins < 60) return `${mins}m ago`;
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return `${hours}h ago`;
+    return `${Math.floor(hours / 24)}d ago`;
+  }
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <ClipboardCheck className="h-4 w-4" />
+            Pending Review
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-16 w-full" />
+          ))}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertTriangle className="h-4 w-4" />
+        <AlertDescription>
+          Failed to load pending verdicts: {(error as Error).message}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  const verdicts = data || [];
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <ClipboardCheck className="h-4 w-4" />
+            Pending Review
+            {!showResolved && verdicts.length > 0 && (
+              <Badge variant="secondary">{verdicts.length}</Badge>
+            )}
+          </CardTitle>
+          <div className="flex gap-1">
+            <Button
+              size="sm"
+              variant={!showResolved ? "default" : "outline"}
+              onClick={() => setShowResolved(false)}
+            >
+              Pending
+            </Button>
+            <Button
+              size="sm"
+              variant={showResolved ? "default" : "outline"}
+              onClick={() => setShowResolved(true)}
+            >
+              Resolved
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {verdicts.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-8 text-center">
+            {showResolved
+              ? "No resolved verdicts yet."
+              : "No items pending review."}
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {verdicts.map((v) => (
+              <div
+                key={v.id}
+                className="flex items-center justify-between rounded-lg border p-3"
+              >
+                <div className="flex flex-col gap-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <code className="text-xs truncate">
+                      {formatId(v.event_id, v.pubkey)}
+                    </code>
+                    {v.category && (
+                      <Badge variant="outline" className="text-xs">
+                        {v.category}
+                      </Badge>
+                    )}
+                    {v.source && (
+                      <Badge variant="secondary" className="text-xs">
+                        {v.source}
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    {v.rule_name && <span>{v.rule_name}</span>}
+                    <span className="flex items-center gap-1">
+                      <Clock className="h-3 w-3" />
+                      {timeAgo(v.created_at)}
+                    </span>
+                  </div>
+                </div>
+                {v.status === "pending" ? (
+                  <div className="flex gap-1 ml-2 shrink-0">
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      disabled={resolveMutation.isPending}
+                      onClick={() =>
+                        resolveMutation.mutate({ id: v.id, action: "confirm" })
+                      }
+                    >
+                      <Check className="h-3 w-3 mr-1" />
+                      Ban
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={resolveMutation.isPending}
+                      onClick={() =>
+                        resolveMutation.mutate({ id: v.id, action: "dismiss" })
+                      }
+                    >
+                      <X className="h-3 w-3 mr-1" />
+                      Dismiss
+                    </Button>
+                  </div>
+                ) : (
+                  <Badge
+                    variant={
+                      v.status === "confirmed" ? "destructive" : "secondary"
+                    }
+                    className="ml-2 shrink-0"
+                  >
+                    {v.status}
+                  </Badge>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/RelayManager.tsx
+++ b/src/components/RelayManager.tsx
@@ -9,16 +9,18 @@ import { Reports } from "@/components/Reports";
 import { Labels } from "@/components/Labels";
 import { DebugPanel } from "@/components/DebugPanel";
 import { SettingsDashboard } from "@/components/SettingsDashboard";
+import { PendingReview } from "@/components/PendingReview";
 import { EnvironmentSelector } from "@/components/EnvironmentSelector";
 import { Card } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Server, FileText, Users, Settings, Flag, Tag, Bug, GripVertical } from "lucide-react";
+import { Server, FileText, Users, Settings, Flag, Tag, Bug, GripVertical, ClipboardCheck } from "lucide-react";
 import { useAppContext } from "@/hooks/useAppContext";
 import AdminBar from "@/components/AdminBar";
 
 // Tab definitions in default order (Reports first for moderation workflow)
 const TAB_DEFINITIONS = [
   { id: 'reports', label: 'Reports', icon: Flag },
+  { id: 'pending-review', label: 'Review', icon: ClipboardCheck },
   { id: 'events', label: 'Events', icon: FileText },
   { id: 'users', label: 'Users', icon: Users },
   { id: 'labels', label: 'Labels', icon: Tag },
@@ -60,6 +62,7 @@ function saveTabOrder(order: TabId[]): void {
 
 // Map URL paths to tab values
 function getTabFromPath(pathname: string): string {
+  if (pathname.startsWith('/pending-review')) return 'pending-review';
   if (pathname.startsWith('/events')) return 'events';
   if (pathname.startsWith('/users')) return 'users';
   if (pathname.startsWith('/reports')) return 'reports';
@@ -167,7 +170,7 @@ export function RelayManager() {
 
       <div className="flex-1 min-h-0 overflow-hidden container mx-auto px-4 py-4">
         <Tabs value={currentTab} onValueChange={handleTabChange} className="h-full flex flex-col">
-          <TabsList className="shrink-0 grid w-full grid-cols-6">
+          <TabsList className="shrink-0 grid w-full grid-cols-7">
             {orderedTabs.map((tab) => {
               const Icon = tab.icon;
               const isDragOver = dragOverTab === tab.id;
@@ -192,6 +195,10 @@ export function RelayManager() {
               );
             })}
           </TabsList>
+
+          <TabsContent value="pending-review" className="flex-1 min-h-0 mt-4">
+            <PendingReview />
+          </TabsContent>
 
           <TabsContent value="events" className="flex-1 min-h-0 overflow-hidden mt-4">
             <EventsList relayUrl={config.relayUrl} />

--- a/worker/src/db.ts
+++ b/worker/src/db.ts
@@ -50,4 +50,26 @@ export async function ensureSchema(db: D1Database): Promise<void> {
       ever_human_reviewed INTEGER DEFAULT 0
     )
   `).run();
+
+  await db.prepare(`
+    CREATE TABLE IF NOT EXISTS pending_verdicts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      event_id TEXT,
+      pubkey TEXT,
+      verdict TEXT NOT NULL DEFAULT 'flag_for_review',
+      category TEXT,
+      rule_name TEXT,
+      source TEXT DEFAULT 'osprey',
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      status TEXT DEFAULT 'pending',
+      resolved_at TEXT,
+      resolved_by TEXT
+    )
+  `).run();
+
+  try {
+    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_verdicts_status ON pending_verdicts(status, created_at)`).run();
+  } catch {
+    // Index already exists
+  }
 }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -372,6 +372,18 @@ export default {
         return handleReportWatcherRoutes(request, path, env, corsHeaders);
       }
 
+      // Pending review queue (interim Osprey verdict surface)
+      if (path === '/api/pending-review' && request.method === 'POST') {
+        return handleSubmitVerdict(request, env, corsHeaders);
+      }
+      if (path === '/api/pending-review' && request.method === 'GET') {
+        return handleListVerdicts(request, env, corsHeaders);
+      }
+      if (path.startsWith('/api/pending-review/') && path.endsWith('/resolve') && request.method === 'POST') {
+        const id = path.replace('/api/pending-review/', '').replace('/resolve', '');
+        return handleResolveVerdict(id, request, env, corsHeaders);
+      }
+
       // Funnelcake REST API proxy -- fast ClickHouse-backed reads
       if (path.startsWith('/api/funnelcake/')) {
         return handleFunnelcakeProxy(path, env, corsHeaders);
@@ -1004,6 +1016,175 @@ async function handleGetAllDecisions(
     });
   } catch (error) {
     console.error('Get all decisions error:', error);
+    return jsonResponse(
+      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
+      500,
+      corsHeaders
+    );
+  }
+}
+
+// --- Pending review queue (interim Osprey verdict surface) ---
+
+async function handleSubmitVerdict(
+  request: Request,
+  env: Env,
+  corsHeaders: Record<string, string>
+): Promise<Response> {
+  try {
+    if (!env.DB) {
+      return jsonResponse({ success: false, error: 'Database not configured' }, 500, corsHeaders);
+    }
+
+    const body = await request.json() as {
+      event_id?: string;
+      pubkey?: string;
+      verdict?: string;
+      category?: string;
+      rule_name?: string;
+      source?: string;
+    };
+
+    if (!body.event_id && !body.pubkey) {
+      return jsonResponse({ success: false, error: 'At least one of event_id or pubkey is required' }, 400, corsHeaders);
+    }
+
+    await ensureSchemaOnce(env.DB);
+
+    const result = await env.DB.prepare(`
+      INSERT INTO pending_verdicts (event_id, pubkey, verdict, category, rule_name, source)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).bind(
+      body.event_id || null,
+      body.pubkey || null,
+      body.verdict || 'flag_for_review',
+      body.category || null,
+      body.rule_name || null,
+      body.source || 'osprey'
+    ).run();
+
+    return new Response(JSON.stringify({
+      success: true,
+      id: result.meta?.last_row_id,
+    }), {
+      status: 201,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    });
+  } catch (error) {
+    console.error('Submit verdict error:', error);
+    return jsonResponse(
+      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
+      500,
+      corsHeaders
+    );
+  }
+}
+
+async function handleListVerdicts(
+  request: Request,
+  env: Env,
+  corsHeaders: Record<string, string>
+): Promise<Response> {
+  try {
+    if (!env.DB) {
+      return jsonResponse({ success: false, error: 'Database not configured' }, 500, corsHeaders);
+    }
+
+    await ensureSchemaOnce(env.DB);
+
+    const url = new URL(request.url);
+    const status = url.searchParams.get('status') || 'pending';
+
+    const verdicts = await env.DB.prepare(`
+      SELECT * FROM pending_verdicts
+      WHERE status = ?
+      ORDER BY created_at DESC
+      LIMIT 200
+    `).bind(status).all();
+
+    return new Response(JSON.stringify({
+      success: true,
+      verdicts: verdicts.results || [],
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    });
+  } catch (error) {
+    console.error('List verdicts error:', error);
+    return jsonResponse(
+      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
+      500,
+      corsHeaders
+    );
+  }
+}
+
+async function handleResolveVerdict(
+  id: string,
+  request: Request,
+  env: Env,
+  corsHeaders: Record<string, string>
+): Promise<Response> {
+  try {
+    if (!env.DB) {
+      return jsonResponse({ success: false, error: 'Database not configured' }, 500, corsHeaders);
+    }
+
+    const body = await request.json() as {
+      action: 'confirm' | 'dismiss';
+      resolved_by?: string;
+    };
+
+    if (body.action !== 'confirm' && body.action !== 'dismiss') {
+      return jsonResponse({ success: false, error: 'action must be "confirm" or "dismiss"' }, 400, corsHeaders);
+    }
+
+    await ensureSchemaOnce(env.DB);
+
+    const verdict = await env.DB.prepare(
+      `SELECT * FROM pending_verdicts WHERE id = ?`
+    ).bind(id).first();
+
+    if (!verdict) {
+      return jsonResponse({ success: false, error: 'Verdict not found' }, 404, corsHeaders);
+    }
+
+    if (verdict.status !== 'pending') {
+      return jsonResponse({ success: false, error: `Verdict already ${verdict.status}` }, 409, corsHeaders);
+    }
+
+    if (body.action === 'confirm' && verdict.event_id) {
+      const rpcRequest = new Request(`https://placeholder/api/relay-rpc`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          method: 'banevent',
+          params: [verdict.event_id, `Confirmed: ${verdict.category || verdict.verdict}`],
+        }),
+      });
+      const rpcResponse = await handleRelayRpc(rpcRequest, env, corsHeaders);
+      const rpcResult = await rpcResponse.json() as { success: boolean; error?: string };
+      if (!rpcResult.success) {
+        return jsonResponse({ success: false, error: rpcResult.error || 'Ban failed' }, 500, corsHeaders);
+      }
+    }
+
+    await env.DB.prepare(`
+      UPDATE pending_verdicts
+      SET status = ?, resolved_at = CURRENT_TIMESTAMP, resolved_by = ?
+      WHERE id = ?
+    `).bind(
+      body.action === 'confirm' ? 'confirmed' : 'dismissed',
+      body.resolved_by || null,
+      id
+    ).run();
+
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    });
+  } catch (error) {
+    console.error('Resolve verdict error:', error);
     return jsonResponse(
       { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
       500,

--- a/worker/src/pending-review.test.ts
+++ b/worker/src/pending-review.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import worker from './index';
+
+function createMockDB() {
+  const rows: Record<string, unknown>[] = [];
+  let nextId = 1;
+
+  const db = {
+    prepare: vi.fn().mockImplementation((sql: string) => {
+      const stmt = {
+        bind: vi.fn().mockImplementation((...args: unknown[]) => ({
+          run: vi.fn().mockImplementation(async () => {
+            if (sql.includes('INSERT INTO pending_verdicts')) {
+              const row = {
+                id: nextId++,
+                event_id: args[0],
+                pubkey: args[1],
+                verdict: args[2],
+                category: args[3],
+                rule_name: args[4],
+                source: args[5],
+                status: 'pending',
+                created_at: new Date().toISOString(),
+                resolved_at: null,
+                resolved_by: null,
+              };
+              rows.push(row);
+              return { success: true, meta: { last_row_id: row.id } };
+            }
+            if (sql.includes('UPDATE pending_verdicts')) {
+              const id = args[args.length - 1];
+              const row = rows.find(r => r.id === Number(id));
+              if (row) {
+                row.status = args[0];
+                row.resolved_by = args[1];
+              }
+              return { success: true, meta: { changes: 1 } };
+            }
+            return { success: true, meta: { changes: 0 } };
+          }),
+          first: vi.fn().mockImplementation(async () => {
+            if (sql.includes('SELECT * FROM pending_verdicts WHERE id')) {
+              const id = Number(args[0]);
+              return rows.find(r => r.id === id) || null;
+            }
+            return null;
+          }),
+          all: vi.fn().mockImplementation(async () => {
+            if (sql.includes('SELECT * FROM pending_verdicts')) {
+              const status = args[0] as string;
+              return { results: rows.filter(r => r.status === status) };
+            }
+            return { results: [] };
+          }),
+        })),
+        run: vi.fn().mockResolvedValue({ success: true }),
+        first: vi.fn().mockResolvedValue(null),
+        all: vi.fn().mockResolvedValue({ results: [] }),
+      };
+      return stmt;
+    }),
+  };
+
+  return { db, rows };
+}
+
+function createEnv(db: unknown) {
+  return {
+    RELAY_URL: 'wss://relay.test.com',
+    ALLOWED_ORIGINS: 'http://localhost:5173',
+    DB: db,
+  };
+}
+
+function authedRequest(url: string, init?: RequestInit): Request {
+  const headers = new Headers(init?.headers);
+  headers.set('Cf-Access-Jwt-Assertion', 'test-jwt');
+  headers.set('Origin', 'http://localhost:5173');
+  return new Request(url, { ...init, headers });
+}
+
+describe('pending review queue', () => {
+  let mockCtx: ExecutionContext;
+
+  beforeEach(() => {
+    mockCtx = { waitUntil: vi.fn(), passThroughOnException: vi.fn() } as unknown as ExecutionContext;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('POST /api/pending-review (submit verdict)', () => {
+    it('should create a pending verdict with event_id', async () => {
+      const { db } = createMockDB();
+      const env = createEnv(db);
+
+      const request = authedRequest('http://localhost/api/pending-review', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          event_id: 'abc123',
+          verdict: 'flag_for_review',
+          category: 'NS-sexualContent',
+          rule_name: 'multi_report_auto_hide',
+        }),
+      });
+
+      const response = await worker.fetch(request, env as never, mockCtx);
+      expect(response.status).toBe(201);
+
+      const body = await response.json() as { success: boolean; id: number };
+      expect(body.success).toBe(true);
+      expect(body.id).toBe(1);
+    });
+
+    it('should create a pending verdict with pubkey only', async () => {
+      const { db } = createMockDB();
+      const env = createEnv(db);
+
+      const request = authedRequest('http://localhost/api/pending-review', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          pubkey: 'deadbeef',
+          verdict: 'flag_for_review',
+          category: 'behavioral',
+          rule_name: 'repeat_offender',
+          source: 'osprey',
+        }),
+      });
+
+      const response = await worker.fetch(request, env as never, mockCtx);
+      expect(response.status).toBe(201);
+    });
+
+    it('should reject when neither event_id nor pubkey provided', async () => {
+      const { db } = createMockDB();
+      const env = createEnv(db);
+
+      const request = authedRequest('http://localhost/api/pending-review', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ verdict: 'flag_for_review' }),
+      });
+
+      const response = await worker.fetch(request, env as never, mockCtx);
+      expect(response.status).toBe(400);
+
+      const body = await response.json() as { success: boolean; error: string };
+      expect(body.success).toBe(false);
+      expect(body.error).toContain('event_id or pubkey');
+    });
+  });
+
+  describe('GET /api/pending-review (list verdicts)', () => {
+    it('should list pending verdicts', async () => {
+      const { db, rows } = createMockDB();
+      rows.push({
+        id: 1,
+        event_id: 'abc123',
+        pubkey: null,
+        verdict: 'flag_for_review',
+        category: 'NS-sexualContent',
+        rule_name: 'test_rule',
+        source: 'osprey',
+        status: 'pending',
+        created_at: new Date().toISOString(),
+        resolved_at: null,
+        resolved_by: null,
+      });
+      const env = createEnv(db);
+
+      const request = authedRequest('http://localhost/api/pending-review?status=pending');
+      const response = await worker.fetch(request, env as never, mockCtx);
+      expect(response.status).toBe(200);
+
+      const body = await response.json() as { success: boolean; verdicts: unknown[] };
+      expect(body.success).toBe(true);
+      expect(body.verdicts).toHaveLength(1);
+    });
+
+    it('should default to pending status when no query param', async () => {
+      const { db } = createMockDB();
+      const env = createEnv(db);
+
+      const request = authedRequest('http://localhost/api/pending-review');
+      const response = await worker.fetch(request, env as never, mockCtx);
+      expect(response.status).toBe(200);
+
+      const body = await response.json() as { success: boolean; verdicts: unknown[] };
+      expect(body.success).toBe(true);
+    });
+  });
+
+  describe('POST /api/pending-review/:id/resolve', () => {
+    it('should dismiss a pending verdict without enforcement', async () => {
+      const { db, rows } = createMockDB();
+      rows.push({
+        id: 1,
+        event_id: 'abc123',
+        pubkey: null,
+        verdict: 'flag_for_review',
+        category: 'NS-sexualContent',
+        rule_name: 'test_rule',
+        source: 'osprey',
+        status: 'pending',
+        created_at: new Date().toISOString(),
+        resolved_at: null,
+        resolved_by: null,
+      });
+      const env = createEnv(db);
+
+      const request = authedRequest('http://localhost/api/pending-review/1/resolve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'dismiss', resolved_by: 'moderator_npub' }),
+      });
+
+      const response = await worker.fetch(request, env as never, mockCtx);
+      expect(response.status).toBe(200);
+
+      const body = await response.json() as { success: boolean };
+      expect(body.success).toBe(true);
+    });
+
+    it('should reject invalid action', async () => {
+      const { db } = createMockDB();
+      const env = createEnv(db);
+
+      const request = authedRequest('http://localhost/api/pending-review/1/resolve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'invalid' }),
+      });
+
+      const response = await worker.fetch(request, env as never, mockCtx);
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 404 for non-existent verdict', async () => {
+      const { db } = createMockDB();
+      const env = createEnv(db);
+
+      const request = authedRequest('http://localhost/api/pending-review/999/resolve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'dismiss' }),
+      });
+
+      const response = await worker.fetch(request, env as never, mockCtx);
+      expect(response.status).toBe(404);
+    });
+
+    it('should require auth', async () => {
+      const { db } = createMockDB();
+      const env = createEnv(db);
+
+      const request = new Request('http://localhost/api/pending-review/1/resolve', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Origin': 'http://localhost:5173',
+        },
+        body: JSON.stringify({ action: 'dismiss' }),
+      });
+
+      const response = await worker.fetch(request, env as never, mockCtx);
+      expect(response.status).toBe(401);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- D1 `pending_verdicts` table + three API endpoints (submit, list, resolve) for `flag_for_review` verdicts
- Review tab in admin UI with pending/resolved toggle, Ban/Dismiss actions
- Thin scaffolding replaced when COOP is ready -- no routing, assignment, or priority

## Context
Osprey emits `flag_for_review` for signals that need human review but shouldn't auto-enforce (first reports below threshold, future AI/behavioral signals). This gives those verdicts an actionable queue until COOP moderation tooling is integrated.

## Test plan
- [ ] 9 worker tests pass (`cd worker && npx vitest run`)
- [ ] Review tab renders in admin UI
- [ ] Submit verdict via curl, see it appear in queue
- [ ] Confirm (ban) and dismiss actions work
- [ ] Resolved tab shows history

Closes #125.
