### PR TITLE
feat: age review clock — 15-day under-16 moderation workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,5 +19,11 @@ VITE_LOCAL_RELAY_URL=wss://localhost:4443
 VITE_LOCAL_API_URL=https://localhost:8788
 
 # ============================================================================
+# Local dev admin auth (optional — only needed for ./scripts/dev-local.sh)
+# Must match ADMIN_API_KEY in worker/.dev.vars
+# ============================================================================
+# VITE_ADMIN_API_KEY=osprey-local-dev-key
+
+# ============================================================================
 # Worker variables are configured in worker/wrangler.toml or Cloudflare dashboard
 # ============================================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,46 @@ Schema is created on-demand via `ensureDecisionsTable()` and `ensureZendeskTable
 | `moderation_targets` | Per-target state tracking (`ever_human_reviewed` prevents auto-hide override) |
 | `zendesk_tickets` | Maps Zendesk ticket IDs to Nostr event IDs and pubkeys |
 
+## Local Development
+
+Full local stack: Wrangler worker + Caddy HTTPS proxy + Vite frontend.
+
+### Prerequisites
+
+```bash
+brew install mkcert caddy
+sudo mkcert -install          # one-time: trust the local CA
+```
+
+### One-time setup
+
+1. Copy `.env.example` to `.env.local` and set the CF Access credentials
+2. Add `VITE_ADMIN_API_KEY=osprey-local-dev-key` to `.env.local`
+3. Create `worker/.dev.vars` with:
+   ```
+   NOSTR_NSEC=your-test-nsec
+   ADMIN_API_KEY=osprey-local-dev-key
+   ```
+
+### Running
+
+```bash
+./scripts/dev-local.sh
+```
+
+This starts:
+- **Worker** on `http://localhost:8787` (Wrangler dev with local D1 + Durable Objects)
+- **Caddy HTTPS proxy** on `https://localhost:8788` (terminates TLS, forwards to worker)
+- **Vite frontend** on `https://localhost:5173`
+
+Select "Local" in the environment selector. The frontend sends `X-Admin-Key` header (from `VITE_ADMIN_API_KEY`) for admin auth since CF Access isn't available locally.
+
+### Why HTTPS locally
+
+The frontend runs on HTTPS (Vite's built-in TLS). Browsers block mixed content: an HTTPS page cannot fetch from an HTTP endpoint. Caddy on port 8788 terminates TLS with mkcert certs so `https://localhost:8788` proxies cleanly to the HTTP worker on 8787.
+
+The same applies to the relay WebSocket: `wss://localhost:4443` proxies to `ws://localhost:4444`.
+
 ## Gotchas
 
 ### Funnelcake admin key alignment

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Start the full local dev stack: worker + Caddy HTTPS proxy + Vite frontend.
+# Prerequisites: brew install mkcert caddy && sudo mkcert -install
+#
+# One-time cert setup (if .certs/*.pem don't exist yet):
+#   mkdir -p .certs
+#   mkcert -key-file .certs/localhost+2-key.pem -cert-file .certs/localhost+2.pem localhost 127.0.0.1 ::1
+#
+# Copy .env.example to .env.local and set VITE_ADMIN_API_KEY=osprey-local-dev-key
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+CERT=".certs/localhost+2.pem"
+KEY=".certs/localhost+2-key.pem"
+
+# Preflight checks
+if ! command -v caddy &>/dev/null; then
+  echo "error: caddy not installed. Run: brew install caddy" >&2; exit 1
+fi
+if ! command -v mkcert &>/dev/null; then
+  echo "error: mkcert not installed. Run: brew install mkcert && sudo mkcert -install" >&2; exit 1
+fi
+if [[ ! -f "$CERT" || ! -f "$KEY" ]]; then
+  echo "Generating local TLS certs..."
+  mkdir -p .certs
+  mkcert -key-file "$KEY" -cert-file "$CERT" localhost 127.0.0.1 ::1
+fi
+if [[ ! -f ".env.local" ]]; then
+  echo "error: .env.local not found. Copy .env.example to .env.local and configure it." >&2; exit 1
+fi
+if [[ ! -f "worker/.dev.vars" ]]; then
+  echo "error: worker/.dev.vars not found. Create it with NOSTR_NSEC and ADMIN_API_KEY." >&2; exit 1
+fi
+
+# Generate Caddyfile with absolute paths for this machine
+REPO_ROOT="$(pwd)"
+cat > .certs/Caddyfile <<CADDY
+{
+  auto_https off
+}
+
+:4443 {
+  tls ${REPO_ROOT}/.certs/localhost+2.pem ${REPO_ROOT}/.certs/localhost+2-key.pem
+  reverse_proxy localhost:4444
+}
+
+:8788 {
+  tls ${REPO_ROOT}/.certs/localhost+2.pem ${REPO_ROOT}/.certs/localhost+2-key.pem
+  reverse_proxy localhost:8787
+}
+CADDY
+
+cleanup() {
+  echo ""
+  echo "Shutting down..."
+  caddy stop 2>/dev/null || true
+  [[ -n "${WRANGLER_PID:-}" ]] && kill "$WRANGLER_PID" 2>/dev/null || true
+  [[ -n "${VITE_PID:-}" ]] && kill "$VITE_PID" 2>/dev/null || true
+  wait 2>/dev/null
+  echo "Done."
+}
+trap cleanup EXIT INT TERM
+
+# Kill anything on our ports
+for port in 5173 8787 8788 4443; do
+  lsof -ti:"$port" 2>/dev/null | xargs kill -9 2>/dev/null || true
+done
+sleep 1
+
+# 1. Worker (local D1 + Durable Objects)
+echo "Starting worker on http://localhost:8787..."
+(cd worker && npx wrangler dev --config wrangler.local.toml --local --port 8787 2>&1 | sed 's/^/[worker] /') &
+WRANGLER_PID=$!
+
+# 2. Caddy HTTPS proxy (8788 → 8787, 4443 → 4444)
+echo "Starting Caddy HTTPS proxy..."
+caddy start --config .certs/Caddyfile 2>/dev/null
+
+# 3. Vite frontend
+echo "Starting frontend on https://localhost:5173..."
+npx vite --port 5173 2>&1 | sed 's/^/[vite] /' &
+VITE_PID=$!
+
+echo ""
+echo "Local dev stack ready:"
+echo "  Frontend:  https://localhost:5173"
+echo "  Worker:    http://localhost:8787 (direct)"
+echo "  API proxy: https://localhost:8788 (via Caddy)"
+echo ""
+echo "Select 'Local' in the environment selector."
+echo "Press Ctrl+C to stop all services."
+echo ""
+
+wait

--- a/shared/age-review.ts
+++ b/shared/age-review.ts
@@ -1,0 +1,62 @@
+export const AGE_BANDS = ['under_13', 'age_13_15', 'age_16_plus_claimed'] as const;
+export type AgeBand = typeof AGE_BANDS[number];
+
+// States match MinorReviewCaseState from divine-mobile PR #3531
+export const AGE_REVIEW_STATES = [
+  'open_reported',
+  'under_moderator_review',
+  'restricted_pending_user_response',
+  'restricted_pending_parental_consent',
+  'restricted_pending_support_email',
+  'submitted_for_review',
+  'needs_follow_up',
+  'cleared',
+  'denied_closed',
+] as const;
+export type AgeReviewState = typeof AGE_REVIEW_STATES[number];
+
+export const TERMINAL_STATES: readonly AgeReviewState[] = ['cleared', 'denied_closed'];
+
+export const RESOLUTION_TYPES = [
+  'support_email_only',
+  'parent_video_or_email',
+  'support_review_only',
+] as const;
+export type ResolutionType = typeof RESOLUTION_TYPES[number];
+
+export const AGE_REVIEW_ACTION = {
+  caseCreated: 'age_review_case_created',
+  stateChanged: 'age_review_state_changed',
+  clockPaused: 'age_review_clock_paused',
+  clockResumed: 'age_review_clock_resumed',
+  caseClosed: 'age_review_case_closed',
+} as const;
+
+export const DEADLINE_DAYS = 15;
+
+export function defaultResolutionForBand(band: AgeBand): ResolutionType {
+  switch (band) {
+    case 'under_13': return 'support_email_only';
+    case 'age_13_15': return 'parent_video_or_email';
+    case 'age_16_plus_claimed': return 'support_review_only';
+  }
+}
+
+export interface AgeReviewCase {
+  id: string;
+  pubkey: string;
+  reporter_pubkey: string | null;
+  report_id: string | null;
+  suspected_age_band: AgeBand;
+  state: AgeReviewState;
+  allowed_resolution: ResolutionType;
+  parent_contact_email: string | null;
+  deadline_at: string | null;
+  clock_paused: number;
+  clock_paused_at: string | null;
+  remaining_days_when_paused: number | null;
+  moderator_pubkey: string | null;
+  resolution_note: string | null;
+  created_at: string;
+  updated_at: string;
+}

--- a/shared/age-review.ts
+++ b/shared/age-review.ts
@@ -17,6 +17,18 @@ export type AgeReviewState = typeof AGE_REVIEW_STATES[number];
 
 export const TERMINAL_STATES: readonly AgeReviewState[] = ['cleared', 'denied_closed'];
 
+export const VALID_TRANSITIONS: Record<AgeReviewState, readonly AgeReviewState[]> = {
+  open_reported: ['under_moderator_review', 'cleared', 'denied_closed'],
+  under_moderator_review: ['restricted_pending_user_response', 'restricted_pending_support_email', 'needs_follow_up', 'cleared', 'denied_closed'],
+  restricted_pending_user_response: ['restricted_pending_parental_consent', 'restricted_pending_support_email', 'submitted_for_review', 'needs_follow_up', 'cleared', 'denied_closed'],
+  restricted_pending_parental_consent: ['submitted_for_review', 'needs_follow_up', 'cleared', 'denied_closed'],
+  restricted_pending_support_email: ['submitted_for_review', 'needs_follow_up', 'cleared', 'denied_closed'],
+  submitted_for_review: ['under_moderator_review', 'needs_follow_up', 'cleared', 'denied_closed'],
+  needs_follow_up: ['under_moderator_review', 'cleared', 'denied_closed'],
+  cleared: [],
+  denied_closed: [],
+};
+
 export const RESOLUTION_TYPES = [
   'support_email_only',
   'parent_video_or_email',
@@ -57,6 +69,7 @@ export interface AgeReviewCase {
   remaining_days_when_paused: number | null;
   moderator_pubkey: string | null;
   resolution_note: string | null;
+  last_alerted_at: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -16,6 +16,7 @@ export function AppRouter() {
         <Route path="/users/:pubkey" element={<Index />} />
         <Route path="/reports" element={<Index />} />
         <Route path="/reports/:reportId" element={<Index />} />
+        <Route path="/age-review" element={<Index />} />
         <Route path="/labels" element={<Index />} />
         <Route path="/settings" element={<Index />} />
         <Route path="/debug" element={<Index />} />

--- a/src/components/AgeReview.tsx
+++ b/src/components/AgeReview.tsx
@@ -1,0 +1,253 @@
+import { useState, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useAdminApi } from "@/hooks/useAdminApi";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Clock, RefreshCw, Filter, AlertTriangle } from "lucide-react";
+import { AgeReviewDetail } from "@/components/AgeReviewDetail";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
+import {
+  AGE_BANDS,
+  TERMINAL_STATES,
+  type AgeReviewCase,
+  type AgeReviewState,
+  type AgeBand,
+} from "../../shared/age-review";
+
+const BAND_LABELS: Record<AgeBand, string> = {
+  under_13: "Under 13",
+  age_13_15: "13–15",
+  age_16_plus_claimed: "16+",
+};
+
+const STATE_SHORT: Record<AgeReviewState, string> = {
+  open_reported: "Open",
+  under_moderator_review: "In Review",
+  restricted_pending_user_response: "Pending User",
+  restricted_pending_parental_consent: "Pending Parent",
+  restricted_pending_support_email: "Pending Email",
+  submitted_for_review: "Submitted",
+  needs_follow_up: "Follow-up",
+  cleared: "Cleared",
+  denied_closed: "Denied",
+};
+
+type FilterMode = 'active' | 'closed' | 'all';
+
+function getDaysRemaining(c: AgeReviewCase): number | null {
+  if (c.clock_paused && c.remaining_days_when_paused != null) {
+    return c.remaining_days_when_paused;
+  }
+  if (!c.deadline_at) return null;
+  return (new Date(c.deadline_at).getTime() - Date.now()) / (24 * 60 * 60 * 1000);
+}
+
+export function AgeReview() {
+  const api = useAdminApi();
+  const isMobile = useIsMobile();
+  const [selectedCaseId, setSelectedCaseId] = useState<string | null>(null);
+  const [filterMode, setFilterMode] = useState<FilterMode>('active');
+  const [bandFilter, setBandFilter] = useState<string>('all');
+
+  const serverParams = useMemo(() => {
+    const params: { state?: string; age_band?: string } = {};
+    if (filterMode !== 'all') params.state = filterMode;
+    if (bandFilter !== 'all') params.age_band = bandFilter;
+    return params;
+  }, [filterMode, bandFilter]);
+
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ['age-review-cases', serverParams],
+    queryFn: () => api.getAgeReviewCases(serverParams),
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+  });
+
+  const filteredCases = data?.cases ?? [];
+
+  const selectedCase = filteredCases.find(c => c.id === selectedCaseId) ?? null;
+
+  const { data: activeData } = useQuery({
+    queryKey: ['age-review-cases', { state: 'active' }],
+    queryFn: () => api.getAgeReviewCases({ state: 'active' }),
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+  });
+
+  const activeCounts = useMemo(() => {
+    if (!activeData?.cases) return { total: 0, urgent: 0 };
+    const urgent = activeData.cases.filter(c => {
+      const days = getDaysRemaining(c);
+      return days != null && days <= 2 && !c.clock_paused;
+    });
+    return { total: activeData.cases.length, urgent: urgent.length };
+  }, [activeData?.cases]);
+
+  const listContent = (
+    <div className="flex flex-col h-full">
+      {/* Filter bar */}
+      <div className="shrink-0 p-3 space-y-2 border-b">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Clock className="h-4 w-4" />
+            <span className="font-medium text-sm">
+              Age Review
+              {activeCounts.total > 0 && (
+                <Badge variant="secondary" className="ml-1.5 text-xs">{activeCounts.total}</Badge>
+              )}
+              {activeCounts.urgent > 0 && (
+                <Badge variant="destructive" className="ml-1 text-xs gap-0.5">
+                  <AlertTriangle className="h-2.5 w-2.5" />
+                  {activeCounts.urgent}
+                </Badge>
+              )}
+            </span>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => refetch()}
+            className="h-7"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+
+        <div className="flex gap-2">
+          <Tabs value={filterMode} onValueChange={(v) => setFilterMode(v as FilterMode)} className="flex-1">
+            <TabsList className="h-7 w-full">
+              <TabsTrigger value="active" className="text-xs h-6 flex-1">Active</TabsTrigger>
+              <TabsTrigger value="closed" className="text-xs h-6 flex-1">Closed</TabsTrigger>
+              <TabsTrigger value="all" className="text-xs h-6 flex-1">All</TabsTrigger>
+            </TabsList>
+          </Tabs>
+
+          <Select value={bandFilter} onValueChange={setBandFilter}>
+            <SelectTrigger className="h-7 w-24 text-xs">
+              <Filter className="h-3 w-3 mr-1" />
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all" className="text-xs">All ages</SelectItem>
+              {AGE_BANDS.map((band) => (
+                <SelectItem key={band} value={band} className="text-xs">
+                  {BAND_LABELS[band]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Case list */}
+      <ScrollArea className="flex-1">
+        {isLoading ? (
+          <div className="p-3 space-y-2">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full" />
+            ))}
+          </div>
+        ) : isError ? (
+          <div className="p-3 text-sm text-red-600">Failed to load cases</div>
+        ) : filteredCases.length === 0 ? (
+          <div className="p-6 text-center text-sm text-muted-foreground">
+            No {filterMode === 'all' ? '' : filterMode} cases
+          </div>
+        ) : (
+          <div className="divide-y">
+            {filteredCases.map((c) => {
+              const days = getDaysRemaining(c);
+              const isUrgent = days != null && days <= 2 && !c.clock_paused && !TERMINAL_STATES.includes(c.state);
+              const isSelected = selectedCaseId === c.id;
+
+              return (
+                <button
+                  key={c.id}
+                  className={`w-full text-left px-3 py-2.5 hover:bg-muted/50 transition-colors ${
+                    isSelected ? 'bg-muted' : ''
+                  } ${isUrgent ? 'border-l-2 border-l-red-500' : ''}`}
+                  onClick={() => setSelectedCaseId(c.id)}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-1.5 mb-0.5">
+                        <code className="text-xs font-mono truncate" title={c.pubkey}>{c.pubkey}</code>
+                      </div>
+                      <div className="flex items-center gap-1.5 flex-wrap">
+                        <Badge variant="outline" className="text-[10px] h-4 px-1">
+                          {STATE_SHORT[c.state]}
+                        </Badge>
+                        <Badge variant="outline" className="text-[10px] h-4 px-1">
+                          {BAND_LABELS[c.suspected_age_band]}
+                        </Badge>
+                        {c.clock_paused ? (
+                          <Badge variant="outline" className="text-[10px] h-4 px-1 gap-0.5">
+                            ⏸ Paused
+                          </Badge>
+                        ) : null}
+                      </div>
+                    </div>
+                    <div className="text-right shrink-0">
+                      {days != null && !TERMINAL_STATES.includes(c.state) && (
+                        <div className={`text-[10px] ${isUrgent ? 'text-red-600 font-medium' : 'text-muted-foreground'}`}>
+                          {days <= 0 ? 'Expired' : `${Math.ceil(days)}d`}
+                        </div>
+                      )}
+                      <div className="text-[10px] text-muted-foreground">
+                        {new Date(c.created_at).toLocaleDateString()}
+                      </div>
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </ScrollArea>
+    </div>
+  );
+
+  const detailContent = selectedCase ? (
+    <AgeReviewDetail caseData={selectedCase} />
+  ) : (
+    <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+      Select a case to view details
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <Card className="h-full flex flex-col overflow-hidden">
+        {listContent}
+        <Sheet open={!!selectedCase} onOpenChange={() => setSelectedCaseId(null)}>
+          <SheetContent side="bottom" className="h-[80vh] p-0">
+            {detailContent}
+          </SheetContent>
+        </Sheet>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="h-full flex gap-4">
+      <Card className="w-[360px] shrink-0 flex flex-col overflow-hidden">
+        {listContent}
+      </Card>
+      <Card className="flex-1 overflow-hidden">
+        {detailContent}
+      </Card>
+    </div>
+  );
+}

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { AgeReviewDetail } from './AgeReviewDetail';
+import type { AgeReviewCase, AgeBand, AgeReviewState } from '../../shared/age-review';
+
+const updateAgeReviewCase = vi.fn().mockResolvedValue({ success: true });
+
+vi.mock('@/hooks/useAdminApi', () => ({
+  useAdminApi: () => ({
+    updateAgeReviewCase,
+  }),
+}));
+
+function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
+  return {
+    id: 'case-1',
+    pubkey: 'a'.repeat(64),
+    reporter_pubkey: 'b'.repeat(64),
+    report_id: 'report-1',
+    suspected_age_band: 'age_13_15',
+    state: 'under_moderator_review',
+    allowed_resolution: 'parent_video_or_email',
+    parent_contact_email: null,
+    deadline_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    clock_paused: 0,
+    clock_paused_at: null,
+    remaining_days_when_paused: null,
+    moderator_pubkey: null,
+    resolution_note: null,
+    last_alerted_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function renderDetail(caseData: AgeReviewCase) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AgeReviewDetail caseData={caseData} />
+    </QueryClientProvider>
+  );
+}
+
+describe('AgeReviewDetail', () => {
+  beforeEach(() => {
+    updateAgeReviewCase.mockClear();
+  });
+
+  it.each<[AgeBand, AgeReviewState]>([
+    ['under_13', 'restricted_pending_support_email'],
+    ['age_13_15', 'restricted_pending_user_response'],
+    ['age_16_plus_claimed', 'restricted_pending_support_email'],
+  ])('maps %s to %s when restricting an account', async (suspectedAgeBand, expectedState) => {
+    renderDetail(makeCase({ suspected_age_band: suspectedAgeBand }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restrict Account' }));
+
+    await waitFor(() => {
+      expect(updateAgeReviewCase).toHaveBeenCalledWith('case-1', { state: expectedState });
+    });
+  });
+});

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAdminApi } from "@/hooks/useAdminApi";
 import { Badge } from "@/components/ui/badge";
@@ -85,6 +85,10 @@ export function AgeReviewDetail({ caseData: c }: Props) {
   const [resolutionNote, setResolutionNote] = useState(c.resolution_note ?? "");
   const [copiedField, setCopiedField] = useState<string | null>(null);
 
+  useEffect(() => {
+    setResolutionNote(c.resolution_note ?? "");
+  }, [c.id, c.resolution_note]);
+
   const isTerminal = TERMINAL_STATES.includes(c.state);
   const daysRemaining = getDaysRemaining(c);
 
@@ -147,7 +151,7 @@ export function AgeReviewDetail({ caseData: c }: Props) {
               {copiedField === 'pubkey' ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
             </button>
             <a
-              href={`/users/${npub}`}
+              href={`/users/${c.pubkey}`}
               className="text-muted-foreground hover:text-foreground"
               title="View in Users tab"
             >

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -1,0 +1,360 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAdminApi } from "@/hooks/useAdminApi";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Separator } from "@/components/ui/separator";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Clock,
+  Play,
+  Pause,
+  CheckCircle,
+  XCircle,
+  AlertTriangle,
+  Loader2,
+  Copy,
+  Check,
+  ExternalLink,
+} from "lucide-react";
+import { nip19 } from "nostr-tools";
+import {
+  AGE_BANDS,
+  TERMINAL_STATES,
+  type AgeReviewCase,
+  type AgeReviewState,
+  type AgeBand,
+} from "../../shared/age-review";
+
+const STATE_LABELS: Record<AgeReviewState, string> = {
+  open_reported: "Open — Reported",
+  under_moderator_review: "Under Moderator Review",
+  restricted_pending_user_response: "Restricted — Pending User Response",
+  restricted_pending_parental_consent: "Restricted — Pending Parental Consent",
+  restricted_pending_support_email: "Restricted — Pending Support Email",
+  submitted_for_review: "Submitted for Review",
+  needs_follow_up: "Needs Follow-up",
+  cleared: "Cleared",
+  denied_closed: "Denied — Closed",
+};
+
+const BAND_LABELS: Record<AgeBand, string> = {
+  under_13: "Under 13",
+  age_13_15: "Age 13–15",
+  age_16_plus_claimed: "16+ (Claimed)",
+};
+
+function stateColor(state: AgeReviewState): string {
+  if (state === 'cleared') return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400';
+  if (state === 'denied_closed') return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400';
+  if (state.startsWith('restricted_')) return 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400';
+  if (state === 'needs_follow_up') return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400';
+  return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400';
+}
+
+function bandColor(band: AgeBand): string {
+  if (band === 'under_13') return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400';
+  if (band === 'age_13_15') return 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400';
+  return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400';
+}
+
+function getDaysRemaining(c: AgeReviewCase): number | null {
+  if (c.clock_paused && c.remaining_days_when_paused != null) {
+    return c.remaining_days_when_paused;
+  }
+  if (!c.deadline_at) return null;
+  const ms = new Date(c.deadline_at).getTime() - Date.now();
+  return ms / (24 * 60 * 60 * 1000);
+}
+
+interface Props {
+  caseData: AgeReviewCase;
+}
+
+export function AgeReviewDetail({ caseData: c }: Props) {
+  const api = useAdminApi();
+  const queryClient = useQueryClient();
+  const [resolutionNote, setResolutionNote] = useState(c.resolution_note ?? "");
+  const [copiedField, setCopiedField] = useState<string | null>(null);
+
+  const isTerminal = TERMINAL_STATES.includes(c.state);
+  const daysRemaining = getDaysRemaining(c);
+
+  const updateCase = useMutation({
+    mutationFn: (updates: Record<string, unknown>) =>
+      api.updateAgeReviewCase(c.id, updates),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['age-review-cases'] });
+    },
+  });
+
+  const copyToClipboard = (text: string, field: string) => {
+    navigator.clipboard.writeText(text);
+    setCopiedField(field);
+    setTimeout(() => setCopiedField(null), 2000);
+  };
+
+  const npub = nip19.npubEncode(c.pubkey);
+
+  return (
+    <ScrollArea className="h-full">
+      <div className="space-y-4 p-4">
+        {/* Header */}
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 flex-wrap">
+            <Badge className={stateColor(c.state)}>{STATE_LABELS[c.state]}</Badge>
+            <Badge className={bandColor(c.suspected_age_band)}>{BAND_LABELS[c.suspected_age_band]}</Badge>
+            {c.clock_paused ? (
+              <Badge variant="outline" className="gap-1">
+                <Pause className="h-3 w-3" /> Clock Paused
+              </Badge>
+            ) : null}
+          </div>
+
+          {/* Deadline */}
+          {!isTerminal && daysRemaining != null && (
+            <div className={`flex items-center gap-1.5 text-sm ${
+              daysRemaining <= 2 ? 'text-red-600 font-medium' : 'text-muted-foreground'
+            }`}>
+              <Clock className="h-3.5 w-3.5" />
+              {daysRemaining <= 0
+                ? "Deadline expired"
+                : `${Math.ceil(daysRemaining)} day${Math.ceil(daysRemaining) !== 1 ? 's' : ''} remaining`}
+            </div>
+          )}
+        </div>
+
+        <Separator />
+
+        {/* Identity */}
+        <div className="space-y-1.5">
+          <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Flagged User</h4>
+          <div className="flex items-center gap-1.5">
+            <code className="text-xs bg-muted px-1.5 py-0.5 rounded font-mono break-all">{npub}</code>
+            <button
+              onClick={() => copyToClipboard(c.pubkey, 'pubkey')}
+              className="text-muted-foreground hover:text-foreground"
+              title="Copy hex pubkey"
+            >
+              {copiedField === 'pubkey' ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+            </button>
+            <a
+              href={`/users/${npub}`}
+              className="text-muted-foreground hover:text-foreground"
+              title="View in Users tab"
+            >
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          </div>
+          {c.reporter_pubkey && (
+            <div className="text-xs text-muted-foreground">
+              Reported by: <code className="bg-muted px-1 py-0.5 rounded font-mono break-all">{c.reporter_pubkey}</code>
+            </div>
+          )}
+          {c.parent_contact_email && (
+            <div className="text-xs text-muted-foreground">
+              Parent email: <span className="font-medium">{c.parent_contact_email}</span>
+            </div>
+          )}
+        </div>
+
+        <Separator />
+
+        {/* Timestamps */}
+        <div className="grid grid-cols-2 gap-2 text-xs">
+          <div>
+            <span className="text-muted-foreground">Created:</span>{" "}
+            {new Date(c.created_at).toLocaleDateString()}
+          </div>
+          <div>
+            <span className="text-muted-foreground">Updated:</span>{" "}
+            {new Date(c.updated_at).toLocaleDateString()}
+          </div>
+          {c.deadline_at && (
+            <div>
+              <span className="text-muted-foreground">Deadline:</span>{" "}
+              {new Date(c.deadline_at).toLocaleDateString()}
+            </div>
+          )}
+          {c.report_id && (
+            <div>
+              <span className="text-muted-foreground">Report:</span>{" "}
+              <code className="bg-muted px-1 rounded font-mono break-all">{c.report_id}</code>
+            </div>
+          )}
+        </div>
+
+        {!isTerminal && (
+          <>
+            <Separator />
+
+            {/* Moderator Actions */}
+            <div className="space-y-3">
+              <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Actions</h4>
+
+              {/* State transitions */}
+              <div className="flex flex-wrap gap-2">
+                {c.state === 'open_reported' && (
+                  <Button
+                    size="sm"
+                    className="h-7 text-xs"
+                    disabled={updateCase.isPending}
+                    onClick={() => updateCase.mutate({ state: 'under_moderator_review' })}
+                  >
+                    <Play className="h-3 w-3 mr-1" />
+                    Begin Review
+                  </Button>
+                )}
+                {c.state === 'under_moderator_review' && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 text-xs"
+                    disabled={updateCase.isPending}
+                    onClick={() => updateCase.mutate({
+                      state: c.suspected_age_band === 'age_16_plus_claimed'
+                        ? 'restricted_pending_support_email'
+                        : 'restricted_pending_user_response',
+                    })}
+                  >
+                    <AlertTriangle className="h-3 w-3 mr-1" />
+                    Restrict Account
+                  </Button>
+                )}
+                {c.state === 'submitted_for_review' && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 text-xs"
+                    disabled={updateCase.isPending}
+                    onClick={() => updateCase.mutate({ state: 'under_moderator_review' })}
+                  >
+                    Re-review
+                  </Button>
+                )}
+
+                {/* Clock controls */}
+                {!c.clock_paused ? (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 text-xs"
+                    disabled={updateCase.isPending}
+                    onClick={() => updateCase.mutate({ clock_paused: true })}
+                  >
+                    <Pause className="h-3 w-3 mr-1" />
+                    Pause Clock
+                  </Button>
+                ) : (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 text-xs"
+                    disabled={updateCase.isPending}
+                    onClick={() => updateCase.mutate({ clock_paused: false })}
+                  >
+                    <Play className="h-3 w-3 mr-1" />
+                    Resume Clock
+                  </Button>
+                )}
+              </div>
+
+              {/* Age band change */}
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-muted-foreground">Age band:</span>
+                <Select
+                  value={c.suspected_age_band}
+                  onValueChange={(val) => updateCase.mutate({ suspected_age_band: val })}
+                  disabled={updateCase.isPending}
+                >
+                  <SelectTrigger className="h-7 w-40 text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {AGE_BANDS.map((band) => (
+                      <SelectItem key={band} value={band} className="text-xs">
+                        {BAND_LABELS[band]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Resolution note */}
+              <div className="space-y-1.5">
+                <Textarea
+                  placeholder="Resolution note..."
+                  value={resolutionNote}
+                  onChange={(e) => setResolutionNote(e.target.value)}
+                  rows={2}
+                  className="text-xs"
+                />
+              </div>
+
+              {/* Terminal actions */}
+              <div className="flex gap-2 pt-1">
+                <Button
+                  size="sm"
+                  variant="default"
+                  className="h-7 text-xs bg-green-600 hover:bg-green-700"
+                  disabled={updateCase.isPending}
+                  onClick={() => updateCase.mutate({
+                    state: 'cleared',
+                    resolution_note: resolutionNote || undefined,
+                  })}
+                >
+                  <CheckCircle className="h-3 w-3 mr-1" />
+                  Clear
+                </Button>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  className="h-7 text-xs"
+                  disabled={updateCase.isPending}
+                  onClick={() => updateCase.mutate({
+                    state: 'denied_closed',
+                    resolution_note: resolutionNote || undefined,
+                  })}
+                >
+                  <XCircle className="h-3 w-3 mr-1" />
+                  Deny &amp; Close
+                </Button>
+              </div>
+
+              {updateCase.isPending && (
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  Updating...
+                </div>
+              )}
+              {updateCase.isError && (
+                <div className="text-xs text-red-600">
+                  Failed to update: {(updateCase.error as Error).message}
+                </div>
+              )}
+            </div>
+          </>
+        )}
+
+        {isTerminal && c.resolution_note && (
+          <>
+            <Separator />
+            <div className="space-y-1">
+              <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Resolution</h4>
+              <p className="text-sm">{c.resolution_note}</p>
+            </div>
+          </>
+        )}
+
+      </div>
+    </ScrollArea>
+  );
+}

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -52,6 +52,16 @@ const BAND_LABELS: Record<AgeBand, string> = {
   age_16_plus_claimed: "16+ (Claimed)",
 };
 
+function getRestrictionStateForBand(band: AgeBand): AgeReviewState {
+  switch (band) {
+    case 'under_13':
+    case 'age_16_plus_claimed':
+      return 'restricted_pending_support_email';
+    case 'age_13_15':
+      return 'restricted_pending_user_response';
+  }
+}
+
 function stateColor(state: AgeReviewState): string {
   if (state === 'cleared') return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400';
   if (state === 'denied_closed') return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400';
@@ -224,9 +234,7 @@ export function AgeReviewDetail({ caseData: c }: Props) {
                     className="h-7 text-xs"
                     disabled={updateCase.isPending}
                     onClick={() => updateCase.mutate({
-                      state: c.suspected_age_band === 'age_16_plus_claimed'
-                        ? 'restricted_pending_support_email'
-                        : 'restricted_pending_user_response',
+                      state: getRestrictionStateForBand(c.suspected_age_band),
                     })}
                   >
                     <AlertTriangle className="h-3 w-3 mr-1" />

--- a/src/components/RelayManager.tsx
+++ b/src/components/RelayManager.tsx
@@ -9,16 +9,18 @@ import { Reports } from "@/components/Reports";
 import { Labels } from "@/components/Labels";
 import { DebugPanel } from "@/components/DebugPanel";
 import { SettingsDashboard } from "@/components/SettingsDashboard";
+import { AgeReview } from "@/components/AgeReview";
 import { EnvironmentSelector } from "@/components/EnvironmentSelector";
 import { Card } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Server, FileText, Users, Settings, Flag, Tag, Bug, GripVertical } from "lucide-react";
+import { Server, FileText, Users, Settings, Flag, Tag, Bug, GripVertical, Clock } from "lucide-react";
 import { useAppContext } from "@/hooks/useAppContext";
 import AdminBar from "@/components/AdminBar";
 
 // Tab definitions in default order (Reports first for moderation workflow)
 const TAB_DEFINITIONS = [
   { id: 'reports', label: 'Reports', icon: Flag },
+  { id: 'age-review', label: 'Age Review', icon: Clock },
   { id: 'events', label: 'Events', icon: FileText },
   { id: 'users', label: 'Users', icon: Users },
   { id: 'labels', label: 'Labels', icon: Tag },
@@ -63,6 +65,7 @@ function getTabFromPath(pathname: string): string {
   if (pathname.startsWith('/events')) return 'events';
   if (pathname.startsWith('/users')) return 'users';
   if (pathname.startsWith('/reports')) return 'reports';
+  if (pathname.startsWith('/age-review')) return 'age-review';
   if (pathname.startsWith('/labels')) return 'labels';
   if (pathname.startsWith('/settings')) return 'settings';
   if (pathname.startsWith('/debug')) return 'debug';
@@ -167,7 +170,7 @@ export function RelayManager() {
 
       <div className="flex-1 min-h-0 overflow-hidden container mx-auto px-4 py-4">
         <Tabs value={currentTab} onValueChange={handleTabChange} className="h-full flex flex-col">
-          <TabsList className="shrink-0 grid w-full grid-cols-6">
+          <TabsList className="shrink-0 grid w-full grid-cols-7">
             {orderedTabs.map((tab) => {
               const Icon = tab.icon;
               const isDragOver = dragOverTab === tab.id;
@@ -203,6 +206,10 @@ export function RelayManager() {
 
           <TabsContent value="reports" className="flex-1 min-h-0 mt-4">
             <Reports relayUrl={config.relayUrl} selectedReportId={params.reportId} />
+          </TabsContent>
+
+          <TabsContent value="age-review" className="flex-1 min-h-0 mt-4">
+            <AgeReview />
           </TabsContent>
 
           <TabsContent value="labels" className="flex-1 min-h-0 mt-4">

--- a/src/hooks/useAdminApi.ts
+++ b/src/hooks/useAdminApi.ts
@@ -111,6 +111,15 @@ export function useAdminApi() {
       adminApi.verifyAgeRestricted(apiUrl, sha256),
     verifyModerationAction: (eventId: string, mediaHashes: string[]) =>
       adminApi.verifyModerationAction(apiUrl, eventId, mediaHashes, relayUrl),
+
+    // Age review
+    getAgeReviewCases: (params?: { state?: string; age_band?: string }) =>
+      adminApi.getAgeReviewCases(apiUrl, params),
+    getAgeReviewCase: (caseId: string) =>
+      adminApi.getAgeReviewCase(apiUrl, caseId),
+    updateAgeReviewCase: (caseId: string, updates: Record<string, unknown>) =>
+      adminApi.updateAgeReviewCase(apiUrl, caseId, updates),
+
   }), [apiUrl, relayUrl]);
 
   return boundApi;

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -17,6 +17,9 @@ export function getApiHeaders(contentType = 'application/json'): Record<string, 
   if (import.meta.env.VITE_CF_ACCESS_CLIENT_SECRET) {
     headers['CF-Access-Client-Secret'] = import.meta.env.VITE_CF_ACCESS_CLIENT_SECRET;
   }
+  if (import.meta.env.VITE_ADMIN_API_KEY) {
+    headers['X-Admin-Key'] = import.meta.env.VITE_ADMIN_API_KEY;
+  }
   return headers;
 }
 
@@ -907,3 +910,4 @@ function extractBreakdown(
 
   return null;
 }
+

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -74,7 +74,7 @@ class ApiError extends Error {
 async function apiRequest<T>(
   apiUrl: string,
   endpoint: string,
-  method: 'GET' | 'POST' | 'DELETE',
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
   body?: object
 ): Promise<T> {
   if (!apiUrl) {
@@ -909,5 +909,47 @@ function extractBreakdown(
   }
 
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// Age Review
+// ---------------------------------------------------------------------------
+
+export type { AgeReviewCase, AgeReviewState, AgeBand } from '../../shared/age-review';
+
+interface AgeReviewCasesResponse {
+  success: boolean;
+  cases: import('../../shared/age-review').AgeReviewCase[];
+}
+
+interface AgeReviewCaseResponse {
+  success: boolean;
+  case: import('../../shared/age-review').AgeReviewCase;
+}
+
+export async function getAgeReviewCases(
+  apiUrl: string,
+  params?: { state?: string; age_band?: string },
+): Promise<AgeReviewCasesResponse> {
+  const query = new URLSearchParams();
+  if (params?.state) query.set('state', params.state);
+  if (params?.age_band) query.set('age_band', params.age_band);
+  const qs = query.toString();
+  return apiRequest<AgeReviewCasesResponse>(apiUrl, `/api/age-review/cases${qs ? `?${qs}` : ''}`, 'GET');
+}
+
+export async function getAgeReviewCase(
+  apiUrl: string,
+  caseId: string,
+): Promise<AgeReviewCaseResponse> {
+  return apiRequest<AgeReviewCaseResponse>(apiUrl, `/api/age-review/cases/${caseId}`, 'GET');
+}
+
+export async function updateAgeReviewCase(
+  apiUrl: string,
+  caseId: string,
+  updates: Record<string, unknown>,
+): Promise<AgeReviewCaseResponse> {
+  return apiRequest<AgeReviewCaseResponse>(apiUrl, `/api/age-review/cases/${caseId}`, 'PATCH', updates);
 }
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -50,6 +50,8 @@ export const CATEGORY_LABELS: Record<string, string> = {
   'false-info': 'Misinformation',
   'falseInformation': 'Misinformation',
   'other': 'Other',
+  'NS-underageUser': 'Under 16',
+  'NS-childSafety': 'Child Safety',
 };
 
 export const RESOLUTION_STATUSES = ['reviewed', 'dismissed', 'no-action', 'false-positive'] as const;
@@ -59,6 +61,7 @@ export type ResolutionStatus = typeof RESOLUTION_STATUSES[number];
 export const HIGH_PRIORITY_CATEGORIES = [
   'sexual_minors', 'csam', 'NS-csam',
   'nonconsensual_sexual_content', 'terrorism_extremism', 'credible_threats',
+  'NS-underageUser', 'NS-childSafety',
 ];
 
 // Helper to get label with fallback

--- a/worker/migrations/0006_age_review.sql
+++ b/worker/migrations/0006_age_review.sql
@@ -1,0 +1,23 @@
+-- Age review cases: 15-day clock for under-16 account moderation
+CREATE TABLE age_review_cases (
+  id TEXT PRIMARY KEY,
+  pubkey TEXT NOT NULL,
+  reporter_pubkey TEXT,
+  report_id TEXT,
+  suspected_age_band TEXT NOT NULL DEFAULT 'age_13_15',
+  state TEXT NOT NULL DEFAULT 'open_reported',
+  allowed_resolution TEXT NOT NULL DEFAULT 'parent_video_or_email',
+  parent_contact_email TEXT,
+  deadline_at TEXT,
+  clock_paused INTEGER DEFAULT 0,
+  clock_paused_at TEXT,
+  remaining_days_when_paused REAL,
+  moderator_pubkey TEXT,
+  resolution_note TEXT,
+  created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_age_review_pubkey ON age_review_cases(pubkey);
+CREATE INDEX idx_age_review_state ON age_review_cases(state);
+CREATE INDEX idx_age_review_deadline ON age_review_cases(deadline_at);

--- a/worker/migrations/0007_age_review_alert_dedupe.sql
+++ b/worker/migrations/0007_age_review_alert_dedupe.sql
@@ -1,0 +1,2 @@
+-- Track when Slack alerts were last sent per case to prevent duplicate notifications
+ALTER TABLE age_review_cases ADD COLUMN last_alerted_at TEXT;

--- a/worker/src/ReportWatcher.ts
+++ b/worker/src/ReportWatcher.ts
@@ -11,6 +11,12 @@ import {
   type AutoHideConfig,
   type AutoHideTier,
 } from '../../shared/autohide';
+import {
+  AGE_REVIEW_ACTION,
+  DEADLINE_DAYS,
+  TERMINAL_STATES,
+  defaultResolutionForBand,
+} from '../../shared/age-review';
 
 /**
  * Extended environment for ReportWatcher DO
@@ -86,6 +92,7 @@ export class ReportWatcher implements DurableObject {
   private reconnectDelay: number = INITIAL_RECONNECT_DELAY_MS;
   private subscriptionId: string = 'auto-hide-reports';
   private autoHideConfig: AutoHideConfig | null = null;
+  private pendingAgeReviewPubkeys = new Set<string>();
 
   constructor(state: DurableObjectState, env: ReportWatcherEnv) {
     this.state = state;
@@ -615,6 +622,17 @@ export class ReportWatcher implements DurableObject {
         console.error('[ReportWatcher] Auto-hide processing failed:', error);
       });
     }
+
+    // Create age review case for under-16 reports (pubkey-level, independent of auto-hide).
+    // In-memory Set guards against the SELECT-then-INSERT race: the Set check+add is
+    // synchronous, so concurrent WebSocket messages can't interleave between them.
+    const reportedPubkey = targetPubkeyTag?.[1];
+    if (category === 'NS-underageUser' && reportedPubkey && !this.pendingAgeReviewPubkeys.has(reportedPubkey)) {
+      this.pendingAgeReviewPubkeys.add(reportedPubkey);
+      this.createAgeReviewCase(event, reportedPubkey)
+        .catch(error => console.error('[ReportWatcher] Age review case creation failed:', error))
+        .finally(() => this.pendingAgeReviewPubkeys.delete(reportedPubkey));
+    }
   }
 
   private async processAutoHide(
@@ -863,6 +881,64 @@ export class ReportWatcher implements DurableObject {
     } catch (error) {
       console.error('[ReportWatcher] Failed to log decision:', error);
     }
+  }
+
+  private async createAgeReviewCase(event: ReportEvent, reportedPubkey: string): Promise<void> {
+    if (!this.env.DB) {
+      console.warn('[ReportWatcher] D1 database not available, cannot create age review case');
+      return;
+    }
+
+    if (!this.schemaReady) {
+      try {
+        await ensureSchema(this.env.DB);
+        this.schemaReady = true;
+      } catch (error) {
+        console.error('[ReportWatcher] Failed to ensure schema:', error);
+        return;
+      }
+    }
+
+    // Skip if an active case already exists for this pubkey
+    const existing = await this.env.DB.prepare(`
+      SELECT id, state FROM age_review_cases
+      WHERE pubkey = ? AND state NOT IN (${TERMINAL_STATES.map(() => '?').join(',')})
+      LIMIT 1
+    `).bind(reportedPubkey, ...TERMINAL_STATES).first<{ id: string; state: string }>();
+
+    if (existing) {
+      console.log(`[ReportWatcher] Active age review case ${existing.id} already exists for ${reportedPubkey.slice(0, 8)}..., skipping`);
+      return;
+    }
+
+    const caseId = crypto.randomUUID();
+    const band = 'age_13_15' as const;
+    const deadline = new Date(Date.now() + DEADLINE_DAYS * 24 * 60 * 60 * 1000).toISOString();
+
+    await this.env.DB.prepare(`
+      INSERT INTO age_review_cases
+      (id, pubkey, reporter_pubkey, report_id, suspected_age_band, state, allowed_resolution, deadline_at)
+      VALUES (?, ?, ?, ?, ?, 'open_reported', ?, ?)
+    `).bind(
+      caseId,
+      reportedPubkey,
+      event.pubkey,
+      event.id,
+      band,
+      defaultResolutionForBand(band),
+      deadline,
+    ).run();
+
+    await this.logDecision({
+      targetType: 'pubkey',
+      targetId: reportedPubkey,
+      action: AGE_REVIEW_ACTION.caseCreated,
+      reason: `Under-16 report: age review case ${caseId} created (default band: ${band})`,
+      reportId: event.id,
+      reporterPubkey: event.pubkey,
+    });
+
+    console.log(`[ReportWatcher] Age review case created: ${caseId} for ${reportedPubkey.slice(0, 8)}... (deadline: ${deadline})`);
   }
 
   /**

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -1,0 +1,446 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  handleGetAgeReviewCases,
+  handleGetAgeReviewCase,
+  handleUpdateAgeReviewCase,
+  handleGetModerationStatus,
+  handleParentContact,
+  checkAgeReviewDeadlines,
+} from './age-review';
+import type { AgeReviewCase } from '../../shared/age-review';
+
+const corsHeaders = { 'Access-Control-Allow-Origin': '*' };
+
+function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
+  return {
+    id: 'case-1',
+    pubkey: 'a'.repeat(64),
+    reporter_pubkey: 'b'.repeat(64),
+    report_id: 'r'.repeat(64),
+    suspected_age_band: 'age_13_15',
+    state: 'open_reported',
+    allowed_resolution: 'parent_video_or_email',
+    parent_contact_email: null,
+    deadline_at: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString(),
+    clock_paused: 0,
+    clock_paused_at: null,
+    remaining_days_when_paused: null,
+    moderator_pubkey: null,
+    resolution_note: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+type MockDb = { prepare: ReturnType<typeof vi.fn> };
+
+function createMockDb(cases: AgeReviewCase[] = []): MockDb {
+  const caseMap = new Map(cases.map(c => [c.id, c]));
+
+  return {
+    prepare: vi.fn().mockImplementation((sql: string) => ({
+      bind: vi.fn().mockReturnValue({
+        all: vi.fn().mockResolvedValue({ results: cases }),
+        first: vi.fn().mockImplementation(async () => {
+          if (sql.includes('WHERE id = ?')) {
+            return caseMap.get(cases[0]?.id) ?? null;
+          }
+          if (sql.includes('WHERE pubkey = ?')) {
+            return cases.find(c => !['cleared', 'denied_closed'].includes(c.state)) ?? null;
+          }
+          return null;
+        }),
+        run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+      }),
+    })),
+  };
+}
+
+// -- handleGetAgeReviewCases --------------------------------------------------
+
+describe('handleGetAgeReviewCases', () => {
+  it('returns cases from DB', async () => {
+    const c = makeCase();
+    const db = createMockDb([c]);
+    const req = new Request('https://api.test/api/age-review/cases');
+    const res = await handleGetAgeReviewCases(req, { DB: db as unknown as D1Database }, corsHeaders);
+    const body = await res.json() as { success: boolean; cases: AgeReviewCase[] };
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.cases).toHaveLength(1);
+  });
+
+  it('returns 500 when DB not configured', async () => {
+    const req = new Request('https://api.test/api/age-review/cases');
+    const res = await handleGetAgeReviewCases(req, {}, corsHeaders);
+    expect(res.status).toBe(500);
+  });
+});
+
+// -- handleGetAgeReviewCase ---------------------------------------------------
+
+describe('handleGetAgeReviewCase', () => {
+  it('returns a single case', async () => {
+    const c = makeCase();
+    const db = createMockDb([c]);
+    const res = await handleGetAgeReviewCase('case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    const body = await res.json() as { success: boolean; case: AgeReviewCase };
+
+    expect(res.status).toBe(200);
+    expect(body.case.id).toBe('case-1');
+  });
+
+  it('returns 404 for unknown case', async () => {
+    const db = createMockDb([]);
+    const res = await handleGetAgeReviewCase('nonexistent', { DB: db as unknown as D1Database }, corsHeaders);
+    expect(res.status).toBe(404);
+  });
+});
+
+// -- handleUpdateAgeReviewCase ------------------------------------------------
+
+describe('handleUpdateAgeReviewCase', () => {
+  let db: MockDb;
+  let activeCase: AgeReviewCase;
+
+  beforeEach(() => {
+    activeCase = makeCase({ state: 'open_reported' });
+    db = createMockDb([activeCase]);
+  });
+
+  it('transitions state', async () => {
+    const req = new Request('https://api.test/api/age-review/cases/case-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ state: 'under_moderator_review' }),
+    });
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    expect(res.status).toBe(200);
+
+    const updateCall = db.prepare.mock.calls.find(
+      (c: string[]) => c[0]?.includes('UPDATE age_review_cases')
+    );
+    expect(updateCall).toBeTruthy();
+  });
+
+  it('rejects invalid state', async () => {
+    const req = new Request('https://api.test/api/age-review/cases/case-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ state: 'bogus_state' }),
+    });
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('Invalid state');
+  });
+
+  it('rejects update on terminal case', async () => {
+    const closedCase = makeCase({ state: 'cleared' });
+    const closedDb = createMockDb([closedCase]);
+    const req = new Request('https://api.test/api/age-review/cases/case-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ state: 'under_moderator_review' }),
+    });
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: closedDb as unknown as D1Database }, corsHeaders);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('closed case');
+  });
+
+  it('pauses clock and records remaining days', async () => {
+    const req = new Request('https://api.test/api/age-review/cases/case-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ clock_paused: true }),
+    });
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    expect(res.status).toBe(200);
+
+    const updateCall = db.prepare.mock.calls.find(
+      (c: string[]) => c[0]?.includes('UPDATE') && c[0]?.includes('clock_paused = 1')
+    );
+    expect(updateCall).toBeTruthy();
+  });
+
+  it('resumes clock and sets new deadline', async () => {
+    const pausedCase = makeCase({
+      clock_paused: 1,
+      remaining_days_when_paused: 7.5,
+      clock_paused_at: new Date().toISOString(),
+    });
+    const pausedDb = createMockDb([pausedCase]);
+
+    const req = new Request('https://api.test/api/age-review/cases/case-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ clock_paused: false }),
+    });
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: pausedDb as unknown as D1Database }, corsHeaders);
+    expect(res.status).toBe(200);
+
+    const updateCall = pausedDb.prepare.mock.calls.find(
+      (c: string[]) => c[0]?.includes('UPDATE') && c[0]?.includes('clock_paused = 0')
+    );
+    expect(updateCall).toBeTruthy();
+  });
+
+  it('validates email format', async () => {
+    const req = new Request('https://api.test/api/age-review/cases/case-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ parent_contact_email: 'not-an-email' }),
+    });
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('email');
+  });
+
+  it('accepts null email (clears it)', async () => {
+    const req = new Request('https://api.test/api/age-review/cases/case-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ parent_contact_email: null }),
+    });
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    expect(res.status).toBe(200);
+  });
+});
+
+// -- handleGetModerationStatus ------------------------------------------------
+
+describe('handleGetModerationStatus', () => {
+  it('returns active when no case exists', async () => {
+    const db = createMockDb([]);
+    const res = await handleGetModerationStatus('a'.repeat(64), { DB: db as unknown as D1Database }, corsHeaders);
+    const body = await res.json() as { restriction: { status: string } };
+
+    expect(res.status).toBe(200);
+    expect(body.restriction.status).toBe('active');
+  });
+
+  it('returns restrictedMinorReview when active case exists', async () => {
+    const c = makeCase({ state: 'restricted_pending_user_response' });
+    const db = createMockDb([c]);
+    // Override first() to return the case for the pubkey query
+    db.prepare.mockImplementation((sql: string) => ({
+      bind: vi.fn().mockReturnValue({
+        first: vi.fn().mockResolvedValue(
+          sql.includes('WHERE pubkey = ?') ? c : null
+        ),
+      }),
+    }));
+
+    const res = await handleGetModerationStatus(c.pubkey, { DB: db as unknown as D1Database }, corsHeaders);
+    const body = await res.json() as {
+      restriction: { status: string };
+      minorReviewCase: { id: string; state: string };
+    };
+
+    expect(body.restriction.status).toBe('restrictedMinorReview');
+    expect(body.minorReviewCase.id).toBe('case-1');
+    expect(body.minorReviewCase.state).toBe('restricted_pending_user_response');
+  });
+
+  it('returns active (fail-open) when DB unavailable', async () => {
+    const res = await handleGetModerationStatus('a'.repeat(64), {}, corsHeaders);
+    const body = await res.json() as { restriction: { status: string } };
+
+    expect(res.status).toBe(200);
+    expect(body.restriction.status).toBe('active');
+  });
+});
+
+// -- handleParentContact ------------------------------------------------------
+
+describe('handleParentContact', () => {
+  it('saves email and pauses clock for age_13_15 case', async () => {
+    const c = makeCase({ state: 'restricted_pending_user_response' });
+    const db = createMockDb([c]);
+    // Override: first returns case when queried by id+pubkey
+    db.prepare.mockImplementation((sql: string) => ({
+      bind: vi.fn().mockReturnValue({
+        first: vi.fn().mockResolvedValue(
+          sql.includes('WHERE id = ? AND pubkey = ?') ? c : null
+        ),
+        run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+      }),
+    }));
+
+    const req = new Request('https://api.test/v1/minor-review-cases/case-1/parent-contact', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'parent@example.com' }),
+    });
+    const res = await handleParentContact(req, 'case-1', c.pubkey, { DB: db as unknown as D1Database }, corsHeaders);
+    expect(res.status).toBe(200);
+
+    const updateCall = db.prepare.mock.calls.find(
+      (call: string[]) => call[0]?.includes('UPDATE') && call[0]?.includes('clock_paused = 1')
+    );
+    expect(updateCall).toBeTruthy();
+  });
+
+  it('rejects request for under_13 case', async () => {
+    const c = makeCase({ suspected_age_band: 'under_13', state: 'restricted_pending_user_response' });
+    const db = createMockDb([c]);
+    db.prepare.mockImplementation((sql: string) => ({
+      bind: vi.fn().mockReturnValue({
+        first: vi.fn().mockResolvedValue(
+          sql.includes('WHERE id = ? AND pubkey = ?') ? c : null
+        ),
+      }),
+    }));
+
+    const req = new Request('https://api.test/v1/minor-review-cases/case-1/parent-contact', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'parent@example.com' }),
+    });
+    const res = await handleParentContact(req, 'case-1', c.pubkey, { DB: db as unknown as D1Database }, corsHeaders);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('Under-13');
+  });
+
+  it('rejects wrong pubkey (cannot access another user case)', async () => {
+    const c = makeCase();
+    const db = createMockDb([c]);
+    // first() returns null because pubkey doesn't match
+    db.prepare.mockImplementation(() => ({
+      bind: vi.fn().mockReturnValue({
+        first: vi.fn().mockResolvedValue(null),
+      }),
+    }));
+
+    const req = new Request('https://api.test/v1/minor-review-cases/case-1/parent-contact', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'parent@example.com' }),
+    });
+    const res = await handleParentContact(req, 'case-1', 'c'.repeat(64), { DB: db as unknown as D1Database }, corsHeaders);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects closed case', async () => {
+    const c = makeCase({ state: 'denied_closed' });
+    const db = createMockDb([c]);
+    db.prepare.mockImplementation((sql: string) => ({
+      bind: vi.fn().mockReturnValue({
+        first: vi.fn().mockResolvedValue(
+          sql.includes('WHERE id = ? AND pubkey = ?') ? c : null
+        ),
+      }),
+    }));
+
+    const req = new Request('https://api.test/v1/minor-review-cases/case-1/parent-contact', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'parent@example.com' }),
+    });
+    const res = await handleParentContact(req, 'case-1', c.pubkey, { DB: db as unknown as D1Database }, corsHeaders);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('closed');
+  });
+
+  it('rejects invalid email', async () => {
+    const c = makeCase({ state: 'restricted_pending_user_response' });
+    const db = createMockDb([c]);
+    db.prepare.mockImplementation((sql: string) => ({
+      bind: vi.fn().mockReturnValue({
+        first: vi.fn().mockResolvedValue(
+          sql.includes('WHERE id = ? AND pubkey = ?') ? c : null
+        ),
+      }),
+    }));
+
+    const req = new Request('https://api.test/v1/minor-review-cases/case-1/parent-contact', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'not-valid' }),
+    });
+    const res = await handleParentContact(req, 'case-1', c.pubkey, { DB: db as unknown as D1Database }, corsHeaders);
+    expect(res.status).toBe(400);
+  });
+});
+
+// -- checkAgeReviewDeadlines --------------------------------------------------
+
+describe('checkAgeReviewDeadlines', () => {
+  it('does nothing when DB unavailable', async () => {
+    await checkAgeReviewDeadlines({});
+    // No throw — just returns
+  });
+
+  it('auto-closes expired cases', async () => {
+    const expiredCase = makeCase({
+      deadline_at: new Date(Date.now() - 1000).toISOString(),
+      state: 'restricted_pending_user_response',
+    });
+    const runMock = vi.fn().mockResolvedValue({ meta: { changes: 1 } });
+    const db = {
+      prepare: vi.fn().mockImplementation((sql: string) => ({
+        bind: vi.fn().mockReturnValue({
+          all: vi.fn().mockResolvedValue({
+            results: sql.includes('deadline_at > datetime') ? [] : [expiredCase],
+          }),
+          run: runMock,
+        }),
+      })),
+    };
+
+    await checkAgeReviewDeadlines({ DB: db as unknown as D1Database });
+
+    const closeCalls = db.prepare.mock.calls.filter(
+      (c: string[]) => c[0]?.includes('denied_closed')
+    );
+    expect(closeCalls.length).toBe(1);
+  });
+
+  it('sends Slack alert for approaching deadlines', async () => {
+    const approachingCase = makeCase({
+      deadline_at: new Date(Date.now() + 1 * 24 * 60 * 60 * 1000).toISOString(),
+      state: 'restricted_pending_user_response',
+    });
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const db = {
+      prepare: vi.fn().mockImplementation((sql: string) => ({
+        bind: vi.fn().mockReturnValue({
+          all: vi.fn().mockResolvedValue({
+            results: sql.includes('deadline_at > datetime') ? [approachingCase] : [],
+          }),
+          run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
+        }),
+      })),
+    };
+
+    await checkAgeReviewDeadlines({
+      DB: db as unknown as D1Database,
+      SLACK_WEBHOOK_URL: 'https://hooks.slack.com/test',
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0][0]).toBe('https://hooks.slack.com/test');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('does not send Slack alert when no webhook configured', async () => {
+    const approachingCase = makeCase({
+      deadline_at: new Date(Date.now() + 1 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+    const mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+
+    const db = {
+      prepare: vi.fn().mockImplementation((sql: string) => ({
+        bind: vi.fn().mockReturnValue({
+          all: vi.fn().mockResolvedValue({
+            results: sql.includes('deadline_at > datetime') ? [approachingCase] : [],
+          }),
+          run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
+        }),
+      })),
+    };
+
+    await checkAgeReviewDeadlines({ DB: db as unknown as D1Database });
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -251,6 +251,25 @@ describe('handleGetModerationStatus', () => {
     expect(body.minorReviewCase.state).toBe('restricted_pending_user_response');
   });
 
+  it('returns active for open_reported case (pre-moderator review)', async () => {
+    const c = makeCase({ state: 'open_reported' });
+    const db = createMockDb([c]);
+    // The query now filters by RESTRICTED_STATES, so open_reported won't match
+    db.prepare.mockImplementation((sql: string) => ({
+      bind: vi.fn().mockReturnValue({
+        first: vi.fn().mockResolvedValue(
+          sql.includes('WHERE pubkey = ?') ? null : null
+        ),
+      }),
+    }));
+
+    const res = await handleGetModerationStatus(c.pubkey, { DB: db as unknown as D1Database }, corsHeaders);
+    const body = await res.json() as { restriction: { status: string } };
+
+    expect(res.status).toBe(200);
+    expect(body.restriction.status).toBe('active');
+  });
+
   it('returns active (fail-open) when DB unavailable', async () => {
     const res = await handleGetModerationStatus('a'.repeat(64), {}, corsHeaders);
     const body = await res.json() as { restriction: { status: string } };
@@ -347,6 +366,28 @@ describe('handleParentContact', () => {
     expect(res.status).toBe(400);
     const body = await res.json() as { error: string };
     expect(body.error).toContain('closed');
+  });
+
+  it('rejects parent contact from invalid state (open_reported)', async () => {
+    const c = makeCase({ state: 'open_reported' });
+    const db = createMockDb([c]);
+    db.prepare.mockImplementation((sql: string) => ({
+      bind: vi.fn().mockReturnValue({
+        first: vi.fn().mockResolvedValue(
+          sql.includes('WHERE id = ? AND pubkey = ?') ? c : null
+        ),
+        run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+      }),
+    }));
+
+    const req = new Request('https://api.test/v1/minor-review-cases/case-1/parent-contact', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'parent@example.com' }),
+    });
+    const res = await handleParentContact(req, 'case-1', c.pubkey, { DB: db as unknown as D1Database }, corsHeaders);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('Cannot submit parent contact');
   });
 
   it('rejects invalid email', async () => {

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -27,6 +27,7 @@ function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
     remaining_days_when_paused: null,
     moderator_pubkey: null,
     resolution_note: null,
+    last_alerted_at: null,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
     ...overrides,
@@ -133,6 +134,17 @@ describe('handleUpdateAgeReviewCase', () => {
     expect(res.status).toBe(400);
     const body = await res.json() as { error: string };
     expect(body.error).toContain('Invalid state');
+  });
+
+  it('rejects invalid state transition', async () => {
+    const req = new Request('https://api.test/api/age-review/cases/case-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ state: 'submitted_for_review' }),
+    });
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('Cannot transition');
   });
 
   it('rejects update on terminal case', async () => {
@@ -416,6 +428,43 @@ describe('checkAgeReviewDeadlines', () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockFetch.mock.calls[0][0]).toBe('https://hooks.slack.com/test');
+
+    const stampCalls = db.prepare.mock.calls.filter(
+      (c: string[]) => c[0]?.includes('UPDATE') && c[0]?.includes('last_alerted_at')
+    );
+    expect(stampCalls.length).toBe(1);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('does not stamp last_alerted_at when Slack send fails', async () => {
+    const approachingCase = makeCase({
+      deadline_at: new Date(Date.now() + 1 * 24 * 60 * 60 * 1000).toISOString(),
+      state: 'restricted_pending_user_response',
+    });
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const db = {
+      prepare: vi.fn().mockImplementation((sql: string) => ({
+        bind: vi.fn().mockReturnValue({
+          all: vi.fn().mockResolvedValue({
+            results: sql.includes('deadline_at > datetime') ? [approachingCase] : [],
+          }),
+          run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
+        }),
+      })),
+    };
+
+    await checkAgeReviewDeadlines({
+      DB: db as unknown as D1Database,
+      SLACK_WEBHOOK_URL: 'https://hooks.slack.com/test',
+    });
+
+    const stampCalls = db.prepare.mock.calls.filter(
+      (c: string[]) => c[0]?.includes('UPDATE') && c[0]?.includes('last_alerted_at')
+    );
+    expect(stampCalls.length).toBe(0);
 
     vi.unstubAllGlobals();
   });

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -5,6 +5,7 @@ import {
   AGE_BANDS,
   AGE_REVIEW_STATES,
   TERMINAL_STATES,
+  VALID_TRANSITIONS,
   DEADLINE_DAYS,
   defaultResolutionForBand,
 } from '../../shared/age-review';
@@ -96,6 +97,13 @@ export async function handleUpdateAgeReviewCase(
   if (body.state && typeof body.state === 'string') {
     if (!AGE_REVIEW_STATES.includes(body.state as AgeReviewState)) {
       return json({ success: false, error: `Invalid state: ${body.state}` }, 400, corsHeaders);
+    }
+    const allowed = VALID_TRANSITIONS[existing.state as AgeReviewState];
+    if (!allowed?.includes(body.state as AgeReviewState)) {
+      return json({
+        success: false,
+        error: `Cannot transition from '${existing.state}' to '${body.state}'`,
+      }, 400, corsHeaders);
     }
     updates.push('state = ?');
     binds.push(body.state);
@@ -287,7 +295,7 @@ export async function handleParentContact(
 export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> {
   if (!env.DB) return;
 
-  // Alert on cases approaching deadline (within 2 days)
+  // Alert on cases approaching deadline (within 2 days), skip if alerted in last 12h
   const approaching = await env.DB.prepare(`
     SELECT * FROM age_review_cases
     WHERE state NOT IN (${TERMINAL_STATES.map(() => '?').join(',')})
@@ -295,11 +303,19 @@ export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> 
       AND deadline_at IS NOT NULL
       AND deadline_at < datetime('now', '+2 days')
       AND deadline_at > datetime('now')
+      AND (last_alerted_at IS NULL OR last_alerted_at < datetime('now', '-12 hours'))
     ORDER BY deadline_at ASC
   `).bind(...TERMINAL_STATES).all<AgeReviewCase>();
 
   if (approaching.results.length > 0 && env.SLACK_WEBHOOK_URL) {
-    await sendSlackAlert(env.SLACK_WEBHOOK_URL, 'approaching', approaching.results);
+    const sent = await sendSlackAlert(env.SLACK_WEBHOOK_URL, 'approaching', approaching.results);
+    if (sent) {
+      for (const row of approaching.results) {
+        await env.DB.prepare(
+          `UPDATE age_review_cases SET last_alerted_at = datetime('now') WHERE id = ?`
+        ).bind(row.id).run();
+      }
+    }
   }
 
   // Auto-close expired cases.
@@ -331,7 +347,7 @@ async function sendSlackAlert(
   webhookUrl: string,
   alertType: 'approaching' | 'expired',
   cases: AgeReviewCase[],
-): Promise<void> {
+): Promise<boolean> {
   const emoji = alertType === 'expired' ? ':rotating_light:' : ':warning:';
   const header = alertType === 'expired'
     ? `${emoji} ${cases.length} age review case(s) expired`
@@ -350,9 +366,12 @@ async function sendSlackAlert(
     });
     if (!res.ok) {
       console.error(`[age-review] Slack alert returned ${res.status}`);
+      return false;
     }
+    return true;
   } catch (error) {
     console.error('[age-review] Failed to send Slack alert:', error);
+    return false;
   }
 }
 

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -1,0 +1,368 @@
+import {
+  type AgeReviewCase,
+  type AgeReviewState,
+  type AgeBand,
+  AGE_BANDS,
+  AGE_REVIEW_STATES,
+  TERMINAL_STATES,
+  DEADLINE_DAYS,
+  defaultResolutionForBand,
+} from '../../shared/age-review';
+
+interface AgeReviewEnv {
+  DB?: D1Database;
+  SLACK_WEBHOOK_URL?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Admin API handlers (behind verifyAdminAccess)
+// ---------------------------------------------------------------------------
+
+export async function handleGetAgeReviewCases(
+  request: Request,
+  env: AgeReviewEnv,
+  corsHeaders: Record<string, string>,
+): Promise<Response> {
+  if (!env.DB) return json({ success: false, error: 'Database not configured' }, 500, corsHeaders);
+
+  const url = new URL(request.url);
+  const stateFilter = url.searchParams.get('state');
+  const bandFilter = url.searchParams.get('age_band');
+
+  let query = 'SELECT * FROM age_review_cases';
+  const conditions: string[] = [];
+  const binds: string[] = [];
+
+  if (stateFilter === 'active') {
+    conditions.push(`state NOT IN (${TERMINAL_STATES.map(() => '?').join(',')})`);
+    binds.push(...TERMINAL_STATES);
+  } else if (stateFilter === 'closed') {
+    conditions.push(`state IN (${TERMINAL_STATES.map(() => '?').join(',')})`);
+    binds.push(...TERMINAL_STATES);
+  } else if (stateFilter && AGE_REVIEW_STATES.includes(stateFilter as AgeReviewState)) {
+    conditions.push('state = ?');
+    binds.push(stateFilter);
+  }
+
+  if (bandFilter && AGE_BANDS.includes(bandFilter as AgeBand)) {
+    conditions.push('suspected_age_band = ?');
+    binds.push(bandFilter);
+  }
+
+  if (conditions.length > 0) {
+    query += ' WHERE ' + conditions.join(' AND ');
+  }
+  query += ' ORDER BY deadline_at ASC LIMIT 500';
+
+  const result = await env.DB.prepare(query).bind(...binds).all<AgeReviewCase>();
+  return json({ success: true, cases: result.results }, 200, corsHeaders);
+}
+
+export async function handleGetAgeReviewCase(
+  caseId: string,
+  env: AgeReviewEnv,
+  corsHeaders: Record<string, string>,
+): Promise<Response> {
+  if (!env.DB) return json({ success: false, error: 'Database not configured' }, 500, corsHeaders);
+
+  const row = await env.DB.prepare('SELECT * FROM age_review_cases WHERE id = ?')
+    .bind(caseId).first<AgeReviewCase>();
+
+  if (!row) return json({ success: false, error: 'Case not found' }, 404, corsHeaders);
+  return json({ success: true, case: row }, 200, corsHeaders);
+}
+
+export async function handleUpdateAgeReviewCase(
+  request: Request,
+  caseId: string,
+  env: AgeReviewEnv,
+  corsHeaders: Record<string, string>,
+): Promise<Response> {
+  if (!env.DB) return json({ success: false, error: 'Database not configured' }, 500, corsHeaders);
+
+  const existing = await env.DB.prepare('SELECT * FROM age_review_cases WHERE id = ?')
+    .bind(caseId).first<AgeReviewCase>();
+  if (!existing) return json({ success: false, error: 'Case not found' }, 404, corsHeaders);
+
+  if (TERMINAL_STATES.includes(existing.state as AgeReviewState)) {
+    return json({ success: false, error: 'Cannot modify a closed case' }, 400, corsHeaders);
+  }
+
+  const body = await request.json() as Record<string, unknown>;
+  const updates: string[] = [];
+  const binds: unknown[] = [];
+
+  // State transition
+  if (body.state && typeof body.state === 'string') {
+    if (!AGE_REVIEW_STATES.includes(body.state as AgeReviewState)) {
+      return json({ success: false, error: `Invalid state: ${body.state}` }, 400, corsHeaders);
+    }
+    updates.push('state = ?');
+    binds.push(body.state);
+  }
+
+  // Age band change
+  if (body.suspected_age_band && typeof body.suspected_age_band === 'string') {
+    if (!AGE_BANDS.includes(body.suspected_age_band as AgeBand)) {
+      return json({ success: false, error: `Invalid age band: ${body.suspected_age_band}` }, 400, corsHeaders);
+    }
+    updates.push('suspected_age_band = ?');
+    binds.push(body.suspected_age_band);
+    updates.push('allowed_resolution = ?');
+    binds.push(defaultResolutionForBand(body.suspected_age_band as AgeBand));
+  }
+
+  // Clock pause/resume
+  if (body.clock_paused === true && !existing.clock_paused) {
+    const now = new Date();
+    const deadline = existing.deadline_at ? new Date(existing.deadline_at) : null;
+    const remainingDays = deadline ? (deadline.getTime() - now.getTime()) / (24 * 60 * 60 * 1000) : null;
+    updates.push('clock_paused = 1', 'clock_paused_at = ?', 'remaining_days_when_paused = ?');
+    binds.push(now.toISOString(), remainingDays);
+  } else if (body.clock_paused === false && existing.clock_paused) {
+    const remaining = existing.remaining_days_when_paused ?? DEADLINE_DAYS;
+    const newDeadline = new Date(Date.now() + remaining * 24 * 60 * 60 * 1000).toISOString();
+    updates.push('clock_paused = 0', 'clock_paused_at = NULL', 'remaining_days_when_paused = NULL', 'deadline_at = ?');
+    binds.push(newDeadline);
+  }
+
+  // Moderator assignment
+  if (body.moderator_pubkey !== undefined) {
+    if (body.moderator_pubkey !== null && typeof body.moderator_pubkey !== 'string') {
+      return json({ success: false, error: 'moderator_pubkey must be a string or null' }, 400, corsHeaders);
+    }
+    updates.push('moderator_pubkey = ?');
+    binds.push(body.moderator_pubkey as string | null);
+  }
+
+  // Resolution note
+  if (body.resolution_note !== undefined) {
+    if (body.resolution_note !== null && typeof body.resolution_note !== 'string') {
+      return json({ success: false, error: 'resolution_note must be a string or null' }, 400, corsHeaders);
+    }
+    updates.push('resolution_note = ?');
+    binds.push(body.resolution_note as string | null);
+  }
+
+  // Parent contact email
+  if (body.parent_contact_email !== undefined) {
+    const email = body.parent_contact_email as string | null;
+    if (email !== null && (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email) || email.length > 254)) {
+      return json({ success: false, error: 'Invalid email format' }, 400, corsHeaders);
+    }
+    updates.push('parent_contact_email = ?');
+    binds.push(email);
+  }
+
+  if (updates.length === 0) {
+    return json({ success: false, error: 'No valid fields to update' }, 400, corsHeaders);
+  }
+
+  updates.push("updated_at = datetime('now')");
+  binds.push(caseId);
+
+  await env.DB.prepare(
+    `UPDATE age_review_cases SET ${updates.join(', ')} WHERE id = ?`
+  ).bind(...binds).run();
+
+  const updated = await env.DB.prepare('SELECT * FROM age_review_cases WHERE id = ?')
+    .bind(caseId).first<AgeReviewCase>();
+  return json({ success: true, case: updated }, 200, corsHeaders);
+}
+
+// ---------------------------------------------------------------------------
+// Mobile-facing endpoints (behind NIP-98 user auth)
+// ---------------------------------------------------------------------------
+
+export async function handleGetModerationStatus(
+  userPubkey: string,
+  env: AgeReviewEnv,
+  corsHeaders: Record<string, string>,
+): Promise<Response> {
+  if (!env.DB) {
+    console.warn('[age-review] DB not available — returning fail-open active status for', userPubkey);
+    return json({ restriction: { status: 'active' } }, 200, corsHeaders);
+  }
+
+  const activeCase = await env.DB.prepare(`
+    SELECT * FROM age_review_cases
+    WHERE pubkey = ? AND state NOT IN (${TERMINAL_STATES.map(() => '?').join(',')})
+    ORDER BY created_at DESC LIMIT 1
+  `).bind(userPubkey, ...TERMINAL_STATES).first<AgeReviewCase>();
+
+  if (!activeCase) {
+    return json({ restriction: { status: 'active' } }, 200, corsHeaders);
+  }
+
+  return json({
+    restriction: { status: 'restrictedMinorReview' },
+    minorReviewCase: {
+      id: activeCase.id,
+      state: activeCase.state,
+      suspectedAgeBand: activeCase.suspected_age_band,
+      allowedResolution: activeCase.allowed_resolution,
+      instructions: null,
+      supportEmail: 'contact@divine.video',
+      moderationConversationPubkey: null,
+      moderationConversationId: null,
+    },
+  }, 200, corsHeaders);
+}
+
+export async function handleParentContact(
+  request: Request,
+  caseId: string,
+  userPubkey: string,
+  env: AgeReviewEnv,
+  corsHeaders: Record<string, string>,
+): Promise<Response> {
+  if (!env.DB) return json({ success: false, error: 'Database not configured' }, 500, corsHeaders);
+
+  const activeCase = await env.DB.prepare(
+    'SELECT * FROM age_review_cases WHERE id = ? AND pubkey = ?'
+  ).bind(caseId, userPubkey).first<AgeReviewCase>();
+
+  if (!activeCase) {
+    return json({ success: false, error: 'Case not found' }, 404, corsHeaders);
+  }
+
+  if (TERMINAL_STATES.includes(activeCase.state as AgeReviewState)) {
+    return json({ success: false, error: 'Case is already closed' }, 400, corsHeaders);
+  }
+
+  if (activeCase.suspected_age_band === 'under_13') {
+    return json({ success: false, error: 'Under-13 cases require support review only' }, 400, corsHeaders);
+  }
+
+  const body = await request.json() as { email?: string };
+  if (!body.email) {
+    return json({ success: false, error: 'email is required' }, 400, corsHeaders);
+  }
+  if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(body.email) || body.email.length > 254) {
+    return json({ success: false, error: 'Invalid email format' }, 400, corsHeaders);
+  }
+
+  // Save parent email, pause the clock (if not already paused), and transition state
+  if (activeCase.clock_paused) {
+    // Clock already paused — update email and state only, preserve existing remaining time
+    await env.DB.prepare(`
+      UPDATE age_review_cases
+      SET parent_contact_email = ?,
+          state = CASE
+            WHEN suspected_age_band = 'age_13_15' THEN 'restricted_pending_parental_consent'
+            WHEN suspected_age_band = 'age_16_plus_claimed' THEN 'restricted_pending_support_email'
+            ELSE state
+          END,
+          updated_at = datetime('now')
+      WHERE id = ?
+    `).bind(body.email, caseId).run();
+  } else {
+    const now = new Date();
+    const deadline = activeCase.deadline_at ? new Date(activeCase.deadline_at) : null;
+    const remainingDays = deadline ? (deadline.getTime() - now.getTime()) / (24 * 60 * 60 * 1000) : DEADLINE_DAYS;
+
+    await env.DB.prepare(`
+      UPDATE age_review_cases
+      SET parent_contact_email = ?,
+          clock_paused = 1,
+          clock_paused_at = ?,
+          remaining_days_when_paused = ?,
+          state = CASE
+            WHEN suspected_age_band = 'age_13_15' THEN 'restricted_pending_parental_consent'
+            WHEN suspected_age_band = 'age_16_plus_claimed' THEN 'restricted_pending_support_email'
+            ELSE state
+          END,
+          updated_at = datetime('now')
+      WHERE id = ?
+    `).bind(body.email, now.toISOString(), remainingDays, caseId).run();
+  }
+
+  return json({ success: true }, 200, corsHeaders);
+}
+
+// ---------------------------------------------------------------------------
+// Cron: deadline checker + Slack alerts
+// ---------------------------------------------------------------------------
+
+export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> {
+  if (!env.DB) return;
+
+  // Alert on cases approaching deadline (within 2 days)
+  const approaching = await env.DB.prepare(`
+    SELECT * FROM age_review_cases
+    WHERE state NOT IN (${TERMINAL_STATES.map(() => '?').join(',')})
+      AND clock_paused = 0
+      AND deadline_at IS NOT NULL
+      AND deadline_at < datetime('now', '+2 days')
+      AND deadline_at > datetime('now')
+    ORDER BY deadline_at ASC
+  `).bind(...TERMINAL_STATES).all<AgeReviewCase>();
+
+  if (approaching.results.length > 0 && env.SLACK_WEBHOOK_URL) {
+    await sendSlackAlert(env.SLACK_WEBHOOK_URL, 'approaching', approaching.results);
+  }
+
+  // Auto-close expired cases.
+  // NOTE: This only updates the case state. Actual account enforcement (ban,
+  // Keycast restriction) is deferred to the Keycast integration (Track C).
+  const expired = await env.DB.prepare(`
+    SELECT * FROM age_review_cases
+    WHERE state NOT IN (${TERMINAL_STATES.map(() => '?').join(',')})
+      AND clock_paused = 0
+      AND deadline_at IS NOT NULL
+      AND deadline_at < datetime('now')
+  `).bind(...TERMINAL_STATES).all<AgeReviewCase>();
+
+  for (const row of expired.results) {
+    await env.DB.prepare(`
+      UPDATE age_review_cases
+      SET state = 'denied_closed', resolution_note = 'Auto-closed: deadline expired with no response', updated_at = datetime('now')
+      WHERE id = ?
+    `).bind(row.id).run();
+    console.log(`[age-review] Auto-closed expired case ${row.id} for ${row.pubkey}`);
+  }
+
+  if (expired.results.length > 0 && env.SLACK_WEBHOOK_URL) {
+    await sendSlackAlert(env.SLACK_WEBHOOK_URL, 'expired', expired.results);
+  }
+}
+
+async function sendSlackAlert(
+  webhookUrl: string,
+  alertType: 'approaching' | 'expired',
+  cases: AgeReviewCase[],
+): Promise<void> {
+  const emoji = alertType === 'expired' ? ':rotating_light:' : ':warning:';
+  const header = alertType === 'expired'
+    ? `${emoji} ${cases.length} age review case(s) expired`
+    : `${emoji} ${cases.length} age review case(s) approaching deadline`;
+
+  const lines = cases.map(c => {
+    const deadline = c.deadline_at ? new Date(c.deadline_at).toISOString().split('T')[0] : 'no deadline';
+    return `• \`${c.pubkey}\` — ${c.suspected_age_band} — deadline: ${deadline} — state: ${c.state}`;
+  });
+
+  try {
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: `${header}\n${lines.join('\n')}` }),
+    });
+    if (!res.ok) {
+      console.error(`[age-review] Slack alert returned ${res.status}`);
+    }
+  } catch (error) {
+    console.error('[age-review] Failed to send Slack alert:', error);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function json(data: unknown, status: number, headers: Record<string, string>): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -192,11 +192,22 @@ export async function handleGetModerationStatus(
     return json({ restriction: { status: 'active' } }, 200, corsHeaders);
   }
 
+  // Only surface restriction for states where a moderator has reviewed.
+  // open_reported is pre-review — a single unsolicited report should not
+  // restrict the user before a human confirms.
+  const RESTRICTED_STATES: readonly AgeReviewState[] = [
+    'under_moderator_review',
+    'restricted_pending_user_response',
+    'restricted_pending_parental_consent',
+    'restricted_pending_support_email',
+    'submitted_for_review',
+    'needs_follow_up',
+  ];
   const activeCase = await env.DB.prepare(`
     SELECT * FROM age_review_cases
-    WHERE pubkey = ? AND state NOT IN (${TERMINAL_STATES.map(() => '?').join(',')})
+    WHERE pubkey = ? AND state IN (${RESTRICTED_STATES.map(() => '?').join(',')})
     ORDER BY created_at DESC LIMIT 1
-  `).bind(userPubkey, ...TERMINAL_STATES).first<AgeReviewCase>();
+  `).bind(userPubkey, ...RESTRICTED_STATES).first<AgeReviewCase>();
 
   if (!activeCase) {
     return json({ restriction: { status: 'active' } }, 200, corsHeaders);
@@ -248,6 +259,18 @@ export async function handleParentContact(
   }
   if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(body.email) || body.email.length > 254) {
     return json({ success: false, error: 'Invalid email format' }, 400, corsHeaders);
+  }
+
+  // Validate state transition before modifying the case
+  const targetState: AgeReviewState = activeCase.suspected_age_band === 'age_13_15'
+    ? 'restricted_pending_parental_consent'
+    : 'restricted_pending_support_email';
+  const allowed = VALID_TRANSITIONS[activeCase.state as AgeReviewState];
+  if (!allowed?.includes(targetState)) {
+    return json({
+      success: false,
+      error: `Cannot submit parent contact from state '${activeCase.state}'`,
+    }, 400, corsHeaders);
   }
 
   // Save parent email, pause the clock (if not already paused), and transition state

--- a/worker/src/db.ts
+++ b/worker/src/db.ts
@@ -50,4 +50,34 @@ export async function ensureSchema(db: D1Database): Promise<void> {
       ever_human_reviewed INTEGER DEFAULT 0
     )
   `).run();
+
+  await db.prepare(`
+    CREATE TABLE IF NOT EXISTS age_review_cases (
+      id TEXT PRIMARY KEY,
+      pubkey TEXT NOT NULL,
+      reporter_pubkey TEXT,
+      report_id TEXT,
+      suspected_age_band TEXT NOT NULL DEFAULT 'age_13_15',
+      state TEXT NOT NULL DEFAULT 'open_reported',
+      allowed_resolution TEXT NOT NULL DEFAULT 'parent_video_or_email',
+      parent_contact_email TEXT,
+      deadline_at TEXT,
+      clock_paused INTEGER DEFAULT 0,
+      clock_paused_at TEXT,
+      remaining_days_when_paused REAL,
+      moderator_pubkey TEXT,
+      resolution_note TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+    )
+  `).run();
+
+  try {
+    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_age_review_pubkey ON age_review_cases(pubkey)`).run();
+    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_age_review_state ON age_review_cases(state)`).run();
+    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_age_review_deadline ON age_review_cases(deadline_at)`).run();
+  } catch {
+    // Indexes already exist
+  }
+
 }

--- a/worker/src/db.ts
+++ b/worker/src/db.ts
@@ -67,6 +67,7 @@ export async function ensureSchema(db: D1Database): Promise<void> {
       remaining_days_when_paused REAL,
       moderator_pubkey TEXT,
       resolution_note TEXT,
+      last_alerted_at TEXT,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT DEFAULT CURRENT_TIMESTAMP
     )

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -25,7 +25,7 @@ describe('relay manager cors', () => {
 
     expect(response.status).toBe(204);
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://app.divine.video');
-    expect(response.headers.get('Access-Control-Allow-Methods')).toBe('GET, POST, PUT, DELETE, OPTIONS');
+    expect(response.headers.get('Access-Control-Allow-Methods')).toBe('GET, POST, PUT, PATCH, DELETE, OPTIONS');
     expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type, Authorization, X-Requested-With, Range, X-Admin-Key, CF-Access-Client-Id, CF-Access-Client-Secret');
     expect(response.headers.get('Access-Control-Max-Age')).toBe('86400');
     expect(response.headers.get('Vary')).toContain('Origin');
@@ -57,7 +57,7 @@ describe('relay manager cors', () => {
     );
 
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://pr-123.openvine-app.pages.dev');
-    expect(response.headers.get('Access-Control-Allow-Methods')).toBe('GET, POST, PUT, DELETE, OPTIONS');
+    expect(response.headers.get('Access-Control-Allow-Methods')).toBe('GET, POST, PUT, PATCH, DELETE, OPTIONS');
     expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type, Authorization, X-Requested-With, Range, X-Admin-Key, CF-Access-Client-Id, CF-Access-Client-Secret');
     expect(response.headers.get('Access-Control-Max-Age')).toBe('86400');
     expect(response.headers.get('Vary')).toContain('Origin');

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -14,6 +14,14 @@ import {
 import { ensureSchema } from './db';
 import { generatePreAuthToken, verifyPreAuthToken, base64UrlEncode } from './zendesk-preauth';
 import { deriveFunnelcakeApiUrl, proxyFunnelcakeRequest } from './funnelcake-proxy';
+import {
+  handleGetAgeReviewCases,
+  handleGetAgeReviewCase,
+  handleUpdateAgeReviewCase,
+  handleGetModerationStatus,
+  handleParentContact,
+  checkAgeReviewDeadlines,
+} from './age-review';
 
 let schemaReady = false;
 async function ensureSchemaOnce(db: D1Database): Promise<void> {
@@ -65,6 +73,8 @@ interface Env {
   AUTO_HIDE_ENABLED?: string;
   // Admin API key — required on all admin endpoints when request doesn't come through CF Access
   ADMIN_API_KEY?: string;
+  // Slack webhook for age review deadline alerts
+  SLACK_WEBHOOK_URL?: string;
   // Environment identifier for deep links (e.g., "production", "staging")
   ENVIRONMENT?: string;
   // Blossom admin bypass (for proxying blocked media to moderators)
@@ -221,7 +231,7 @@ function hostnameMatchesWildcard(hostname: string, suffix: string): boolean {
 
 function buildCorsHeaders(allowedOrigin: string | null): Record<string, string> {
   const headers: Record<string, string> = {
-    'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Requested-With, Range, X-Admin-Key, CF-Access-Client-Id, CF-Access-Client-Secret',
     'Access-Control-Expose-Headers': 'Content-Range, Accept-Ranges, X-Admin-Proxy, X-Moderation-Status',
     'Access-Control-Max-Age': '86400',
@@ -305,6 +315,23 @@ export default {
       // Zendesk endpoints have their own auth (HMAC, NIP-98, JWT) — skip admin gate
       if (path.startsWith('/api/zendesk/')) {
         return handleZendeskRoutes(request, path, env, corsHeaders);
+      }
+
+      // Mobile-facing endpoints: NIP-98 user auth, not admin auth
+      if (path === '/v1/account/moderation-status' && request.method === 'GET') {
+        const authResult = await verifyNip98Auth(request, request.url);
+        if (!authResult.valid || !authResult.pubkey) return jsonResponse({ success: false, error: authResult.error ?? 'Unauthorized' }, 401, corsHeaders);
+        if (env.DB) await ensureSchemaOnce(env.DB);
+        return handleGetModerationStatus(authResult.pubkey, env, corsHeaders);
+      }
+
+      if (path.startsWith('/v1/minor-review-cases/') && path.endsWith('/parent-contact') && request.method === 'POST') {
+        const authResult = await verifyNip98Auth(request, request.url);
+        if (!authResult.valid || !authResult.pubkey) return jsonResponse({ success: false, error: authResult.error ?? 'Unauthorized' }, 401, corsHeaders);
+        if (env.DB) await ensureSchemaOnce(env.DB);
+        const caseId = path.replace('/v1/minor-review-cases/', '').replace('/parent-contact', '');
+        if (!caseId) return jsonResponse({ success: false, error: 'Invalid caseId' }, 400, corsHeaders);
+        return handleParentContact(request, caseId, authResult.pubkey, env, corsHeaders);
       }
 
       // All other /api/* endpoints require admin access (CF Access or API key)
@@ -397,6 +424,22 @@ export default {
         return jsonResponse({ success: true, events: result.events }, 200, corsHeaders);
       }
 
+      // Age review case management
+      if (path === '/api/age-review/cases' && request.method === 'GET') {
+        if (env.DB) await ensureSchemaOnce(env.DB);
+        return handleGetAgeReviewCases(request, env, corsHeaders);
+      }
+      if (path.startsWith('/api/age-review/cases/') && request.method === 'GET') {
+        if (env.DB) await ensureSchemaOnce(env.DB);
+        const caseId = path.replace('/api/age-review/cases/', '');
+        return handleGetAgeReviewCase(caseId, env, corsHeaders);
+      }
+      if (path.startsWith('/api/age-review/cases/') && request.method === 'PATCH') {
+        if (env.DB) await ensureSchemaOnce(env.DB);
+        const caseId = path.replace('/api/age-review/cases/', '');
+        return handleUpdateAgeReviewCase(request, caseId, env, corsHeaders);
+      }
+
       // 404 for unknown routes
       return jsonResponse({ success: false, error: 'Not found' }, 404, corsHeaders);
     } catch (error) {
@@ -438,6 +481,14 @@ export default {
         }
       } catch (error) {
         console.error('[scheduled] Failed to clean up pre-auth nonces:', error);
+      }
+
+      // Check age review deadlines and auto-close expired cases
+      try {
+        await ensureSchemaOnce(env.DB);
+        await checkAgeReviewDeadlines(env);
+      } catch (error) {
+        console.error('[scheduled] Age review deadline check failed:', error);
       }
     }
   },

--- a/worker/wrangler.prod.toml
+++ b/worker/wrangler.prod.toml
@@ -60,6 +60,8 @@ CDN_DOMAIN = "media.divine.video"
 # Zendesk custom field IDs for webhook callback
 ZENDESK_FIELD_ACTION_STATUS = "14545793289743"
 ZENDESK_FIELD_ACTION_REQUESTED = "14545826900367"
+# Slack webhook for age review deadline alerts (add via: wrangler secret put SLACK_WEBHOOK_URL --config wrangler.prod.toml)
+# SLACK_WEBHOOK_URL — not in [vars] because it's a secret
 # Zendesk custom field IDs for auto-solve required fields
 ZENDESK_FIELD_CATEGORY = "14559549220879"
 ZENDESK_FIELD_ISSUE = "14560383908879"

--- a/worker/wrangler.staging.toml
+++ b/worker/wrangler.staging.toml
@@ -59,6 +59,8 @@ CDN_DOMAIN = "media.divine.video"
 # Zendesk custom field IDs for webhook callback
 ZENDESK_FIELD_ACTION_STATUS = "14545793289743"
 ZENDESK_FIELD_ACTION_REQUESTED = "14545826900367"
+# Slack webhook for age review deadline alerts (add via: wrangler secret put SLACK_WEBHOOK_URL --config wrangler.staging.toml)
+# SLACK_WEBHOOK_URL — not in [vars] because it's a secret
 # Zendesk custom field IDs for auto-solve required fields
 ZENDESK_FIELD_CATEGORY = "14559549220879"
 ZENDESK_FIELD_ISSUE = "14560383908879"


### PR DESCRIPTION
## Summary

Backend and admin UI for the 15-day age review clock. This is what divine-mobile PR #3531 will call to check moderation status and submit parent contact info.

- **D1 table + migration** for `age_review_cases` with state machine, clock pause/resume, and deadline tracking
- **ReportWatcher hook** auto-creates a case when an `NS-underageUser` report arrives (in-memory Set guard against DO WebSocket handler race conditions)
- **Admin API** for case listing (server-side filtering), detail, and moderator actions (state transitions, age band changes, clock control, resolution notes)
- **Mobile-facing `/v1/` endpoints** behind NIP-98 auth: `GET /v1/account/moderation-status` and `POST /v1/minor-review-cases/:caseId/parent-contact` (matches #3531 contract)
- **Cron deadline checker** with Slack alerts for approaching/expired cases, auto-close on expiry
- **Admin UI tab** with split-pane queue, urgency indicators, moderator action panel

What this provides: case tracking, clock management, status reporting to the mobile app, and moderator workflow. Posting restriction is already possible via relay ban on case denial. Keycast integration (Track C, separate PR) adds account-level suspension, covering login and key delegation beyond just relay access.

## Commits

1. `feat: support X-Admin-Key header for local dev`
2. `docs: add local dev setup script and documentation`
3. `feat: age review clock — 15-day under-16 moderation workflow`

## Test plan

**Already verified locally:**
- [x] 123 worker tests passing (`worker/` vitest), including 23 new age-review tests
- [x] 80 frontend tests passing (root vitest)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean (0 errors across all changed files)
- [x] divine-plugin review-before-commit passed (ID integrity, logging discipline, content security)

**Staging verification (pre-prod):**
- [ ] Deploy worker to staging, run `wrangler d1 migrations apply`
- [ ] Send a test `NS-underageUser` report, verify case auto-created
- [ ] Open admin UI, verify Age Review tab loads with case list and detail
- [ ] Test moderator actions: state transitions, clock pause/resume, clear/deny
- [ ] Call `/v1/account/moderation-status` with NIP-98 signed request, verify response shape matches #3531 contract
- [ ] Set a test case deadline to past, trigger cron, verify auto-close and Slack alert