### PR TITLE
fix: add BLOSSOM_WEBHOOK_SECRET secrets store binding to worker configs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ CF Pages                               CF Workers (staging + prod)
   |                                      |
   |-- useThread, useAuthor, etc.         |-- handleModerate() --> relay RPC
   |   (direct relay WebSocket)           |-- syncZendeskAfterAction()
-  |                                      |-- notifyBlossom()
+  |                                      |-- handleMediaProxy()
   |                                      |-- ReportWatcher (Durable Object)
   v                                      v
 Funnelcake relay (GKE)               D1 (moderation_decisions, zendesk_tickets,
@@ -64,7 +64,6 @@ When a moderation action completes, `handleModerate()` triggers side effects:
 | Relay RPC (banevent/banpubkey/etc.) | **YES** | Return error to UI. Do not proceed. |
 | `markHumanReviewed()` | No | Log error, continue. Prevents auto-hide from overriding human decisions. |
 | `syncZendeskAfterAction()` | No | Log error, continue. Zendesk ticket state may lag. |
-| `notifyBlossom()` | No | Log error, continue. Media moderation state may lag. |
 
 **Rules:**
 - Critical side effects: `await`, return error on failure.
@@ -78,11 +77,12 @@ When a moderation action completes, `handleModerate()` triggers side effects:
 - Only resolves tickets for actions in the `resolutionActions` array
 - **When adding new moderation actions, check whether they should resolve tickets and add to `resolutionActions` if so.**
 
-### notifyBlossom()
+### handleMediaProxy()
 
-- POSTs to the Blossom media server admin moderation endpoint with Bearer token auth
-- Payload: `{ sha256, action: "BLOCK"|"RESTRICT"|"APPROVE" }`
-- Auth token is a per-worker secret (not in wrangler config)
+- Proxies blocked media to moderators via Blossom's admin blob endpoint
+- Requires `BLOSSOM_WEBHOOK_SECRET` Bearer auth and returns a clear 500 if the secret is unbound
+- Uses `CDN_DOMAIN` from `wrangler.*.toml`, defaulting to `media.divine.video`
+- Forwards `Range` requests and streams the upstream response body through without buffering
 
 ### ReportWatcher (Durable Object)
 

--- a/worker/wrangler.local.toml
+++ b/worker/wrangler.local.toml
@@ -13,6 +13,8 @@ compatibility_date = "2024-12-01"
 
 # CF Access credentials - set via: wrangler secret put CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET
 
+# BLOSSOM_WEBHOOK_SECRET - set via: wrangler secret put BLOSSOM_WEBHOOK_SECRET
+
 [vars]
 RELAY_URL = "wss://relay.divine.video"
 AUTO_HIDE_ENABLED = "false"

--- a/worker/wrangler.prod.toml
+++ b/worker/wrangler.prod.toml
@@ -33,6 +33,12 @@ binding = "SERVICE_API_TOKEN"
 store_id = "ef490704b12a4feb91c7feb51229c364"
 secret_name = "SERVICE_API_TOKEN"
 
+# Blossom admin bypass token (proxies blocked media to moderators)
+[[secrets_store_secrets]]
+binding = "BLOSSOM_WEBHOOK_SECRET"
+store_id = "ef490704b12a4feb91c7feb51229c364"
+secret_name = "BLOSSOM_WEBHOOK_SECRET"
+
 [vars]
 RELAY_URL = "wss://relay.divine.video"
 ENVIRONMENT = "production"

--- a/worker/wrangler.staging.toml
+++ b/worker/wrangler.staging.toml
@@ -33,6 +33,12 @@ binding = "SERVICE_API_TOKEN"
 store_id = "ef490704b12a4feb91c7feb51229c364"
 secret_name = "SERVICE_API_TOKEN"
 
+# Blossom admin bypass token (proxies blocked media to moderators)
+[[secrets_store_secrets]]
+binding = "BLOSSOM_WEBHOOK_SECRET"
+store_id = "ef490704b12a4feb91c7feb51229c364"
+secret_name = "BLOSSOM_WEBHOOK_SECRET"
+
 [vars]
 RELAY_URL = "wss://relay.staging.divine.video"
 ENVIRONMENT = "staging"


### PR DESCRIPTION
## Summary

- Adds `BLOSSOM_WEBHOOK_SECRET` secrets store binding to both staging and prod wrangler configs
- Media proxy was returning 500 because the handler code existed but the secret was never wired
- Already hotfixed to staging and prod; this PR aligns the config files

Split out from #56 per review feedback — infra change isolated for independent review.

## Test plan

- [x] Already deployed and verified on both environments
- [ ] Confirm media proxy returns content after next deploy from this config