### PR TITLE
fix: resolve SERVICE_API_TOKEN from Secrets Store before use

### DIFF
--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import worker from './index';
+import { describe, expect, it, vi } from 'vitest';
+import worker, { notifyModerationService } from './index';
 
 const env = {
   ALLOWED_ORIGINS: 'https://app.divine.video,https://*.openvine-app.pages.dev',
@@ -7,6 +7,21 @@ const env = {
 } as never;
 
 const ctx = {} as ExecutionContext;
+
+function makeModerateMediaEnv(serviceApiToken: string | { get: () => Promise<string> }) {
+  return {
+    ALLOWED_ORIGINS: 'https://app.divine.video',
+    RELAY_URL: 'wss://relay.divine.video',
+    ADMIN_API_KEY: 'test-admin-key',
+    MODERATION_ADMIN_URL: 'https://moderation-api.divine.video',
+    SERVICE_API_TOKEN: serviceApiToken,
+    MODERATION_API: {
+      fetch: vi.fn(async () => {
+        return new Response(JSON.stringify({ success: true, sha256: 'abc123', action: 'AGE_RESTRICTED' }), { status: 200 });
+      }),
+    },
+  } as never;
+}
 
 describe('relay manager cors', () => {
   it('echoes app origin on preflight', async () => {
@@ -61,5 +76,90 @@ describe('relay manager cors', () => {
     expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type, Authorization, X-Requested-With, Range, X-Admin-Key, CF-Access-Client-Id, CF-Access-Client-Secret');
     expect(response.headers.get('Access-Control-Max-Age')).toBe('86400');
     expect(response.headers.get('Vary')).toContain('Origin');
+  });
+});
+
+describe('SERVICE_API_TOKEN secrets store resolution', () => {
+  it('resolves plain string token', async () => {
+    const testEnv = makeModerateMediaEnv('my-secret-token');
+    const response = await worker.fetch(
+      new Request('https://api-relay-prod.divine.video/api/moderate-media', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Key': 'test-admin-key',
+          Origin: 'https://app.divine.video',
+        },
+        body: JSON.stringify({ sha256: 'abc123', action: 'AGE_RESTRICTED' }),
+      }),
+      testEnv,
+      ctx,
+    );
+
+    expect(response.status).toBe(200);
+    const mockFetch = (testEnv as unknown as { MODERATION_API: { fetch: ReturnType<typeof vi.fn> } }).MODERATION_API.fetch;
+    const forwardedRequest = mockFetch.mock.calls[0][0] as Request;
+    expect(forwardedRequest.headers.get('Authorization')).toBe('Bearer my-secret-token');
+  });
+
+  it('resolves Secrets Store binding via .get()', async () => {
+    const secretsStoreBinding = { get: vi.fn(async () => 'resolved-secret') };
+    const testEnv = makeModerateMediaEnv(secretsStoreBinding);
+    const response = await worker.fetch(
+      new Request('https://api-relay-prod.divine.video/api/moderate-media', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Key': 'test-admin-key',
+          Origin: 'https://app.divine.video',
+        },
+        body: JSON.stringify({ sha256: 'abc123', action: 'AGE_RESTRICTED' }),
+      }),
+      testEnv,
+      ctx,
+    );
+
+    expect(response.status).toBe(200);
+    const mockFetch = (testEnv as unknown as { MODERATION_API: { fetch: ReturnType<typeof vi.fn> } }).MODERATION_API.fetch;
+    const forwardedRequest = mockFetch.mock.calls[0][0] as Request;
+    expect(forwardedRequest.headers.get('Authorization')).toBe('Bearer resolved-secret');
+    expect(secretsStoreBinding.get).toHaveBeenCalledOnce();
+  });
+
+  it('returns 500 when Secrets Store binding resolves to null', async () => {
+    const secretsStoreBinding = { get: vi.fn(async () => null) };
+    const testEnv = makeModerateMediaEnv(secretsStoreBinding as never);
+    const response = await worker.fetch(
+      new Request('https://api-relay-prod.divine.video/api/moderate-media', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Key': 'test-admin-key',
+          Origin: 'https://app.divine.video',
+        },
+        body: JSON.stringify({ sha256: 'abc123', action: 'AGE_RESTRICTED' }),
+      }),
+      testEnv,
+      ctx,
+    );
+
+    expect(response.status).toBe(500);
+    const body = await response.json() as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('SERVICE_API_TOKEN');
+  });
+});
+
+describe('notifyModerationService null token', () => {
+  it('throws when Secrets Store binding resolves to null', async () => {
+    const nullBinding = { get: vi.fn(async () => null) };
+    const testEnv = {
+      SERVICE_API_TOKEN: nullBinding,
+      MODERATION_ADMIN_URL: 'https://moderation-api.divine.video',
+    } as never;
+
+    await expect(
+      notifyModerationService(testEnv, 'deadbeef', 'ACCOUNT_SUSPENDED', 'test reason')
+    ).rejects.toThrow('SERVICE_API_TOKEN');
   });
 });

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
-import worker, { notifyModerationService } from './index';
+import worker from './index';
 
 const env = {
   ALLOWED_ORIGINS: 'https://app.divine.video,https://*.openvine-app.pages.dev',
   RELAY_URL: 'wss://relay.divine.video',
 } as never;
+
+const TEST_NSEC = 'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5';
 
 const ctx = {} as ExecutionContext;
 
@@ -20,6 +22,17 @@ function makeModerateMediaEnv(serviceApiToken: string | { get: () => Promise<str
         return new Response(JSON.stringify({ success: true, sha256: 'abc123', action: 'AGE_RESTRICTED' }), { status: 200 });
       }),
     },
+  } as never;
+}
+
+function makeRelayRpcEnv(serviceApiToken: string | { get: () => Promise<string> }) {
+  return {
+    ALLOWED_ORIGINS: 'https://app.divine.video',
+    RELAY_URL: 'wss://relay.divine.video',
+    ADMIN_API_KEY: 'test-admin-key',
+    MODERATION_ADMIN_URL: 'https://moderation-api.divine.video',
+    SERVICE_API_TOKEN: serviceApiToken,
+    NOSTR_NSEC: TEST_NSEC,
   } as never;
 }
 
@@ -151,15 +164,44 @@ describe('SERVICE_API_TOKEN secrets store resolution', () => {
 });
 
 describe('notifyModerationService null token', () => {
-  it('throws when Secrets Store binding resolves to null', async () => {
+  it('logs and swallows null token errors on the non-critical DM path', async () => {
     const nullBinding = { get: vi.fn(async () => null) };
-    const testEnv = {
-      SERVICE_API_TOKEN: nullBinding,
-      MODERATION_ADMIN_URL: 'https://moderation-api.divine.video',
-    } as never;
+    const testEnv = makeRelayRpcEnv(nullBinding as never);
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ result: true }), { status: 200 })
+    );
 
-    await expect(
-      notifyModerationService(testEnv, 'deadbeef', 'ACCOUNT_SUSPENDED', 'test reason')
-    ).rejects.toThrow('SERVICE_API_TOKEN');
+    const response = await worker.fetch(
+      new Request('https://api-relay-prod.divine.video/api/relay-rpc', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Key': 'test-admin-key',
+          Origin: 'https://app.divine.video',
+        },
+        body: JSON.stringify({
+          method: 'banpubkey',
+          params: ['deadbeef', 'test reason'],
+        }),
+      }),
+      testEnv,
+      testCtx,
+    );
+
+    expect(response.status).toBe(200);
+    expect(waitUntil).toHaveBeenCalledOnce();
+    await waitUntil.mock.calls[0][0];
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[handleRelayRpc] DM notification error:',
+      expect.objectContaining({
+        message: expect.stringContaining('SERVICE_API_TOKEN'),
+      }),
+    );
+
+    fetchSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 });

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -64,7 +64,7 @@ interface Env {
   MANAGEMENT_URL?: string;   // Full URL override for NIP-86 management API (for local dev with HTTP)
   MODERATION_SERVICE_URL?: string;  // URL for public moderation API (check-result, status)
   MODERATION_ADMIN_URL?: string;    // URL for CF Access-protected moderation service (/api/v1/moderate, /api/v1/notify)
-  SERVICE_API_TOKEN?: string;       // Bearer token for moderation-service API auth (via service binding)
+  SERVICE_API_TOKEN?: string | SecretStoreSecret;  // Bearer token for moderation-service API auth (via Secrets Store)
   REALNESS_API_URL?: string;  // URL for AI detection/realness service
   FUNNELCAKE_API_URL?: string;  // Explicit Funnelcake REST API URL (derived from RELAY_URL if not set)
   // Durable Object bindings
@@ -136,7 +136,7 @@ async function getCfAccessCredentials(env: Env): Promise<{ clientId: string; cli
  * If a dedicated DM service is extracted later (support-trust-safety#118),
  * this function is the single call site to update.
  */
-async function notifyModerationService(
+export async function notifyModerationService(
   env: Env,
   recipientPubkey: string,
   action: string,
@@ -148,11 +148,15 @@ async function notifyModerationService(
     'Content-Type': 'application/json',
   };
 
-  if (env.MODERATION_API && env.SERVICE_API_TOKEN) {
-    // Service binding: authenticate via Bearer token
-    headers['Authorization'] = `Bearer ${env.SERVICE_API_TOKEN}`;
+  if (env.SERVICE_API_TOKEN) {
+    const token = typeof env.SERVICE_API_TOKEN === 'string'
+      ? env.SERVICE_API_TOKEN
+      : await env.SERVICE_API_TOKEN.get();
+    if (!token) {
+      throw new Error('SERVICE_API_TOKEN binding exists but resolved to empty — secret misconfigured');
+    }
+    headers['Authorization'] = `Bearer ${token}`;
   } else {
-    // HTTP fallback: authenticate via CF Access service token
     const cfAccess = await getCfAccessCredentials(env);
     if (!cfAccess) {
       console.warn('[notifyModerationService] No auth credentials configured, skipping DM');
@@ -1255,11 +1259,15 @@ async function handleModerateMedia(
       'Content-Type': 'application/json',
     };
 
-    if (env.MODERATION_API && env.SERVICE_API_TOKEN) {
-      // Service binding: authenticate via Bearer token
-      headers['Authorization'] = `Bearer ${env.SERVICE_API_TOKEN}`;
+    if (env.SERVICE_API_TOKEN) {
+      const token = typeof env.SERVICE_API_TOKEN === 'string'
+        ? env.SERVICE_API_TOKEN
+        : await env.SERVICE_API_TOKEN.get();
+      if (!token) {
+        return jsonResponse({ success: false, error: 'SERVICE_API_TOKEN binding exists but resolved to empty' }, 500, corsHeaders);
+      }
+      headers['Authorization'] = `Bearer ${token}`;
     } else {
-      // HTTP fallback: authenticate via CF Access service token
       const cfAccess = await getCfAccessCredentials(env);
       if (!cfAccess) {
         return jsonResponse({ success: false, error: 'CF_ACCESS credentials not configured' }, 500, corsHeaders);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -110,18 +110,20 @@ function getModerationAdminUrl(env: Env): string {
   return env.MODERATION_ADMIN_URL;
 }
 
+async function resolveSecret(binding: string | SecretStoreSecret | undefined): Promise<string | null> {
+  if (!binding) return null;
+  const value = typeof binding === 'string' ? binding : await binding.get();
+  return value ?? null;
+}
+
 /**
  * Resolve CF Access credentials from env (supports both plain strings and SecretStoreSecret bindings).
  */
 async function getCfAccessCredentials(env: Env): Promise<{ clientId: string; clientSecret: string } | null> {
   if (!env.CF_ACCESS_CLIENT_ID || !env.CF_ACCESS_CLIENT_SECRET) return null;
 
-  const clientId = typeof env.CF_ACCESS_CLIENT_ID === 'string'
-    ? env.CF_ACCESS_CLIENT_ID
-    : await env.CF_ACCESS_CLIENT_ID.get();
-  const clientSecret = typeof env.CF_ACCESS_CLIENT_SECRET === 'string'
-    ? env.CF_ACCESS_CLIENT_SECRET
-    : await env.CF_ACCESS_CLIENT_SECRET.get();
+  const clientId = await resolveSecret(env.CF_ACCESS_CLIENT_ID);
+  const clientSecret = await resolveSecret(env.CF_ACCESS_CLIENT_SECRET);
 
   if (!clientId || !clientSecret) return null;
   return { clientId, clientSecret };
@@ -131,12 +133,12 @@ async function getCfAccessCredentials(env: Env): Promise<{ clientId: string; cli
  * Notify moderation-service to send a DM to an affected user.
  * Non-critical side effect — caller must wrap in try/catch.
  *
- * Uses service binding (MODERATION_API) with Bearer token when available,
- * falls back to fetch() with CF Access headers.
+ * Uses Bearer auth when SERVICE_API_TOKEN is configured,
+ * falls back to CF Access headers otherwise.
  * If a dedicated DM service is extracted later (support-trust-safety#118),
  * this function is the single call site to update.
  */
-export async function notifyModerationService(
+async function notifyModerationService(
   env: Env,
   recipientPubkey: string,
   action: string,
@@ -149,9 +151,7 @@ export async function notifyModerationService(
   };
 
   if (env.SERVICE_API_TOKEN) {
-    const token = typeof env.SERVICE_API_TOKEN === 'string'
-      ? env.SERVICE_API_TOKEN
-      : await env.SERVICE_API_TOKEN.get();
+    const token = await resolveSecret(env.SERVICE_API_TOKEN);
     if (!token) {
       throw new Error('SERVICE_API_TOKEN binding exists but resolved to empty — secret misconfigured');
     }
@@ -1254,15 +1254,13 @@ async function handleModerateMedia(
       return jsonResponse({ success: false, error: 'Missing action' }, 400, corsHeaders);
     }
 
-    // Build auth headers: Bearer token for service binding, CF Access for HTTP fallback
+    // Build auth headers: Bearer when SERVICE_API_TOKEN is configured, CF Access otherwise
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
     };
 
     if (env.SERVICE_API_TOKEN) {
-      const token = typeof env.SERVICE_API_TOKEN === 'string'
-        ? env.SERVICE_API_TOKEN
-        : await env.SERVICE_API_TOKEN.get();
+      const token = await resolveSecret(env.SERVICE_API_TOKEN);
       if (!token) {
         return jsonResponse({ success: false, error: 'SERVICE_API_TOKEN binding exists but resolved to empty' }, 500, corsHeaders);
       }
@@ -1787,9 +1785,10 @@ async function handleMediaProxy(
     return jsonResponse({ success: false, error: 'BLOSSOM_WEBHOOK_SECRET not configured' }, 500, corsHeaders);
   }
 
-  const secret = typeof env.BLOSSOM_WEBHOOK_SECRET === 'string'
-    ? env.BLOSSOM_WEBHOOK_SECRET
-    : await env.BLOSSOM_WEBHOOK_SECRET.get();
+  const secret = await resolveSecret(env.BLOSSOM_WEBHOOK_SECRET);
+  if (!secret) {
+    return jsonResponse({ success: false, error: 'BLOSSOM_WEBHOOK_SECRET binding exists but resolved to empty' }, 500, corsHeaders);
+  }
 
   const cdnDomain = env.CDN_DOMAIN || 'media.divine.video';
   const upstreamUrl = `https://${cdnDomain}/admin/api/blob/${sha256.toLowerCase()}/content`;


### PR DESCRIPTION
## Summary

- `SERVICE_API_TOKEN` changed from a plain string secret to a Secrets Store binding, but code calling `.get()` clobbered, so moderation-service received `Bearer [object Object]` and returned 401
- Applies the same `typeof`/`.get()` resolution pattern used by `NOSTR_NSEC`, `CF_ACCESS_CLIENT_ID`, and `BLOSSOM_WEBHOOK_SECRET`
- Fixes both call sites: `handleModerateMedia` and `notifyModerationService`

## Test plan

- [ ] Deploy to staging, attempt age-restrict action from admin UI (currently 401)
- [ ] Verify DM notifications still fire on ban actions