### PR TITLE
feat(#61): child safety report category labels

### DIFF
--- a/src/components/Reports.tsx
+++ b/src/components/Reports.tsx
@@ -61,7 +61,7 @@ const SORT_OPTIONS: { value: SortOption; label: string }[] = [
 
 // High-priority categories that need immediate attention (CSAM, illegal content)
 // Includes both NIP-56 standard names and Divine client variations
-const HIGH_PRIORITY_CATEGORIES = ['sexual_minors', 'csam', 'NS-csam', 'nonconsensual_sexual_content', 'terrorism_extremism', 'credible_threats'];
+const HIGH_PRIORITY_CATEGORIES = ['sexual_minors', 'csam', 'NS-csam', 'NS-childSafety', 'NS-child-safety', 'nonconsensual_sexual_content', 'terrorism_extremism', 'credible_threats'];
 const MEDIUM_PRIORITY_CATEGORIES = ['doxxing_pii', 'malware_scam', 'illegal_goods'];
 
 // Category priority for sorting

--- a/src/lib/constants.test.ts
+++ b/src/lib/constants.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import { CATEGORY_LABELS, getReportCategory } from './constants';
+import { CATEGORY_LABELS, HIGH_PRIORITY_CATEGORIES, getReportCategory } from './constants';
 
 describe('CATEGORY_LABELS', () => {
   it('maps the divine-mobile NIP-32 labels to existing display labels', () => {
     expect(CATEGORY_LABELS['NS-spam']).toBe('Spam');
     expect(CATEGORY_LABELS['NS-harassment']).toBe('Harassment');
     expect(CATEGORY_LABELS['NS-violence']).toBe('Violence');
+    expect(CATEGORY_LABELS['NS-childSafety']).toBe('Child Safety');
+    expect(CATEGORY_LABELS['NS-underageUser']).toBe('Under 16');
     expect(CATEGORY_LABELS['NS-sexualContent']).toBe('Sexual Content');
     expect(CATEGORY_LABELS['NS-copyright']).toBe('Copyright');
     expect(CATEGORY_LABELS['NS-falseInformation']).toBe('Misinformation');
@@ -16,9 +18,25 @@ describe('CATEGORY_LABELS', () => {
   });
 
   it('maps kebab-case aliases to the same display labels as camelCase', () => {
+    expect(CATEGORY_LABELS['NS-child-safety']).toBe('Child Safety');
+    expect(CATEGORY_LABELS['NS-underage-user']).toBe('Under 16');
     expect(CATEGORY_LABELS['NS-sexual-content']).toBe('Sexual Content');
     expect(CATEGORY_LABELS['NS-false-information']).toBe('Misinformation');
     expect(CATEGORY_LABELS['NS-ai-generated']).toBe('AI Generated');
+  });
+
+  it('maps non-prefixed child-safety aliases used across clients', () => {
+    expect(CATEGORY_LABELS['childSafety']).toBe('Child Safety');
+    expect(CATEGORY_LABELS['child-safety']).toBe('Child Safety');
+    expect(CATEGORY_LABELS['underageUser']).toBe('Under 16');
+    expect(CATEGORY_LABELS['underage-user']).toBe('Under 16');
+  });
+});
+
+describe('HIGH_PRIORITY_CATEGORIES', () => {
+  it('includes child-safety aliases for moderator-safety treatment', () => {
+    expect(HIGH_PRIORITY_CATEGORIES).toContain('NS-childSafety');
+    expect(HIGH_PRIORITY_CATEGORIES).toContain('NS-child-safety');
   });
 });
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -12,6 +12,10 @@ export const CATEGORY_LABELS: Record<string, string> = {
   'NS-spam': 'Spam',
   'NS-harassment': 'Harassment',
   'NS-violence': 'Violence',
+  'NS-childSafety': 'Child Safety',
+  'NS-child-safety': 'Child Safety',
+  'NS-underageUser': 'Under 16',
+  'NS-underage-user': 'Under 16',
   'NS-sexualContent': 'Sexual Content',
   'NS-sexual-content': 'Sexual Content',
   'NS-copyright': 'Copyright',
@@ -44,6 +48,10 @@ export const CATEGORY_LABELS: Record<string, string> = {
   'ai-generated': 'AI Generated',
   'NS-ai-generated': 'AI Generated',
   'violence': 'Violence',
+  'childSafety': 'Child Safety',
+  'child-safety': 'Child Safety',
+  'underageUser': 'Under 16',
+  'underage-user': 'Under 16',
   'sexual-content': 'Sexual Content',
   'sexualContent': 'Sexual Content',
   'false-info': 'Misinformation',
@@ -57,6 +65,7 @@ export type ResolutionStatus = typeof RESOLUTION_STATUSES[number];
 // Categories where media should be hidden by default for moderator safety
 export const HIGH_PRIORITY_CATEGORIES = [
   'sexual_minors', 'csam', 'NS-csam',
+  'NS-childSafety', 'NS-child-safety',
   'nonconsensual_sexual_content', 'terrorism_extremism', 'credible_threats',
 ];
 


### PR DESCRIPTION
## Summary

- Added `CATEGORY_LABELS` mappings for new child-safety categories and aliases so reports render human-readable labels instead of raw strings.
- Added support for both camelCase and kebab-case variants used by clients:
  - `NS-childSafety`, `childSafety`, `child-safety`, `NS-child-safety` -> `Child Safety`
  - `NS-underageUser`, `underageUser`, `underage-user`, `NS-underage-user` -> `Under 16`
- Updated high-priority category handling to include child-safety aliases for moderator-safety treatment.
- Extended constants tests to cover new aliases and high-priority expectations.

## Motivation

- Mobile and web now emit split child-safety report categories with different wire-format aliases.
- Without these mappings, moderator UI shows raw category strings, which reduces readability and slows triage.
- This keeps relay-manager display behavior aligned with the category split introduced in companion mobile/web work.

## Related Issue

- Closes #61

## Validation

- [x] `npm run test`
- [x] `npx tsc --noEmit`
- [x] `npx vite build`
- [x] `cd worker && npx vitest run` if worker code changed (N/A: worker code was not changed)
- [ ] I could not run some validation locally, and I explained why below

## Manual Test Plan / Notes

- Open the reports list and verify child-safety/underage reports display as `Child Safety` / `Under 16` instead of raw keys.
- Verify both camelCase and kebab-case aliases resolve to the same label in the UI.
- Verify child-safety categories are treated as high-priority in report list/detail highlighting.
- Confirm no worker behavior changes are included in this PR.

## Visuals / API Examples

- [ ] No visual change
- [x] Screenshots, sample payloads, or logs attached if needed

## Public Artifact Review

- [x] Titles, descriptions, branch names, and screenshots avoid partner, customer, brand, campaign, or other sensitive external names unless explicitly approved