### PR TITLE
fix: recognize QUARANTINE as blocked state in media status

### DIFF
--- a/src/components/HiveAIReport.tsx
+++ b/src/components/HiveAIReport.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Displays Hive AI moderation results from the divine-moderation-service
 // ABOUTME: Shows confidence scores, classification categories, timestamps, and re-check ability
 
-import { getApiHeaders } from "@/lib/adminApi";
+import { getApiHeaders, type MediaStatusAction } from "@/lib/adminApi";
 import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Badge } from "@/components/ui/badge";
@@ -27,7 +27,7 @@ interface HiveAIReportProps {
 }
 
 interface ModerationResult {
-  action: 'SAFE' | 'REVIEW' | 'AGE_RESTRICTED' | 'PERMANENT_BAN' | 'FLAGGED' | 'QUARANTINE';
+  action: MediaStatusAction | 'FLAGGED';
   scores: {
     nudity?: number;
     violence?: number;

--- a/src/hooks/useMediaStatus.ts
+++ b/src/hooks/useMediaStatus.ts
@@ -3,7 +3,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useAdminApi } from "@/hooks/useAdminApi";
-import type { MediaStatus } from "@/lib/adminApi";
+import { isBlockedMediaAction, type MediaStatus } from "@/lib/adminApi";
 
 export interface MediaStatusResult {
   hash: string;
@@ -26,7 +26,7 @@ export function useMediaStatus(hashes: string[]) {
           return {
             hash,
             status,
-            isBlocked: status?.action === 'PERMANENT_BAN' || status?.action === 'QUARANTINE',
+            isBlocked: isBlockedMediaAction(status?.action),
             isRestricted: status?.action === 'AGE_RESTRICTED',
           };
         })

--- a/src/hooks/useMediaStatus.ts
+++ b/src/hooks/useMediaStatus.ts
@@ -26,7 +26,7 @@ export function useMediaStatus(hashes: string[]) {
           return {
             hash,
             status,
-            isBlocked: status?.action === 'PERMANENT_BAN',
+            isBlocked: status?.action === 'PERMANENT_BAN' || status?.action === 'QUARANTINE',
             isRestricted: status?.action === 'AGE_RESTRICTED',
           };
         })

--- a/src/lib/adminApi.test.ts
+++ b/src/lib/adminApi.test.ts
@@ -24,10 +24,12 @@ import {
   logDecision,
   getDecisions,
   extractMediaHashes,
+  isBlockedMediaAction,
   type UnsignedEvent,
   type ApiResponse,
   type LabelParams,
   type ModerationAction,
+  type MediaStatusAction,
 } from './adminApi';
 
 // Mock fetch globally
@@ -754,6 +756,24 @@ describe('adminApi', () => {
 
       expect(result).toBe(false);
       vi.useRealTimers();
+    });
+  });
+
+  describe('isBlockedMediaAction', () => {
+    it('treats permanently banned media as blocked', () => {
+      expect(isBlockedMediaAction('PERMANENT_BAN')).toBe(true);
+    });
+
+    it('treats quarantined media as blocked', () => {
+      expect(isBlockedMediaAction('QUARANTINE')).toBe(true);
+    });
+
+    it('does not treat non-blocking statuses as blocked', () => {
+      const actions: MediaStatusAction[] = ['SAFE', 'REVIEW', 'AGE_RESTRICTED'];
+
+      for (const action of actions) {
+        expect(isBlockedMediaAction(action)).toBe(false);
+      }
     });
   });
 

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -280,15 +280,21 @@ export async function markAsReviewed(
   });
 }
 
-// Media moderation actions
-export type ModerationAction = 'SAFE' | 'REVIEW' | 'AGE_RESTRICTED' | 'PERMANENT_BAN' | 'QUARANTINE';
+// Media moderation request actions
+export type ModerationAction = 'SAFE' | 'REVIEW' | 'AGE_RESTRICTED' | 'PERMANENT_BAN';
+// Media moderation status values returned by /api/check-result/:sha256
+export type MediaStatusAction = ModerationAction | 'QUARANTINE';
 
 export interface MediaStatus {
   sha256: string;
-  action: ModerationAction;
+  action: MediaStatusAction;
   reason?: string;
   created_at?: string;
   source?: string;
+}
+
+export function isBlockedMediaAction(action: MediaStatusAction | null | undefined): boolean {
+  return action === 'PERMANENT_BAN' || action === 'QUARANTINE';
 }
 
 export async function moderateMedia(

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -281,7 +281,7 @@ export async function markAsReviewed(
 }
 
 // Media moderation actions
-export type ModerationAction = 'SAFE' | 'REVIEW' | 'AGE_RESTRICTED' | 'PERMANENT_BAN';
+export type ModerationAction = 'SAFE' | 'REVIEW' | 'AGE_RESTRICTED' | 'PERMANENT_BAN' | 'QUARANTINE';
 
 export interface MediaStatus {
   sha256: string;


### PR DESCRIPTION
## Summary

- Adds `QUARANTINE` to the `ModerationAction` union type in `adminApi.ts`
- Treats QUARANTINE as blocked in `useMediaStatus` so quarantined items show correct action buttons

Split out from #56 per review feedback — isolated for independent rollout/rollback.

## Test plan

- [x] tsc passes
- [ ] Verify quarantined media shows blocked UI (ban icon, not play button)