### PR TITLE
feat: enrich age review UI with profile data

### DIFF
--- a/src/components/AgeReview.tsx
+++ b/src/components/AgeReview.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/select";
 import { Clock, RefreshCw, Filter, AlertTriangle } from "lucide-react";
 import { AgeReviewDetail } from "@/components/AgeReviewDetail";
+import { UserIdentifier } from "@/components/UserIdentifier";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import {
@@ -175,7 +176,7 @@ export function AgeReview() {
                   <div className="flex items-start justify-between gap-2">
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-1.5 mb-0.5">
-                        <code className="text-xs font-mono truncate" title={c.pubkey}>{c.pubkey}</code>
+                        <UserIdentifier pubkey={c.pubkey} variant="compact" showAvatar={false} linkToProfile={false} className="text-xs" />
                       </div>
                       <div className="flex items-center gap-1.5 flex-wrap">
                         <Badge variant="outline" className="text-[10px] h-4 px-1">

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -13,6 +13,10 @@ vi.mock('@/hooks/useAdminApi', () => ({
   }),
 }));
 
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({ data: undefined, isLoading: false }),
+}));
+
 function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
   return {
     id: 'case-1',

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -6,6 +6,7 @@ import { AgeReviewDetail } from './AgeReviewDetail';
 import type { AgeReviewCase, AgeBand, AgeReviewState } from '../../shared/age-review';
 
 const updateAgeReviewCase = vi.fn().mockResolvedValue({ success: true });
+const writeText = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('@/hooks/useAdminApi', () => ({
   useAdminApi: () => ({
@@ -59,6 +60,12 @@ function renderDetail(caseData: AgeReviewCase) {
 describe('AgeReviewDetail', () => {
   beforeEach(() => {
     updateAgeReviewCase.mockClear();
+    writeText.mockClear();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText,
+      },
+    });
   });
 
   it.each<[AgeBand, AgeReviewState]>([
@@ -72,6 +79,17 @@ describe('AgeReviewDetail', () => {
 
     await waitFor(() => {
       expect(updateAgeReviewCase).toHaveBeenCalledWith('case-1', { state: expectedState });
+    });
+  });
+
+  it('copies the raw hex pubkey from the moderator control', async () => {
+    const caseData = makeCase();
+    renderDetail(caseData);
+
+    fireEvent.click(screen.getByRole('button', { name: /Hex pubkey:/ }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(caseData.pubkey);
     });
   });
 });

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -21,11 +21,9 @@ import {
   XCircle,
   AlertTriangle,
   Loader2,
-  Copy,
-  Check,
   ExternalLink,
 } from "lucide-react";
-import { nip19 } from "nostr-tools";
+import { UserIdentifier } from "@/components/UserIdentifier";
 import {
   AGE_BANDS,
   TERMINAL_STATES,
@@ -85,7 +83,6 @@ export function AgeReviewDetail({ caseData: c }: Props) {
   const api = useAdminApi();
   const queryClient = useQueryClient();
   const [resolutionNote, setResolutionNote] = useState(c.resolution_note ?? "");
-  const [copiedField, setCopiedField] = useState<string | null>(null);
 
   useEffect(() => {
     setResolutionNote(c.resolution_note ?? "");
@@ -102,13 +99,6 @@ export function AgeReviewDetail({ caseData: c }: Props) {
     },
   });
 
-  const copyToClipboard = (text: string, field: string) => {
-    navigator.clipboard.writeText(text);
-    setCopiedField(field);
-    setTimeout(() => setCopiedField(null), 2000);
-  };
-
-  const npub = nip19.npubEncode(c.pubkey);
 
   return (
     <ScrollArea className="h-full">
@@ -143,26 +133,31 @@ export function AgeReviewDetail({ caseData: c }: Props) {
         {/* Identity */}
         <div className="space-y-1.5">
           <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Flagged User</h4>
-          <div className="flex items-center gap-1.5">
-            <code className="text-xs bg-muted px-1.5 py-0.5 rounded font-mono break-all">{npub}</code>
-            <button
-              onClick={() => copyToClipboard(c.pubkey, 'pubkey')}
-              className="text-muted-foreground hover:text-foreground"
-              title="Copy hex pubkey"
-            >
-              {copiedField === 'pubkey' ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-            </button>
-            <a
-              href={`/users/${c.pubkey}`}
-              className="text-muted-foreground hover:text-foreground"
-              title="View in Users tab"
-            >
-              <ExternalLink className="h-3 w-3" />
-            </a>
-          </div>
+          <UserIdentifier
+            pubkey={c.pubkey}
+            variant="block"
+            showAvatar={true}
+            avatarSize="md"
+            showCopyButton={true}
+            showNip05={true}
+            linkToProfile={true}
+          />
+          <a
+            href={`/users/${c.pubkey}`}
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            <ExternalLink className="h-3 w-3" />
+            View in Users tab
+          </a>
           {c.reporter_pubkey && (
-            <div className="text-xs text-muted-foreground">
-              Reported by: <code className="bg-muted px-1 py-0.5 rounded font-mono break-all">{c.reporter_pubkey}</code>
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span>Reported by:</span>
+              <UserIdentifier
+                pubkey={c.reporter_pubkey}
+                variant="compact"
+                showAvatar={false}
+                linkToProfile={false}
+              />
             </div>
           )}
           {c.parent_contact_email && (

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -23,6 +23,7 @@ import {
   Loader2,
   ExternalLink,
 } from "lucide-react";
+import { CopyableId } from "@/components/CopyableId";
 import { UserIdentifier } from "@/components/UserIdentifier";
 import {
   AGE_BANDS,
@@ -99,7 +100,6 @@ export function AgeReviewDetail({ caseData: c }: Props) {
     },
   });
 
-
   return (
     <ScrollArea className="h-full">
       <div className="space-y-4 p-4">
@@ -138,17 +138,27 @@ export function AgeReviewDetail({ caseData: c }: Props) {
             variant="block"
             showAvatar={true}
             avatarSize="md"
-            showCopyButton={true}
+            showCopyButton={false}
             showNip05={true}
             linkToProfile={true}
           />
-          <a
-            href={`/users/${c.pubkey}`}
-            className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-          >
-            <ExternalLink className="h-3 w-3" />
-            View in Users tab
-          </a>
+          <div className="flex flex-wrap items-center gap-2">
+            <CopyableId
+              value={c.pubkey}
+              type="hex"
+              size="xs"
+              label="Hex pubkey:"
+              truncateStart={16}
+              truncateEnd={8}
+            />
+            <a
+              href={`/users/${c.pubkey}`}
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+            >
+              <ExternalLink className="h-3 w-3" />
+              View in Users tab
+            </a>
+          </div>
           {c.reporter_pubkey && (
             <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
               <span>Reported by:</span>
@@ -157,6 +167,7 @@ export function AgeReviewDetail({ caseData: c }: Props) {
                 variant="compact"
                 showAvatar={false}
                 linkToProfile={false}
+                copyOnClick={false}
               />
             </div>
           )}

--- a/src/components/AppProvider.tsx
+++ b/src/components/AppProvider.tsx
@@ -31,7 +31,7 @@ export function AppProvider(props: AppProviderProps) {
     if (config.relayUrl?.includes('localhost') || config.relayUrl?.startsWith('ws://localhost')) {
       setConfig((prev) => ({ ...prev, relayUrl: defaultConfig.relayUrl }));
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [config.apiUrl, config.relayUrl, defaultConfig.apiUrl, defaultConfig.relayUrl, setConfig]);
 
   // Generic config updater with callback pattern
   const updateConfig = (updater: (currentConfig: AppConfig) => AppConfig) => {

--- a/src/components/EventsList.tsx
+++ b/src/components/EventsList.tsx
@@ -535,7 +535,7 @@ export function EventsList({ relayUrl }: EventsListProps) {
   }, [directEventLookup, searchMode]);
 
   // Flatten all pages into a single events array
-  const events = eventsData?.pages.flat() ?? [];
+  const events = useMemo(() => eventsData?.pages.flat() ?? [], [eventsData?.pages]);
 
   // Auto-load more when scrolling near bottom of the scroll area
   useEffect(() => {

--- a/src/components/UserIdentifier.test.tsx
+++ b/src/components/UserIdentifier.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { UserIdentifier } from './UserIdentifier';
+
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({ data: undefined, isLoading: false }),
+}));
+
+describe('UserIdentifier', () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    writeText.mockClear();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText,
+      },
+    });
+  });
+
+  it('does not copy by default in compact mode', () => {
+    render(
+      <UserIdentifier
+        pubkey={'a'.repeat(64)}
+        variant="compact"
+        showAvatar={false}
+        linkToProfile={false}
+      />
+    );
+
+    fireEvent.click(screen.getByText(/npub/i));
+
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('copies npub in compact mode when explicitly enabled', async () => {
+    render(
+      <UserIdentifier
+        pubkey={'a'.repeat(64)}
+        variant="compact"
+        showAvatar={false}
+        linkToProfile={false}
+        copyOnClick
+      />
+    );
+
+    fireEvent.click(screen.getByText(/npub/i));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledTimes(1);
+      expect(writeText.mock.calls[0][0]).toMatch(/^npub1/);
+    });
+  });
+});

--- a/src/components/UserIdentifier.tsx
+++ b/src/components/UserIdentifier.tsx
@@ -21,6 +21,7 @@ interface UserIdentifierProps {
   showAvatar?: boolean;
   avatarSize?: "sm" | "md" | "lg";
   showCopyButton?: boolean;
+  copyOnClick?: boolean;
   showNip05?: boolean;
   linkToProfile?: boolean;
   variant?: "inline" | "block" | "compact";
@@ -32,6 +33,7 @@ export function UserIdentifier({
   showAvatar = false,
   avatarSize = "sm",
   showCopyButton = true,
+  copyOnClick = false,
   showNip05 = true,
   linkToProfile = false,
   variant = "inline",
@@ -123,10 +125,11 @@ export function UserIdentifier({
             ) : (
               <span
                 className={cn(
-                  "inline-flex items-center gap-1 cursor-pointer hover:opacity-80",
+                  "inline-flex items-center gap-1",
+                  copyOnClick && "cursor-pointer hover:opacity-80",
                   className
                 )}
-                onClick={handleCopy}
+                onClick={copyOnClick ? handleCopy : undefined}
               >
                 {content}
                 {copied && <Check className="h-3 w-3 text-green-500" />}
@@ -142,9 +145,11 @@ export function UserIdentifier({
                 <p className="text-xs text-muted-foreground">{nip05}</p>
               )}
               <p className="text-xs font-mono break-all">{npub}</p>
-              <p className="text-xs text-muted-foreground">
-                {linkToProfile ? "Click to view profile" : "Click to copy"}
-              </p>
+              {(linkToProfile || copyOnClick) && (
+                <p className="text-xs text-muted-foreground">
+                  {linkToProfile ? "Click to view profile" : "Click to copy"}
+                </p>
+              )}
             </div>
           </TooltipContent>
         </Tooltip>


### PR DESCRIPTION
## Summary

- Replace raw hex pubkeys in Age Review list and detail views with `UserIdentifier` / `UserDisplayName` components
- Moderators now see display names, NIP-05, and avatars for flagged users and reporters
- Removes ~40 lines of duplicated clipboard/npub logic from `AgeReviewDetail`
- Adds `useAuthor` mock to `AgeReviewDetail` tests

Closes #73