### PR TITLE
fix: ignore thumbnail hashes for media moderation

### DIFF
--- a/src/lib/adminApi.test.ts
+++ b/src/lib/adminApi.test.ts
@@ -869,6 +869,27 @@ describe('adminApi', () => {
       expect(hashes).toContain('abc123def4567890abc123def4567890abc123def4567890abc123def4567890');
     });
 
+    it('should ignore imeta image thumbnail hashes for video moderation actions', () => {
+      const videoHash = '81661ca024bec2be842557ff7e07c833660038f134203f10293568f5ea11863f';
+      const thumbnailHash = 'b06e68dbec25463be257e44b06b0bcbb376d3cd1d5fa47e41747ead9e290e068';
+      const tags = [
+        [
+          'imeta',
+          `url https://media.divine.video/${videoHash}`,
+          'm video/mp4',
+          `image https://media.divine.video/${thumbnailHash}`,
+          'dim 608x608',
+          'size 1397120',
+          `x ${videoHash}`,
+          'blurhash UD0WGxgXghf[h2gagff_e6f~feg5g7f9e@e-',
+        ],
+      ];
+
+      const hashes = extractMediaHashes('', tags);
+
+      expect(hashes).toEqual([videoHash]);
+    });
+
     it('should extract hashes from content URLs', () => {
       const content = 'Check out https://blossom.test.com/sha256/fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
 

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -541,21 +541,36 @@ export function extractMediaHashes(content: string, tags: string[][]): string[] 
   // e.g., https://cdn.example.com/abc123def456.mp4
   // e.g., https://blossom.example.com/sha256/abc123def456
   const sha256Pattern = /\b([a-f0-9]{64})\b/gi;
+  const addHashesFromText = (value: string) => {
+    let match;
+    sha256Pattern.lastIndex = 0;
+    while ((match = sha256Pattern.exec(value)) !== null) {
+      hashes.add(match[1].toLowerCase());
+    }
+  };
 
   // Check content for hashes
-  let match;
-  while ((match = sha256Pattern.exec(content)) !== null) {
-    hashes.add(match[1].toLowerCase());
-  }
+  addHashesFromText(content);
 
   // Check imeta tags and url tags
   for (const tag of tags) {
-    if (tag[0] === 'imeta' || tag[0] === 'url' || tag[0] === 'x') {
-      const tagContent = tag.join(' ');
-      sha256Pattern.lastIndex = 0;
-      while ((match = sha256Pattern.exec(tagContent)) !== null) {
-        hashes.add(match[1].toLowerCase());
+    if (tag[0] === 'imeta') {
+      const mime = tag.find((part) => part.toLowerCase().startsWith('m '))?.split(/\s+/)[1];
+      if (mime?.toLowerCase().startsWith('video/')) {
+        for (const part of tag.slice(1)) {
+          const [key, ...values] = part.split(/\s+/);
+          if (key === 'url' || key === 'x') {
+            addHashesFromText(values.join(' '));
+          }
+        }
+      } else {
+        addHashesFromText(tag.join(' '));
       }
+      continue;
+    }
+
+    if (tag[0] === 'url' || tag[0] === 'x') {
+      addHashesFromText(tag.join(' '));
     }
     // Direct x tag with hash
     if (tag[0] === 'x' && tag[1] && /^[a-f0-9]{64}$/i.test(tag[1])) {


### PR DESCRIPTION
## Summary
- Parse video `imeta` tags semantically so media moderation actions use only the video `url`/`x` hash.
- Ignore `image` thumbnail hashes when collecting hashes for block and age-restrict actions.
- Add a regression test covering a relay-style video `imeta` tag with both video and thumbnail hashes.

## Motivation
Relay admin age-restrict actions could fail because the UI attempted to moderate thumbnail hashes alongside the actual video hash.

## Linked Issue
- None. Reported by Aleysha via Slack.

## Manual Validation
- `npx vitest run src/lib/adminApi.test.ts`
- `npx tsc -p tsconfig.app.json --noEmit`
- `npx eslint src/lib/adminApi.ts src/lib/adminApi.test.ts`
- `npx vite build`
- No visual change.