### PR TITLE
feat: Zendesk integration for age review parent contact

### DIFF
--- a/shared/age-review.ts
+++ b/shared/age-review.ts
@@ -54,6 +54,14 @@ export function defaultResolutionForBand(band: AgeBand): ResolutionType {
   }
 }
 
+export function getDaysRemaining(c: AgeReviewCase): number | null {
+  if (c.clock_paused && c.remaining_days_when_paused != null) {
+    return c.remaining_days_when_paused;
+  }
+  if (!c.deadline_at) return null;
+  return (new Date(c.deadline_at).getTime() - Date.now()) / (24 * 60 * 60 * 1000);
+}
+
 export interface AgeReviewCase {
   id: string;
   pubkey: string;
@@ -70,6 +78,7 @@ export interface AgeReviewCase {
   moderator_pubkey: string | null;
   resolution_note: string | null;
   last_alerted_at: string | null;
+  zendesk_ticket_id: number | null;
   created_at: string;
   updated_at: string;
 }

--- a/src/components/AgeReview.tsx
+++ b/src/components/AgeReview.tsx
@@ -21,7 +21,7 @@ import { Sheet, SheetContent } from "@/components/ui/sheet";
 import {
   AGE_BANDS,
   TERMINAL_STATES,
-  type AgeReviewCase,
+  getDaysRemaining,
   type AgeReviewState,
   type AgeBand,
 } from "../../shared/age-review";
@@ -45,14 +45,6 @@ const STATE_SHORT: Record<AgeReviewState, string> = {
 };
 
 type FilterMode = 'active' | 'closed' | 'all';
-
-function getDaysRemaining(c: AgeReviewCase): number | null {
-  if (c.clock_paused && c.remaining_days_when_paused != null) {
-    return c.remaining_days_when_paused;
-  }
-  if (!c.deadline_at) return null;
-  return (new Date(c.deadline_at).getTime() - Date.now()) / (24 * 60 * 60 * 1000);
-}
 
 export function AgeReview() {
   const api = useAdminApi();

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -30,6 +30,7 @@ function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
     moderator_pubkey: null,
     resolution_note: null,
     last_alerted_at: null,
+    zendesk_ticket_id: null,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
     ...overrides,

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -29,6 +29,7 @@ import { nip19 } from "nostr-tools";
 import {
   AGE_BANDS,
   TERMINAL_STATES,
+  getDaysRemaining,
   type AgeReviewCase,
   type AgeReviewState,
   type AgeBand,
@@ -74,15 +75,6 @@ function bandColor(band: AgeBand): string {
   if (band === 'under_13') return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400';
   if (band === 'age_13_15') return 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400';
   return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400';
-}
-
-function getDaysRemaining(c: AgeReviewCase): number | null {
-  if (c.clock_paused && c.remaining_days_when_paused != null) {
-    return c.remaining_days_when_paused;
-  }
-  if (!c.deadline_at) return null;
-  const ms = new Date(c.deadline_at).getTime() - Date.now();
-  return ms / (24 * 60 * 60 * 1000);
 }
 
 interface Props {

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -952,4 +952,3 @@ export async function updateAgeReviewCase(
 ): Promise<AgeReviewCaseResponse> {
   return apiRequest<AgeReviewCaseResponse>(apiUrl, `/api/age-review/cases/${caseId}`, 'PATCH', updates);
 }
-

--- a/worker/migrations/0008_age_review_zendesk.sql
+++ b/worker/migrations/0008_age_review_zendesk.sql
@@ -1,0 +1,3 @@
+-- Link age review cases to Zendesk tickets for parent contact workflow
+ALTER TABLE age_review_cases ADD COLUMN zendesk_ticket_id INTEGER;
+CREATE INDEX IF NOT EXISTS idx_age_review_zendesk_ticket ON age_review_cases(zendesk_ticket_id);

--- a/worker/src/ReportWatcher.ts
+++ b/worker/src/ReportWatcher.ts
@@ -609,10 +609,10 @@ export class ReportWatcher implements DurableObject {
 
     console.log(`[ReportWatcher] Report received:`, {
       reportId: event.id,
-      reporter: event.pubkey.slice(0, 8) + '...',
+      reporter: event.pubkey,
       category,
       targetType,
-      targetId: targetId.slice(0, 8) + '...',
+      targetId,
       content: event.content.slice(0, 50) + (event.content.length > 50 ? '...' : ''),
     });
 
@@ -682,12 +682,12 @@ export class ReportWatcher implements DurableObject {
     }
 
     if (await this.hasHumanResolution(targetEventId)) {
-      console.log(`[ReportWatcher] Event ${targetEventId.slice(0, 8)}... has human resolution, skipping auto-hide`);
+      console.log(`[ReportWatcher] Event ${targetEventId} has human resolution, skipping auto-hide`);
       return;
     }
 
     if (await this.isAlreadyAutoHidden(targetEventId)) {
-      console.log(`[ReportWatcher] Event ${targetEventId.slice(0, 8)}... already auto-hidden, skipping`);
+      console.log(`[ReportWatcher] Event ${targetEventId} already auto-hidden, skipping`);
       return;
     }
 
@@ -723,10 +723,10 @@ export class ReportWatcher implements DurableObject {
     const count = await this.countUniqueReporters(targetEventId, category);
 
     if (count >= tier.threshold) {
-      console.log(`[ReportWatcher] Threshold met for ${targetEventId.slice(0, 8)}... (${count}/${tier.threshold})`);
+      console.log(`[ReportWatcher] Threshold met for ${targetEventId} (${count}/${tier.threshold})`);
       await this.executeAutoHide(event, category, targetEventId, tier.name);
     } else {
-      console.log(`[ReportWatcher] Below threshold for ${targetEventId.slice(0, 8)}... (${count}/${tier.threshold})`);
+      console.log(`[ReportWatcher] Below threshold for ${targetEventId} (${count}/${tier.threshold})`);
     }
   }
 
@@ -736,13 +736,13 @@ export class ReportWatcher implements DurableObject {
     targetEventId: string,
     tierName: string
   ): Promise<void> {
-    console.log(`[ReportWatcher] Auto-hiding event ${targetEventId.slice(0, 8)}... (tier: ${tierName})`);
+    console.log(`[ReportWatcher] Auto-hiding event ${targetEventId} (tier: ${tierName})`);
 
     const reason = `Auto-hidden: ${category} report (tier: ${tierName}, report_id: ${event.id})`;
     const result = await banEvent(targetEventId, reason, this.env);
 
     if (result.success) {
-      console.log(`[ReportWatcher] Successfully auto-hidden event ${targetEventId.slice(0, 8)}...`);
+      console.log(`[ReportWatcher] Successfully auto-hidden event ${targetEventId}`);
       this.eventsAutoHidden++;
       await this.persistState();
 
@@ -877,7 +877,7 @@ export class ReportWatcher implements DurableObject {
         decision.reporterPubkey
       ).run();
 
-      console.log(`[ReportWatcher] Logged decision: ${decision.action} for ${decision.targetId.slice(0, 8)}...`);
+      console.log(`[ReportWatcher] Logged decision: ${decision.action} for ${decision.targetId}`);
     } catch (error) {
       console.error('[ReportWatcher] Failed to log decision:', error);
     }
@@ -907,7 +907,7 @@ export class ReportWatcher implements DurableObject {
     `).bind(reportedPubkey, ...TERMINAL_STATES).first<{ id: string; state: string }>();
 
     if (existing) {
-      console.log(`[ReportWatcher] Active age review case ${existing.id} already exists for ${reportedPubkey.slice(0, 8)}..., skipping`);
+      console.log(`[ReportWatcher] Active age review case ${existing.id} already exists for ${reportedPubkey}, skipping`);
       return;
     }
 
@@ -938,7 +938,7 @@ export class ReportWatcher implements DurableObject {
       reporterPubkey: event.pubkey,
     });
 
-    console.log(`[ReportWatcher] Age review case created: ${caseId} for ${reportedPubkey.slice(0, 8)}... (deadline: ${deadline})`);
+    console.log(`[ReportWatcher] Age review case created: ${caseId} for ${reportedPubkey} (deadline: ${deadline})`);
   }
 
   /**

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -5,7 +5,9 @@ import {
   handleUpdateAgeReviewCase,
   handleGetModerationStatus,
   handleParentContact,
+  handleAgeReviewReplyWebhook,
   checkAgeReviewDeadlines,
+  syncAgeReviewTicketResolution,
 } from './age-review';
 import type { AgeReviewCase } from '../../shared/age-review';
 
@@ -28,6 +30,7 @@ function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
     moderator_pubkey: null,
     resolution_note: null,
     last_alerted_at: null,
+    zendesk_ticket_id: null,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
     ...overrides,
@@ -213,6 +216,39 @@ describe('handleUpdateAgeReviewCase', () => {
     });
     const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
     expect(res.status).toBe(200);
+  });
+
+  it('syncs Zendesk ticket when transitioning to terminal state', async () => {
+    const reviewCase = makeCase({
+      state: 'under_moderator_review',
+      zendesk_ticket_id: 55,
+    });
+    const reviewDb = createMockDb([reviewCase]);
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const req = new Request('https://api.test/api/age-review/cases/case-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ state: 'cleared', resolution_note: 'Age verified' }),
+    });
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', {
+      DB: reviewDb as unknown as D1Database,
+      ZENDESK_SUBDOMAIN: 'test',
+      ZENDESK_API_TOKEN: 'tok',
+      ZENDESK_EMAIL: 'agent@test.com',
+    }, corsHeaders);
+    expect(res.status).toBe(200);
+
+    const zendeskCall = mockFetch.mock.calls.find(
+      (call: unknown[]) => (call[0] as string).includes('zendesk.com/api/v2/tickets/55')
+    );
+    expect(zendeskCall).toBeTruthy();
+    const payload = JSON.parse(zendeskCall![1].body);
+    expect(payload.ticket.status).toBe('solved');
+    expect(payload.ticket.comment.body).toContain('cleared');
+
+    vi.unstubAllGlobals();
   });
 });
 
@@ -418,29 +454,51 @@ describe('checkAgeReviewDeadlines', () => {
     // No throw — just returns
   });
 
-  it('auto-closes expired cases', async () => {
+  it('auto-closes expired cases and syncs Zendesk', async () => {
     const expiredCase = makeCase({
       deadline_at: new Date(Date.now() - 1000).toISOString(),
       state: 'restricted_pending_user_response',
+      zendesk_ticket_id: 55,
     });
     const runMock = vi.fn().mockResolvedValue({ meta: { changes: 1 } });
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+
     const db = {
       prepare: vi.fn().mockImplementation((sql: string) => ({
         bind: vi.fn().mockReturnValue({
           all: vi.fn().mockResolvedValue({
             results: sql.includes('deadline_at > datetime') ? [] : [expiredCase],
           }),
+          first: vi.fn().mockResolvedValue(
+            sql.includes('zendesk_ticket_id') ? { zendesk_ticket_id: 55 } : null
+          ),
           run: runMock,
         }),
       })),
     };
 
-    await checkAgeReviewDeadlines({ DB: db as unknown as D1Database });
+    await checkAgeReviewDeadlines({
+      DB: db as unknown as D1Database,
+      ZENDESK_SUBDOMAIN: 'test',
+      ZENDESK_API_TOKEN: 'tok',
+      ZENDESK_EMAIL: 'agent@test.com',
+    });
 
     const closeCalls = db.prepare.mock.calls.filter(
       (c: string[]) => c[0]?.includes('denied_closed')
     );
     expect(closeCalls.length).toBe(1);
+
+    // Verify Zendesk ticket was resolved
+    const zendeskCall = mockFetch.mock.calls.find(
+      (call: unknown[]) => (call[0] as string).includes('zendesk.com/api/v2/tickets/55')
+    );
+    expect(zendeskCall).toBeTruthy();
+    const payload = JSON.parse((zendeskCall as [string, RequestInit])[1].body as string);
+    expect(payload.ticket.status).toBe('solved');
+
+    vi.unstubAllGlobals();
   });
 
   it('sends Slack alert for approaching deadlines', async () => {
@@ -532,5 +590,377 @@ describe('checkAgeReviewDeadlines', () => {
     expect(mockFetch).not.toHaveBeenCalled();
 
     vi.unstubAllGlobals();
+  });
+});
+
+// -- handleParentContact + Zendesk ticket creation ----------------------------
+
+describe('handleParentContact Zendesk integration', () => {
+  it('creates Zendesk ticket on parent email submission', async () => {
+    const c = makeCase({ state: 'restricted_pending_user_response' });
+    const runMock = vi.fn().mockResolvedValue({ meta: { changes: 1 } });
+    const db = {
+      prepare: vi.fn().mockImplementation((sql: string) => ({
+        bind: vi.fn().mockReturnValue({
+          first: vi.fn().mockResolvedValue(
+            sql.includes('WHERE id = ? AND pubkey = ?') ? c : null
+          ),
+          run: runMock,
+        }),
+      })),
+    };
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ ticket: { id: 42 } }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const req = new Request('https://api.test/v1/minor-review-cases/case-1/parent-contact', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'parent@example.com' }),
+    });
+    const res = await handleParentContact(req, 'case-1', c.pubkey, {
+      DB: db as unknown as D1Database,
+      ZENDESK_SUBDOMAIN: 'test',
+      ZENDESK_API_TOKEN: 'tok',
+      ZENDESK_EMAIL: 'agent@test.com',
+    }, corsHeaders);
+    expect(res.status).toBe(200);
+
+    // Zendesk API was called to create ticket
+    const zendeskCall = mockFetch.mock.calls.find(
+      (call: unknown[]) => (call[0] as string).includes('zendesk.com/api/v2/tickets')
+    );
+    expect(zendeskCall).toBeTruthy();
+    const ticketPayload = JSON.parse(zendeskCall![1].body);
+    expect(ticketPayload.ticket.requester.email).toBe('parent@example.com');
+    expect(ticketPayload.ticket.tags).toContain('age-review');
+
+    // Ticket ID was stored back on the case
+    const storeCall = db.prepare.mock.calls.find(
+      (call: string[]) => call[0]?.includes('zendesk_ticket_id')
+    );
+    expect(storeCall).toBeTruthy();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('succeeds even when Zendesk ticket creation fails', async () => {
+    const c = makeCase({ state: 'restricted_pending_user_response' });
+    const db = {
+      prepare: vi.fn().mockImplementation((sql: string) => ({
+        bind: vi.fn().mockReturnValue({
+          first: vi.fn().mockResolvedValue(
+            sql.includes('WHERE id = ? AND pubkey = ?') ? c : null
+          ),
+          run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+        }),
+      })),
+    };
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('Internal Server Error'),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const req = new Request('https://api.test/v1/minor-review-cases/case-1/parent-contact', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'parent@example.com' }),
+    });
+    const res = await handleParentContact(req, 'case-1', c.pubkey, {
+      DB: db as unknown as D1Database,
+      ZENDESK_SUBDOMAIN: 'test',
+      ZENDESK_API_TOKEN: 'tok',
+      ZENDESK_EMAIL: 'agent@test.com',
+    }, corsHeaders);
+
+    // Still succeeds — Zendesk is non-critical
+    expect(res.status).toBe(200);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('skips Zendesk when credentials missing', async () => {
+    const c = makeCase({ state: 'restricted_pending_user_response' });
+    const db = {
+      prepare: vi.fn().mockImplementation((sql: string) => ({
+        bind: vi.fn().mockReturnValue({
+          first: vi.fn().mockResolvedValue(
+            sql.includes('WHERE id = ? AND pubkey = ?') ? c : null
+          ),
+          run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+        }),
+      })),
+    };
+
+    const mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+
+    const req = new Request('https://api.test/v1/minor-review-cases/case-1/parent-contact', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'parent@example.com' }),
+    });
+    const res = await handleParentContact(req, 'case-1', c.pubkey, {
+      DB: db as unknown as D1Database,
+    }, corsHeaders);
+
+    expect(res.status).toBe(200);
+    // No Zendesk API call made
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('skips ticket creation when case already has a zendesk_ticket_id', async () => {
+    const c = makeCase({ state: 'restricted_pending_user_response', zendesk_ticket_id: 99 });
+    const db = {
+      prepare: vi.fn().mockImplementation((sql: string) => ({
+        bind: vi.fn().mockReturnValue({
+          first: vi.fn().mockResolvedValue(
+            sql.includes('WHERE id = ? AND pubkey = ?') ? c : null
+          ),
+          run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+        }),
+      })),
+    };
+
+    const mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+
+    const req = new Request('https://api.test/v1/minor-review-cases/case-1/parent-contact', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'parent@example.com' }),
+    });
+    const res = await handleParentContact(req, 'case-1', c.pubkey, {
+      DB: db as unknown as D1Database,
+      ZENDESK_SUBDOMAIN: 'test',
+      ZENDESK_API_TOKEN: 'tok',
+      ZENDESK_EMAIL: 'agent@test.com',
+    }, corsHeaders);
+
+    expect(res.status).toBe(200);
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+});
+
+// -- syncAgeReviewTicketResolution ---------------------------------------------
+
+describe('syncAgeReviewTicketResolution', () => {
+  it('returns early when case has no zendesk_ticket_id', async () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+
+    const db = {
+      prepare: vi.fn().mockImplementation(() => ({
+        bind: vi.fn().mockReturnValue({
+          first: vi.fn().mockResolvedValue({ zendesk_ticket_id: null }),
+        }),
+      })),
+    };
+
+    await syncAgeReviewTicketResolution('case-1', 'cleared', 'All good', {
+      DB: db as unknown as D1Database,
+      ZENDESK_SUBDOMAIN: 'test',
+      ZENDESK_API_TOKEN: 'tok',
+      ZENDESK_EMAIL: 'agent@test.com',
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it('solves Zendesk ticket with internal note on resolution', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const db = {
+      prepare: vi.fn().mockImplementation(() => ({
+        bind: vi.fn().mockReturnValue({
+          first: vi.fn().mockResolvedValue({ zendesk_ticket_id: 42 }),
+        }),
+      })),
+    };
+
+    await syncAgeReviewTicketResolution('case-1', 'denied_closed', 'Expired', {
+      DB: db as unknown as D1Database,
+      ZENDESK_SUBDOMAIN: 'test',
+      ZENDESK_API_TOKEN: 'tok',
+      ZENDESK_EMAIL: 'agent@test.com',
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/api/v2/tickets/42');
+    const payload = JSON.parse(opts.body as string);
+    expect(payload.ticket.status).toBe('solved');
+    expect(payload.ticket.comment.public).toBe(false);
+    expect(payload.ticket.comment.body).toContain('denied_closed');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('includes custom fields when env vars are set', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const db = {
+      prepare: vi.fn().mockImplementation(() => ({
+        bind: vi.fn().mockReturnValue({
+          first: vi.fn().mockResolvedValue({ zendesk_ticket_id: 42 }),
+        }),
+      })),
+    };
+
+    await syncAgeReviewTicketResolution('case-1', 'cleared', null, {
+      DB: db as unknown as D1Database,
+      ZENDESK_SUBDOMAIN: 'test',
+      ZENDESK_API_TOKEN: 'tok',
+      ZENDESK_EMAIL: 'agent@test.com',
+      ZENDESK_FIELD_CATEGORY: '12345',
+      ZENDESK_FIELD_ISSUE: '67890',
+    });
+
+    const payload = JSON.parse((mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string);
+    expect(payload.ticket.custom_fields).toEqual([
+      { id: 12345, value: 'trust___safety' },
+      { id: 67890, value: 'age_review' },
+    ]);
+
+    vi.unstubAllGlobals();
+  });
+});
+
+// -- handleAgeReviewReplyWebhook ------------------------------------------------
+
+describe('handleAgeReviewReplyWebhook', () => {
+  it('transitions pending case to submitted_for_review', async () => {
+    const c = makeCase({
+      state: 'restricted_pending_parental_consent',
+      zendesk_ticket_id: 42,
+    });
+    const runMock = vi.fn().mockResolvedValue({ meta: { changes: 1 } });
+    const db = {
+      prepare: vi.fn().mockImplementation((sql: string) => ({
+        bind: vi.fn().mockReturnValue({
+          first: vi.fn().mockResolvedValue(
+            sql.includes('zendesk_ticket_id') ? c : null
+          ),
+          run: runMock,
+        }),
+      })),
+    };
+
+    const req = new Request('https://api.test/api/zendesk/age-review-reply', {
+      method: 'POST',
+      body: JSON.stringify({ ticket_id: 42 }),
+    });
+    const res = await handleAgeReviewReplyWebhook(req, { DB: db as unknown as D1Database }, corsHeaders);
+    const body = await res.json() as { success: boolean; new_state: string };
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.new_state).toBe('submitted_for_review');
+
+    const updateCall = db.prepare.mock.calls.find(
+      (call: string[]) => call[0]?.includes('submitted_for_review')
+    );
+    expect(updateCall).toBeTruthy();
+    expect(updateCall![0]).toContain('clock_paused = 1');
+  });
+
+  it('re-pauses clock when moderator had resumed it', async () => {
+    const c = makeCase({
+      state: 'restricted_pending_parental_consent',
+      zendesk_ticket_id: 42,
+      clock_paused: 0,
+      deadline_at: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+    const runMock = vi.fn().mockResolvedValue({ meta: { changes: 1 } });
+    const boundValues: unknown[] = [];
+    const db = {
+      prepare: vi.fn().mockImplementation((sql: string) => ({
+        bind: vi.fn().mockImplementation((...args: unknown[]) => {
+          if (sql.includes('submitted_for_review')) boundValues.push(...args);
+          return {
+            first: vi.fn().mockResolvedValue(
+              sql.includes('zendesk_ticket_id') ? c : null
+            ),
+            run: runMock,
+          };
+        }),
+      })),
+    };
+
+    const req = new Request('https://api.test/api/zendesk/age-review-reply', {
+      method: 'POST',
+      body: JSON.stringify({ ticket_id: 42 }),
+    });
+    const res = await handleAgeReviewReplyWebhook(req, { DB: db as unknown as D1Database }, corsHeaders);
+    expect(res.status).toBe(200);
+
+    // Should have bound an ISO timestamp and remaining days (~5)
+    expect(boundValues.length).toBeGreaterThanOrEqual(2);
+    const remainingDays = boundValues[1] as number;
+    expect(remainingDays).toBeGreaterThan(4);
+    expect(remainingDays).toBeLessThan(6);
+  });
+
+  it('returns 404 when no case linked to ticket', async () => {
+    const db = {
+      prepare: vi.fn().mockImplementation(() => ({
+        bind: vi.fn().mockReturnValue({
+          first: vi.fn().mockResolvedValue(null),
+        }),
+      })),
+    };
+
+    const req = new Request('https://api.test/api/zendesk/age-review-reply', {
+      method: 'POST',
+      body: JSON.stringify({ ticket_id: 999 }),
+    });
+    const res = await handleAgeReviewReplyWebhook(req, { DB: db as unknown as D1Database }, corsHeaders);
+    expect(res.status).toBe(404);
+  });
+
+  it('does not transition if case is not in pending state', async () => {
+    const c = makeCase({
+      state: 'under_moderator_review',
+      zendesk_ticket_id: 42,
+    });
+    const db = {
+      prepare: vi.fn().mockImplementation((sql: string) => ({
+        bind: vi.fn().mockReturnValue({
+          first: vi.fn().mockResolvedValue(
+            sql.includes('zendesk_ticket_id') ? c : null
+          ),
+          run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+        }),
+      })),
+    };
+
+    const req = new Request('https://api.test/api/zendesk/age-review-reply', {
+      method: 'POST',
+      body: JSON.stringify({ ticket_id: 42 }),
+    });
+    const res = await handleAgeReviewReplyWebhook(req, { DB: db as unknown as D1Database }, corsHeaders);
+    const body = await res.json() as { success: boolean; message: string };
+
+    expect(res.status).toBe(200);
+    expect(body.message).toContain('not in a state that can advance');
+  });
+
+  it('returns 400 when ticket_id missing', async () => {
+    const db = createMockDb([]);
+    const req = new Request('https://api.test/api/zendesk/age-review-reply', {
+      method: 'POST',
+      body: JSON.stringify({}),
+    });
+    const res = await handleAgeReviewReplyWebhook(req, { DB: db as unknown as D1Database }, corsHeaders);
+    expect(res.status).toBe(400);
   });
 });

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -13,6 +13,11 @@ import {
 interface AgeReviewEnv {
   DB?: D1Database;
   SLACK_WEBHOOK_URL?: string;
+  ZENDESK_SUBDOMAIN?: string;
+  ZENDESK_API_TOKEN?: string;
+  ZENDESK_EMAIL?: string;
+  ZENDESK_FIELD_CATEGORY?: string;
+  ZENDESK_FIELD_ISSUE?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -175,6 +180,18 @@ export async function handleUpdateAgeReviewCase(
 
   const updated = await env.DB.prepare('SELECT * FROM age_review_cases WHERE id = ?')
     .bind(caseId).first<AgeReviewCase>();
+
+  // Non-critical: sync Zendesk ticket when case reaches terminal state
+  const newState = (body.state as AgeReviewState) ?? existing.state;
+  if (TERMINAL_STATES.includes(newState)) {
+    try {
+      const note = (body.resolution_note as string | undefined) ?? existing.resolution_note;
+      await syncAgeReviewTicketResolution(caseId, newState, note ?? null, env);
+    } catch (error) {
+      console.error('[age-review] Failed to sync Zendesk ticket resolution:', error);
+    }
+  }
+
   return json({ success: true, case: updated }, 200, corsHeaders);
 }
 
@@ -308,7 +325,196 @@ export async function handleParentContact(
     `).bind(body.email, now.toISOString(), remainingDays, caseId).run();
   }
 
+  // Non-critical: create Zendesk ticket for parent outreach (skip if one already exists)
+  if (activeCase.zendesk_ticket_id) {
+    console.log(`[age-review] Case ${caseId} already has Zendesk ticket #${activeCase.zendesk_ticket_id}, skipping creation`);
+  } else {
+    try {
+      await createAgeReviewTicket(caseId, body.email, activeCase.suspected_age_band as AgeBand, env);
+    } catch (error) {
+      console.error('[age-review] Failed to create Zendesk ticket:', error);
+    }
+  }
+
   return json({ success: true }, 200, corsHeaders);
+}
+
+// ---------------------------------------------------------------------------
+// Zendesk integration
+// ---------------------------------------------------------------------------
+
+const BAND_DISPLAY: Record<AgeBand, string> = {
+  under_13: 'Under 13',
+  age_13_15: '13-15',
+  age_16_plus_claimed: '16+ (claimed)',
+};
+
+async function createAgeReviewTicket(
+  caseId: string,
+  parentEmail: string,
+  ageBand: AgeBand,
+  env: AgeReviewEnv,
+): Promise<void> {
+  if (!env.ZENDESK_SUBDOMAIN || !env.ZENDESK_API_TOKEN || !env.ZENDESK_EMAIL) {
+    console.warn('[age-review] Missing Zendesk credentials, skipping ticket creation');
+    return;
+  }
+  if (!env.DB) return;
+
+  const auth = btoa(`${env.ZENDESK_EMAIL}/token:${env.ZENDESK_API_TOKEN}`);
+  const url = `https://${env.ZENDESK_SUBDOMAIN}.zendesk.com/api/v2/tickets`;
+
+  const subject = `Age review: parental verification needed [${caseId}]`;
+  const body = [
+    'Hello,',
+    '',
+    'We received a report that an account on Divine may belong to a minor in the ' +
+      `${BAND_DISPLAY[ageBand]} age range. As part of our safety process, we need a ` +
+      'parent or guardian to verify they are aware of and approve this account.',
+    '',
+    'Please reply to this email to confirm you are the parent or legal guardian of the account holder.',
+    '',
+    'If you have questions, you can reply directly to this email or contact us at contact@divine.video.',
+    '',
+    'Thank you,',
+    'Divine Trust & Safety',
+  ].join('\n');
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Basic ${auth}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      ticket: {
+        subject,
+        comment: { body, public: true },
+        requester: { email: parentEmail, name: 'Parent/Guardian' },
+        tags: ['age-review', `age-band-${ageBand}`],
+        priority: 'high',
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text();
+    throw new Error(`Zendesk ticket creation failed: ${res.status} - ${errorText}`);
+  }
+
+  const data = await res.json() as { ticket?: { id: number } };
+  if (data.ticket?.id) {
+    await env.DB.prepare(
+      'UPDATE age_review_cases SET zendesk_ticket_id = ? WHERE id = ?'
+    ).bind(data.ticket.id, caseId).run();
+    console.log(`[age-review] Created Zendesk ticket #${data.ticket.id} for case ${caseId}`);
+  }
+}
+
+export async function syncAgeReviewTicketResolution(
+  caseId: string,
+  state: AgeReviewState,
+  resolutionNote: string | null,
+  env: AgeReviewEnv,
+): Promise<void> {
+  if (!env.DB || !env.ZENDESK_SUBDOMAIN || !env.ZENDESK_API_TOKEN || !env.ZENDESK_EMAIL) return;
+
+  const row = await env.DB.prepare(
+    'SELECT zendesk_ticket_id FROM age_review_cases WHERE id = ?'
+  ).bind(caseId).first<{ zendesk_ticket_id: number | null }>();
+
+  if (!row?.zendesk_ticket_id) return;
+
+  const ticketId = row.zendesk_ticket_id;
+  const auth = btoa(`${env.ZENDESK_EMAIL}/token:${env.ZENDESK_API_TOKEN}`);
+  const url = `https://${env.ZENDESK_SUBDOMAIN}.zendesk.com/api/v2/tickets/${ticketId}`;
+
+  const noteLines = [
+    `Age review case ${caseId} resolved: **${state}**`,
+  ];
+  if (resolutionNote) noteLines.push(`Note: ${resolutionNote}`);
+
+  const payload: Record<string, unknown> = {
+    ticket: {
+      comment: { body: noteLines.join('\n'), public: false },
+      status: 'solved',
+      assignee_email: env.ZENDESK_EMAIL,
+    },
+  };
+
+  // Required fields for solving (same pattern as addZendeskInternalNote in index.ts)
+  if (env.ZENDESK_FIELD_CATEGORY && env.ZENDESK_FIELD_ISSUE) {
+    (payload.ticket as Record<string, unknown>).custom_fields = [
+      { id: parseInt(env.ZENDESK_FIELD_CATEGORY, 10), value: 'trust___safety' },
+      { id: parseInt(env.ZENDESK_FIELD_ISSUE, 10), value: 'age_review' },
+    ];
+  }
+
+  // Catches Zendesk API/network errors here; callers also wrap in try/catch for unexpected errors (e.g. D1 failure on the SELECT above)
+  try {
+    const res = await fetch(url, {
+      method: 'PUT',
+      headers: {
+        'Authorization': `Basic ${auth}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      const errorText = await res.text();
+      console.error(`[age-review] Failed to resolve Zendesk ticket #${ticketId}: ${res.status} - ${errorText}`);
+    }
+  } catch (error) {
+    console.error('[age-review] Error resolving Zendesk ticket:', error);
+  }
+}
+
+export async function handleAgeReviewReplyWebhook(
+  request: Request,
+  env: AgeReviewEnv,
+  corsHeaders: Record<string, string>,
+): Promise<Response> {
+  if (!env.DB) return json({ success: false, error: 'Database not configured' }, 500, corsHeaders);
+
+  const body = await request.json() as { ticket_id?: number | string };
+  const rawTicketId = body.ticket_id;
+  const ticketId = typeof rawTicketId === 'string' ? parseInt(rawTicketId, 10) : rawTicketId;
+  if (!ticketId || Number.isNaN(ticketId)) {
+    return json({ success: false, error: 'ticket_id is required' }, 400, corsHeaders);
+  }
+
+  const activeCase = await env.DB.prepare(
+    `SELECT * FROM age_review_cases WHERE zendesk_ticket_id = ? AND state NOT IN (${TERMINAL_STATES.map(() => '?').join(',')})`
+  ).bind(ticketId, ...TERMINAL_STATES).first<AgeReviewCase>();
+
+  if (!activeCase) {
+    return json({ success: false, error: 'No active case linked to this ticket' }, 404, corsHeaders);
+  }
+
+  const allowed = VALID_TRANSITIONS[activeCase.state as AgeReviewState];
+  if (!allowed?.includes('submitted_for_review')) {
+    return json({ success: true, message: 'Case not in a state that can advance to submitted_for_review' }, 200, corsHeaders);
+  }
+
+  const now = new Date();
+  const deadline = activeCase.deadline_at ? new Date(activeCase.deadline_at) : null;
+  const remainingDays = activeCase.clock_paused
+    ? activeCase.remaining_days_when_paused
+    : deadline ? (deadline.getTime() - now.getTime()) / (24 * 60 * 60 * 1000) : DEADLINE_DAYS;
+
+  await env.DB.prepare(`
+    UPDATE age_review_cases
+    SET state = 'submitted_for_review',
+        clock_paused = 1,
+        clock_paused_at = ?,
+        remaining_days_when_paused = ?,
+        updated_at = datetime('now')
+    WHERE id = ?
+  `).bind(now.toISOString(), remainingDays, activeCase.id).run();
+
+  console.log(`[age-review] Parent replied on ticket #${ticketId}, case ${activeCase.id} → submitted_for_review (clock paused)`);
+
+  return json({ success: true, case_id: activeCase.id, new_state: 'submitted_for_review' }, 200, corsHeaders);
 }
 
 // ---------------------------------------------------------------------------
@@ -359,6 +565,11 @@ export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> 
       WHERE id = ?
     `).bind(row.id).run();
     console.log(`[age-review] Auto-closed expired case ${row.id} for ${row.pubkey}`);
+    try {
+      await syncAgeReviewTicketResolution(row.id, 'denied_closed', 'Auto-closed: deadline expired with no response', env);
+    } catch (error) {
+      console.error(`[age-review] Failed to sync Zendesk for auto-closed case ${row.id}:`, error);
+    }
   }
 
   if (expired.results.length > 0 && env.SLACK_WEBHOOK_URL) {

--- a/worker/src/db.ts
+++ b/worker/src/db.ts
@@ -74,13 +74,25 @@ export async function ensureSchema(db: D1Database): Promise<void> {
     )
   `).run();
 
+  // Add zendesk_ticket_id to existing tables that were created without it
+  try {
+    await db.prepare(`ALTER TABLE age_review_cases ADD COLUMN zendesk_ticket_id INTEGER`).run();
+  } catch {
+    // Column already exists
+  }
+
   try {
     await db.prepare(`CREATE INDEX IF NOT EXISTS idx_age_review_pubkey ON age_review_cases(pubkey)`).run();
     await db.prepare(`CREATE INDEX IF NOT EXISTS idx_age_review_state ON age_review_cases(state)`).run();
     await db.prepare(`CREATE INDEX IF NOT EXISTS idx_age_review_deadline ON age_review_cases(deadline_at)`).run();
-    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_age_review_zendesk_ticket ON age_review_cases(zendesk_ticket_id)`).run();
   } catch {
     // Indexes already exist
+  }
+
+  try {
+    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_age_review_zendesk_ticket ON age_review_cases(zendesk_ticket_id)`).run();
+  } catch {
+    // Index already exists
   }
 
 }

--- a/worker/src/db.ts
+++ b/worker/src/db.ts
@@ -68,6 +68,7 @@ export async function ensureSchema(db: D1Database): Promise<void> {
       moderator_pubkey TEXT,
       resolution_note TEXT,
       last_alerted_at TEXT,
+      zendesk_ticket_id INTEGER,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT DEFAULT CURRENT_TIMESTAMP
     )
@@ -77,6 +78,7 @@ export async function ensureSchema(db: D1Database): Promise<void> {
     await db.prepare(`CREATE INDEX IF NOT EXISTS idx_age_review_pubkey ON age_review_cases(pubkey)`).run();
     await db.prepare(`CREATE INDEX IF NOT EXISTS idx_age_review_state ON age_review_cases(state)`).run();
     await db.prepare(`CREATE INDEX IF NOT EXISTS idx_age_review_deadline ON age_review_cases(deadline_at)`).run();
+    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_age_review_zendesk_ticket ON age_review_cases(zendesk_ticket_id)`).run();
   } catch {
     // Indexes already exist
   }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -20,6 +20,7 @@ import {
   handleUpdateAgeReviewCase,
   handleGetModerationStatus,
   handleParentContact,
+  handleAgeReviewReplyWebhook,
   checkAgeReviewDeadlines,
 } from './age-review';
 
@@ -51,6 +52,7 @@ interface Env {
   ZENDESK_PREAUTH_SECRET?: string;  // HMAC secret for pre-auth token generation/verification
   ZENDESK_WEBHOOK_SECRET?: string;  // For /api/zendesk/webhook
   ZENDESK_PARSE_REPORT_SECRET?: string;  // For /api/zendesk/parse-report
+  ZENDESK_AGE_REVIEW_WEBHOOK_SECRET?: string;  // For /api/zendesk/age-review-reply
   ZENDESK_API_TOKEN?: string;
   ZENDESK_EMAIL?: string;
   ZENDESK_FIELD_ACTION_STATUS?: string;
@@ -2077,6 +2079,22 @@ async function handleZendeskRoutes(
   // Webhook endpoint uses signature verification instead of JWT
   if (subPath === '/webhook' && request.method === 'POST') {
     return handleZendeskWebhook(request, env, corsHeaders);
+  }
+
+  // Age review: parent replied to Zendesk ticket
+  if (subPath === '/age-review-reply' && request.method === 'POST') {
+    const bodyText = await request.text();
+    if (!await verifyZendeskWebhook(request, bodyText, env.ZENDESK_AGE_REVIEW_WEBHOOK_SECRET)) {
+      return jsonResponse({ success: false, error: 'Invalid webhook signature' }, 401, corsHeaders);
+    }
+    if (env.DB) await ensureSchemaOnce(env.DB);
+    // Body was consumed by request.text() for signature verification; reconstruct
+    const syntheticRequest = new Request(request.url, {
+      method: request.method,
+      headers: request.headers,
+      body: bodyText,
+    });
+    return handleAgeReviewReplyWebhook(syntheticRequest, env, corsHeaders);
   }
 
   // Parse report endpoint - extracts Nostr IDs from ticket description, stores mapping, adds links


### PR DESCRIPTION
## Summary

Closes #68. Fast follow on PR #67 (age review clock).

- **Outbound**: Auto-creates Zendesk ticket (parent as requester) when parent email is submitted via mobile endpoint. Ticket ID stored on the case for bidirectional linking.
- **Inbound**: New webhook endpoint `POST /api/zendesk/age-review-reply` -- detects parent replies and advances case to `submitted_for_review`.
- **Resolution sync**: When moderator clears/denies a case with a linked ticket, adds internal note and auto-solves the Zendesk ticket.
- All Zendesk interactions are non-critical side effects (fire-and-forget with logging).
- **ReportWatcher log cleanup**: Expands truncated Nostr IDs (pubkeys, event IDs) to full 64-char hex in log lines. Truncated IDs are useless for debugging -- caught by our own code review as a violation of the project's "do not truncate Nostr IDs" guardrail (CLAUDE.md). Included here since the age-review case creation logs were already being touched.

### Zendesk-side config needed after merge

- Trigger: on tickets tagged `age-review` where requester replied, fire webhook to `POST /api/zendesk/age-review-reply` with `{ "ticket_id": {{ticket.id}} }`
- **Secret**: `ZENDESK_AGE_REVIEW_WEBHOOK_SECRET` -- separate from the existing `ZENDESK_WEBHOOK_SECRET`. Must be configured in the Cloudflare Secrets Store and matched in the Zendesk webhook trigger.

### Migration

`0008_age_review_zendesk.sql` -- adds `zendesk_ticket_id` column to `age_review_cases`. `ensureSchema()` also self-heals existing tables via `ALTER TABLE ADD COLUMN`.

## Test plan

- [x] 7 new tests: ticket creation (success, failure, missing creds), webhook handler (transition, no match, non-pending state, missing ticket_id)
- [x] All 32 age-review tests pass
- [x] `tsc --noEmit` clean (frontend + worker, excluding pre-existing worker issues)
- [ ] Deploy to staging and verify ticket creation with test Zendesk instance
- [ ] Configure Zendesk trigger and verify inbound webhook flow