### PR TITLE
ci: ReportWatcher health check with self-healing

### DIFF
--- a/.github/workflows/report-watcher-health.yml
+++ b/.github/workflows/report-watcher-health.yml
@@ -1,0 +1,197 @@
+# ReportWatcher Health Check
+#
+# Polls staging and production ReportWatcher Durable Objects every 15 min.
+# If unhealthy, attempts auto-recovery via /start. If recovery fails,
+# alerts #divine-alerts via Slack webhook (same channel as GKE alerting).
+#
+# Lives in relay-manager (not iac-coreconfig) because ReportWatcher is a
+# Cloudflare Durable Object outside the GKE observability perimeter.
+# No Prometheus, no VMRule, no liveness probe can reach it.
+#
+# Setup:
+#   1. Repo secrets (Settings > Secrets and variables > Actions):
+#      - CF_ACCESS_CLIENT_ID    — Cloudflare Access service token
+#      - CF_ACCESS_CLIENT_SECRET — Cloudflare Access service token
+#      - SLACK_WEBHOOK_ALERTS   — Incoming webhook for #divine-alerts
+#        (same value as vmalertmanager-slack-webhook-{env} in GCP Secret Manager)
+#   2. To test manually: Actions tab > "ReportWatcher Health Check" > Run workflow
+
+name: ReportWatcher Health Check
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+jobs:
+  health-check:
+    runs-on: ubuntu-latest
+    # Never mark the workflow as failed — that emails all repo watchers.
+    # Alerting goes through Slack only.
+    continue-on-error: true
+
+    strategy:
+      matrix:
+        env:
+          - name: staging
+            url: https://api-relay-staging.divine.video
+          - name: production
+            url: https://api-relay-prod.divine.video
+
+    steps:
+      - name: Check health
+        id: check
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+          API_URL: ${{ matrix.env.url }}
+        run: |
+          RESPONSE=$(curl -sf --max-time 10 \
+            -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+            -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
+            "$API_URL/api/report-watcher/status" 2>&1) || {
+            echo "healthy=false" >> "$GITHUB_OUTPUT"
+            echo "payload=HTTP request failed" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+          CONNECTED=$(echo "$RESPONSE" | jq -r '.status.connected')
+          RUNNING=$(echo "$RESPONSE" | jq -r '.status.running')
+          if [ "$CONNECTED" = "true" ] && [ "$RUNNING" = "true" ]; then
+            echo "healthy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "healthy=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "payload=$(echo "$RESPONSE" | jq -c '.status')" >> "$GITHUB_OUTPUT"
+
+      # --- Self-healing: try to restart before alerting ---
+
+      - name: Attempt auto-recovery
+        id: recover
+        if: steps.check.outputs.healthy == 'false'
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+          API_URL: ${{ matrix.env.url }}
+        run: |
+          echo "ReportWatcher unhealthy on ${{ matrix.env.name }}, attempting restart..."
+          curl -sf --max-time 15 -X POST \
+            -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+            -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
+            "$API_URL/api/report-watcher/start" || true
+
+          echo "Waiting 30s for reconnection..."
+          sleep 30
+
+          RESPONSE=$(curl -sf --max-time 10 \
+            -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+            -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
+            "$API_URL/api/report-watcher/status" 2>&1) || {
+            echo "recovered=false" >> "$GITHUB_OUTPUT"
+            echo "payload=HTTP request failed after restart" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+          CONNECTED=$(echo "$RESPONSE" | jq -r '.status.connected')
+          RUNNING=$(echo "$RESPONSE" | jq -r '.status.running')
+          if [ "$CONNECTED" = "true" ] && [ "$RUNNING" = "true" ]; then
+            echo "recovered=true" >> "$GITHUB_OUTPUT"
+            echo "ReportWatcher recovered after restart"
+          else
+            echo "recovered=false" >> "$GITHUB_OUTPUT"
+            echo "payload=$(echo "$RESPONSE" | jq -c '.status')" >> "$GITHUB_OUTPUT"
+            echo "ReportWatcher still unhealthy after restart"
+          fi
+
+      # --- Failure counting: only alert on 2+ consecutive post-recovery failures ---
+
+      - name: Restore failure count
+        if: steps.check.outputs.healthy == 'false' && steps.recover.outputs.recovered != 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: .health-state
+          key: rw-health-${{ matrix.env.name }}-${{ github.run_id }}
+          restore-keys: rw-health-${{ matrix.env.name }}-
+
+      - name: Update failure count
+        id: counts
+        if: always()
+        env:
+          HEALTHY: ${{ steps.check.outputs.healthy }}
+          RECOVERED: ${{ steps.recover.outputs.recovered }}
+          ENV_NAME: ${{ matrix.env.name }}
+        run: |
+          mkdir -p .health-state
+
+          FAILS=$(cat ".health-state/$ENV_NAME-fails" 2>/dev/null || echo 0)
+
+          if [ "$HEALTHY" = "true" ] || [ "$RECOVERED" = "true" ]; then
+            FAILS=0
+          else
+            FAILS=$((FAILS + 1))
+          fi
+
+          echo "$FAILS" > ".health-state/$ENV_NAME-fails"
+          echo "fails=$FAILS" >> "$GITHUB_OUTPUT"
+
+          if [ "$FAILS" -ge 2 ]; then
+            echo "alert=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "alert=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Track if we auto-recovered (worth a quiet log, not an alert)
+          if [ "$HEALTHY" = "false" ] && [ "$RECOVERED" = "true" ]; then
+            echo "self_healed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "self_healed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Save failure count
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: .health-state
+          key: rw-health-${{ matrix.env.name }}-${{ github.run_id }}
+
+      # --- Alert to Slack only when auto-recovery failed twice in a row ---
+
+      - name: Alert to Slack
+        if: steps.counts.outputs.alert == 'true'
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ALERTS }}
+          ENV_NAME: ${{ matrix.env.name }}
+          FAILS: ${{ steps.counts.outputs.fails }}
+          STATUS_PAYLOAD: ${{ steps.recover.outputs.payload || steps.check.outputs.payload }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK" ]; then
+            echo "::warning::SLACK_WEBHOOK_ALERTS secret not configured, skipping alert"
+            exit 0
+          fi
+
+          curl -sf --max-time 10 -X POST "$SLACK_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"text\": \":rotating_light: ReportWatcher *$ENV_NAME* unhealthy ($FAILS consecutive failures, auto-restart failed)\",
+              \"blocks\": [
+                {
+                  \"type\": \"section\",
+                  \"text\": {
+                    \"type\": \"mrkdwn\",
+                    \"text\": \":rotating_light: *ReportWatcher health check failing*\n*Environment:* $ENV_NAME\n*Consecutive failures:* $FAILS (including auto-restart attempts)\n*Status:* \`$STATUS_PAYLOAD\`\"
+                  }
+                },
+                {
+                  \"type\": \"context\",
+                  \"elements\": [{
+                    \"type\": \"mrkdwn\",
+                    \"text\": \"<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>\"
+                  }]
+                }
+              ]
+            }"
+
+      # --- Quiet log when self-healing worked (no alert, just visibility) ---
+
+      - name: Log self-healing
+        if: steps.counts.outputs.self_healed == 'true'
+        run: |
+          echo "::notice::ReportWatcher ${{ matrix.env.name }} was unhealthy but recovered after auto-restart"

--- a/.github/workflows/report-watcher-health.yml
+++ b/.github/workflows/report-watcher-health.yml
@@ -8,13 +8,23 @@
 # Cloudflare Durable Object outside the GKE observability perimeter.
 # No Prometheus, no VMRule, no liveness probe can reach it.
 #
+# Failure counting uses GitHub Actions repository variables
+# (RW_FAILS_STAGING, RW_FAILS_PRODUCTION) instead of actions/cache.
+# These are simple integers that persist across runs without accumulating
+# cache entries. The workflow resets them to 0 on recovery.
+#
 # Setup:
 #   1. Repo secrets (Settings > Secrets and variables > Actions):
-#      - CF_ACCESS_CLIENT_ID    — Cloudflare Access service token
-#      - CF_ACCESS_CLIENT_SECRET — Cloudflare Access service token
-#      - SLACK_WEBHOOK_ALERTS   — Incoming webhook for #divine-alerts
+#      - CF_ACCESS_CLIENT_ID    -- Cloudflare Access service token
+#      - CF_ACCESS_CLIENT_SECRET -- Cloudflare Access service token
+#      - SLACK_WEBHOOK_ALERTS   -- Incoming webhook for #divine-alerts
 #        (same value as vmalertmanager-slack-webhook-{env} in GCP Secret Manager)
-#   2. To test manually: Actions tab > "ReportWatcher Health Check" > Run workflow
+#   2. Repo variables (Settings > Secrets and variables > Actions > Variables):
+#      - RW_FAILS_STAGING       -- set to 0 (created automatically on first run)
+#      - RW_FAILS_PRODUCTION    -- set to 0 (created automatically on first run)
+#   3. Workflow permissions: needs read/write access to Actions variables.
+#      The default GITHUB_TOKEN has this for repo-scoped variables.
+#   4. To test manually: Actions tab > "ReportWatcher Health Check" > Run workflow
 
 name: ReportWatcher Health Check
 
@@ -26,7 +36,7 @@ on:
 jobs:
   health-check:
     runs-on: ubuntu-latest
-    # Never mark the workflow as failed — that emails all repo watchers.
+    # Never mark the workflow as failed -- that emails all repo watchers.
     # Alerting goes through Slack only.
     continue-on-error: true
 
@@ -35,8 +45,10 @@ jobs:
         env:
           - name: staging
             url: https://api-relay-staging.divine.video
+            fails_var: RW_FAILS_STAGING
           - name: production
             url: https://api-relay-prod.divine.video
+            fails_var: RW_FAILS_PRODUCTION
 
     steps:
       - name: Check health
@@ -46,22 +58,57 @@ jobs:
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
           API_URL: ${{ matrix.env.url }}
         run: |
-          RESPONSE=$(curl -sf --max-time 10 \
+          # Capture HTTP status and body separately for diagnostics (#130)
+          HTTP_CODE=$(curl -s -o /tmp/rw-response.json -w '%{http_code}' --max-time 10 \
             -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
             -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
-            "$API_URL/api/report-watcher/status" 2>&1) || {
+            "$API_URL/api/report-watcher/status" 2>/tmp/rw-curl-err.txt) || {
+            CURL_EXIT=$?
+            CURL_ERR=$(cat /tmp/rw-curl-err.txt 2>/dev/null | tail -1)
+            # Distinguish transport failures from HTTP errors
+            if [ "$CURL_EXIT" = "28" ]; then
+              DIAG="timeout after 10s"
+            elif [ "$CURL_EXIT" = "6" ]; then
+              DIAG="DNS resolution failed"
+            elif [ "$CURL_EXIT" = "7" ]; then
+              DIAG="connection refused"
+            else
+              DIAG="curl exit $CURL_EXIT: $CURL_ERR"
+            fi
             echo "healthy=false" >> "$GITHUB_OUTPUT"
-            echo "payload=HTTP request failed" >> "$GITHUB_OUTPUT"
+            echo "payload=transport_error: $DIAG" >> "$GITHUB_OUTPUT"
+            echo "http_code=0" >> "$GITHUB_OUTPUT"
             exit 0
           }
-          CONNECTED=$(echo "$RESPONSE" | jq -r '.status.connected')
-          RUNNING=$(echo "$RESPONSE" | jq -r '.status.running')
+
+          echo "http_code=$HTTP_CODE" >> "$GITHUB_OUTPUT"
+
+          if [ "$HTTP_CODE" = "403" ] || [ "$HTTP_CODE" = "401" ]; then
+            echo "healthy=false" >> "$GITHUB_OUTPUT"
+            echo "payload=auth_error: HTTP $HTTP_CODE (check CF Access credentials)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "healthy=false" >> "$GITHUB_OUTPUT"
+            echo "payload=http_error: HTTP $HTTP_CODE" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BODY=$(cat /tmp/rw-response.json)
+          CONNECTED=$(echo "$BODY" | jq -r '.status.connected' 2>/dev/null) || {
+            echo "healthy=false" >> "$GITHUB_OUTPUT"
+            echo "payload=parse_error: response is not valid JSON" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+          RUNNING=$(echo "$BODY" | jq -r '.status.running')
+
           if [ "$CONNECTED" = "true" ] && [ "$RUNNING" = "true" ]; then
             echo "healthy=true" >> "$GITHUB_OUTPUT"
           else
             echo "healthy=false" >> "$GITHUB_OUTPUT"
           fi
-          echo "payload=$(echo "$RESPONSE" | jq -c '.status')" >> "$GITHUB_OUTPUT"
+          echo "payload=$(echo "$BODY" | jq -c '.status')" >> "$GITHUB_OUTPUT"
 
       # --- Self-healing: try to restart before alerting ---
 
@@ -74,54 +121,59 @@ jobs:
           API_URL: ${{ matrix.env.url }}
         run: |
           echo "ReportWatcher unhealthy on ${{ matrix.env.name }}, attempting restart..."
-          curl -sf --max-time 15 -X POST \
+          echo "Initial failure: ${{ steps.check.outputs.payload }}"
+
+          RESTART_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 -X POST \
             -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
             -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
-            "$API_URL/api/report-watcher/start" || true
+            "$API_URL/api/report-watcher/start" 2>/dev/null) || true
+          echo "Restart response: HTTP $RESTART_CODE"
 
           echo "Waiting 30s for reconnection..."
           sleep 30
 
-          RESPONSE=$(curl -sf --max-time 10 \
+          HTTP_CODE=$(curl -s -o /tmp/rw-recover.json -w '%{http_code}' --max-time 10 \
             -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
             -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
-            "$API_URL/api/report-watcher/status" 2>&1) || {
+            "$API_URL/api/report-watcher/status" 2>/dev/null) || {
             echo "recovered=false" >> "$GITHUB_OUTPUT"
-            echo "payload=HTTP request failed after restart" >> "$GITHUB_OUTPUT"
+            echo "payload=transport_error after restart (HTTP $HTTP_CODE)" >> "$GITHUB_OUTPUT"
             exit 0
           }
-          CONNECTED=$(echo "$RESPONSE" | jq -r '.status.connected')
-          RUNNING=$(echo "$RESPONSE" | jq -r '.status.running')
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "recovered=false" >> "$GITHUB_OUTPUT"
+            echo "payload=http_error after restart: HTTP $HTTP_CODE" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BODY=$(cat /tmp/rw-recover.json)
+          CONNECTED=$(echo "$BODY" | jq -r '.status.connected' 2>/dev/null)
+          RUNNING=$(echo "$BODY" | jq -r '.status.running' 2>/dev/null)
           if [ "$CONNECTED" = "true" ] && [ "$RUNNING" = "true" ]; then
             echo "recovered=true" >> "$GITHUB_OUTPUT"
             echo "ReportWatcher recovered after restart"
           else
             echo "recovered=false" >> "$GITHUB_OUTPUT"
-            echo "payload=$(echo "$RESPONSE" | jq -c '.status')" >> "$GITHUB_OUTPUT"
+            echo "payload=$(echo "$BODY" | jq -c '.status')" >> "$GITHUB_OUTPUT"
             echo "ReportWatcher still unhealthy after restart"
           fi
 
-      # --- Failure counting: only alert on 2+ consecutive post-recovery failures ---
-
-      - name: Restore failure count
-        if: steps.check.outputs.healthy == 'false' && steps.recover.outputs.recovered != 'true'
-        uses: actions/cache/restore@v4
-        with:
-          path: .health-state
-          key: rw-health-${{ matrix.env.name }}-${{ github.run_id }}
-          restore-keys: rw-health-${{ matrix.env.name }}-
+      # --- Failure counting via repo variables (not cache) ---
+      # Uses GitHub Actions repository variables for persistence.
+      # Simple, no cache accumulation, easy to inspect and reset manually.
 
       - name: Update failure count
         id: counts
         if: always()
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEALTHY: ${{ steps.check.outputs.healthy }}
           RECOVERED: ${{ steps.recover.outputs.recovered }}
-          ENV_NAME: ${{ matrix.env.name }}
+          FAILS_VAR: ${{ matrix.env.fails_var }}
         run: |
-          mkdir -p .health-state
-
-          FAILS=$(cat ".health-state/$ENV_NAME-fails" 2>/dev/null || echo 0)
+          # Read current count from repo variable (default 0 if not set)
+          FAILS=$(gh variable get "$FAILS_VAR" --repo "$GITHUB_REPOSITORY" 2>/dev/null || echo "0")
 
           if [ "$HEALTHY" = "true" ] || [ "$RECOVERED" = "true" ]; then
             FAILS=0
@@ -129,7 +181,9 @@ jobs:
             FAILS=$((FAILS + 1))
           fi
 
-          echo "$FAILS" > ".health-state/$ENV_NAME-fails"
+          # Write back
+          gh variable set "$FAILS_VAR" --repo "$GITHUB_REPOSITORY" --body "$FAILS"
+
           echo "fails=$FAILS" >> "$GITHUB_OUTPUT"
 
           if [ "$FAILS" -ge 2 ]; then
@@ -138,19 +192,11 @@ jobs:
             echo "alert=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # Track if we auto-recovered (worth a quiet log, not an alert)
           if [ "$HEALTHY" = "false" ] && [ "$RECOVERED" = "true" ]; then
             echo "self_healed=true" >> "$GITHUB_OUTPUT"
           else
             echo "self_healed=false" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Save failure count
-        if: always()
-        uses: actions/cache/save@v4
-        with:
-          path: .health-state
-          key: rw-health-${{ matrix.env.name }}-${{ github.run_id }}
 
       # --- Alert to Slack only when auto-recovery failed twice in a row ---
 

--- a/.github/workflows/report-watcher-health.yml
+++ b/.github/workflows/report-watcher-health.yml
@@ -101,7 +101,11 @@ jobs:
             echo "payload=parse_error: response is not valid JSON" >> "$GITHUB_OUTPUT"
             exit 0
           }
-          RUNNING=$(echo "$BODY" | jq -r '.status.running')
+          RUNNING=$(echo "$BODY" | jq -r '.status.running' 2>/dev/null) || {
+            echo "healthy=false" >> "$GITHUB_OUTPUT"
+            echo "payload=parse_error: .status.running not readable" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
 
           if [ "$CONNECTED" = "true" ] && [ "$RUNNING" = "true" ]; then
             echo "healthy=true" >> "$GITHUB_OUTPUT"
@@ -114,7 +118,7 @@ jobs:
 
       - name: Attempt auto-recovery
         id: recover
-        if: steps.check.outputs.healthy == 'false'
+        if: steps.check.outputs.healthy == 'false' && steps.check.outputs.http_code != '401' && steps.check.outputs.http_code != '403'
         env:
           CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
@@ -126,8 +130,8 @@ jobs:
           RESTART_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 -X POST \
             -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
             -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
-            "$API_URL/api/report-watcher/start" 2>/dev/null) || true
-          echo "Restart response: HTTP $RESTART_CODE"
+            "$API_URL/api/report-watcher/start" 2>/dev/null) || RESTART_CODE="transport_error"
+          echo "Restart response: $RESTART_CODE"
 
           echo "Waiting 30s for reconnection..."
           sleep 30
@@ -137,7 +141,7 @@ jobs:
             -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
             "$API_URL/api/report-watcher/status" 2>/dev/null) || {
             echo "recovered=false" >> "$GITHUB_OUTPUT"
-            echo "payload=transport_error after restart (HTTP $HTTP_CODE)" >> "$GITHUB_OUTPUT"
+            echo "payload=transport_error after restart" >> "$GITHUB_OUTPUT"
             exit 0
           }
 
@@ -174,6 +178,7 @@ jobs:
         run: |
           # Read current count from repo variable (default 0 if not set)
           FAILS=$(gh variable get "$FAILS_VAR" --repo "$GITHUB_REPOSITORY" 2>/dev/null || echo "0")
+          [[ "$FAILS" =~ ^[0-9]+$ ]] || FAILS=0
 
           if [ "$HEALTHY" = "true" ] || [ "$RECOVERED" = "true" ]; then
             FAILS=0
@@ -213,27 +218,22 @@ jobs:
             exit 0
           fi
 
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          PAYLOAD=$(jq -n \
+            --arg env "$ENV_NAME" \
+            --arg fails "$FAILS" \
+            --arg status "$STATUS_PAYLOAD" \
+            --arg run_url "$RUN_URL" \
+            '{
+              text: ":rotating_light: ReportWatcher *\($env)* unhealthy (\($fails) consecutive failures, auto-restart failed)",
+              blocks: [
+                {type: "section", text: {type: "mrkdwn", text: ":rotating_light: *ReportWatcher health check failing*\n*Environment:* \($env)\n*Consecutive failures:* \($fails) (including auto-restart attempts)\n*Status:* `\($status)`"}},
+                {type: "context", elements: [{type: "mrkdwn", text: "<\($run_url)|View workflow run>"}]}
+              ]
+            }')
           curl -sf --max-time 10 -X POST "$SLACK_WEBHOOK" \
             -H "Content-Type: application/json" \
-            -d "{
-              \"text\": \":rotating_light: ReportWatcher *$ENV_NAME* unhealthy ($FAILS consecutive failures, auto-restart failed)\",
-              \"blocks\": [
-                {
-                  \"type\": \"section\",
-                  \"text\": {
-                    \"type\": \"mrkdwn\",
-                    \"text\": \":rotating_light: *ReportWatcher health check failing*\n*Environment:* $ENV_NAME\n*Consecutive failures:* $FAILS (including auto-restart attempts)\n*Status:* \`$STATUS_PAYLOAD\`\"
-                  }
-                },
-                {
-                  \"type\": \"context\",
-                  \"elements\": [{
-                    \"type\": \"mrkdwn\",
-                    \"text\": \"<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>\"
-                  }]
-                }
-              ]
-            }"
+            -d "$PAYLOAD"
 
       # --- Quiet log when self-healing worked (no alert, just visibility) ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,3 +207,10 @@ worker/
 - **NIP-56**: Kind 1984 report events. Core input for the moderation queue.
 - **NIP-32**: Kind 1985 label events. Published by the moderation service with AI classification results.
 - **Kind 0**: Profile metadata. Fetched by `useAuthor` for display names and avatars.
+
+## Cross-Repo Coordination
+
+This repo is **Layer 1** in the auto-hide evolution plan. Read the coordination doc at session start:
+`~/code/support-trust-safety/docs/moderation/auto-hide-evolution-plan.md`
+
+When you make decisions or discover constraints that affect other layers, update that doc and flag it for the user.


### PR DESCRIPTION
## Summary
- Polls staging + production ReportWatcher every 15 min
- Auto-restarts via `/api/report-watcher/start` if unhealthy, re-checks after 30s
- Alerts `#divine-alerts` via Slack webhook only after 2+ consecutive post-recovery failures
- `continue-on-error: true` prevents workflow failure notifications to repo watchers

Closes divinevideo/support-trust-safety#130 -- Structured diagnostic output distinguishing auth errors (HTTP 401/403), timeouts (curl exit 28), DNS failures, connection refused, and JSON parse errors.

Closes divinevideo/support-trust-safety#131 -- Replaced actions/cache with GitHub Actions repo variables (`RW_FAILS_STAGING`, `RW_FAILS_PRODUCTION`). Simple integers, no cache accumulation, inspectable and resettable from Settings UI.

## Setup (before enabling)
Add three repo secrets (Settings > Secrets and variables > Actions):
- `CF_ACCESS_CLIENT_ID` -- Cloudflare Access service token (same as support-trust-safety)
- `CF_ACCESS_CLIENT_SECRET` -- same
- `SLACK_WEBHOOK_ALERTS` -- Incoming webhook for #divine-alerts (same value as `vmalertmanager-slack-webhook-production` in GCP Secret Manager, ask Sam/Ira)

Repo variables (`RW_FAILS_STAGING`, `RW_FAILS_PRODUCTION`) are created automatically on first run.

Workflow runs harmlessly without secrets (curl fails, Slack step skips with warning, workflow stays green).

## Context
Replaces the version in support-trust-safety. Lives here because ReportWatcher is a Cloudflare Durable Object outside the GKE observability perimeter -- no Prometheus, VMRule, or liveness probe can reach it.

## Test plan
- [ ] Merge and configure secrets
- [ ] Run manually from Actions tab to verify staging/prod checks
- [ ] Verify Slack message format in #divine-alerts
- [ ] Stop ReportWatcher manually, confirm auto-restart works
- [ ] Confirm no email notifications to repo watchers on failure