### PR TITLE
feat: create Zendesk ticket on age review restriction

### DIFF
--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -714,7 +714,7 @@ describe('handleParentContact Zendesk integration', () => {
     vi.unstubAllGlobals();
   });
 
-  it('skips ticket creation when case already has a zendesk_ticket_id', async () => {
+  it('updates existing Zendesk ticket when case already has a zendesk_ticket_id', async () => {
     const c = makeCase({ state: 'restricted_pending_user_response', zendesk_ticket_id: 99 });
     const db = {
       prepare: vi.fn().mockImplementation((sql: string) => ({
@@ -727,7 +727,7 @@ describe('handleParentContact Zendesk integration', () => {
       })),
     };
 
-    const mockFetch = vi.fn();
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
     vi.stubGlobal('fetch', mockFetch);
 
     const req = new Request('https://api.test/v1/minor-review-cases/case-1/parent-contact', {
@@ -742,7 +742,13 @@ describe('handleParentContact Zendesk integration', () => {
     }, corsHeaders);
 
     expect(res.status).toBe(200);
-    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('https://test.zendesk.com/api/v2/tickets/99');
+    expect(opts.method).toBe('PUT');
+    const payload = JSON.parse(opts.body);
+    expect(payload.ticket.requester.email).toBe('parent@example.com');
+    expect(payload.ticket.comment.public).toBe(true);
 
     vi.unstubAllGlobals();
   });

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -250,6 +250,81 @@ describe('handleUpdateAgeReviewCase', () => {
 
     vi.unstubAllGlobals();
   });
+
+  it('creates an internal Zendesk ticket when transitioning into a restricted state', async () => {
+    const reviewCase = makeCase({
+      state: 'under_moderator_review',
+      suspected_age_band: 'age_16_plus_claimed',
+      deadline_at: '2026-05-30T12:00:00.000Z',
+    });
+    const updatedCase = {
+      ...reviewCase,
+      state: 'restricted_pending_support_email',
+    };
+
+    const bindCalls: Array<{ sql: string; params: unknown[] }> = [];
+    let selectCount = 0;
+    const db = {
+      prepare: vi.fn().mockImplementation((sql: string) => ({
+        bind: vi.fn().mockImplementation((...params: unknown[]) => {
+          bindCalls.push({ sql, params });
+          return {
+            first: vi.fn().mockImplementation(async () => {
+              if (sql === 'SELECT * FROM age_review_cases WHERE id = ?') {
+                selectCount += 1;
+                return selectCount === 1 ? reviewCase : updatedCase;
+              }
+              return null;
+            }),
+            run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+          };
+        }),
+      })),
+    };
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ ticket: { id: 321 } }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const req = new Request('https://api.test/api/age-review/cases/case-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ state: 'restricted_pending_support_email' }),
+    });
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', {
+      DB: db as unknown as D1Database,
+      ZENDESK_SUBDOMAIN: 'test',
+      ZENDESK_API_TOKEN: 'tok',
+      ZENDESK_EMAIL: 'agent@test.com',
+      ZENDESK_FIELD_CATEGORY: '1001',
+      ZENDESK_FIELD_ISSUE: '1002',
+      ZENDESK_FIELD_AGE_REVIEW_DEADLINE: '1003',
+    }, corsHeaders);
+    const body = await res.json() as { success: boolean; case: AgeReviewCase };
+
+    expect(res.status).toBe(200);
+    expect(body.case.zendesk_ticket_id).toBe(321);
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(mockFetch.mock.calls[0][0]).toBe('https://test.zendesk.com/api/v2/tickets');
+
+    const payload = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(payload.ticket.subject).toBe('Age review: 16+ (claimed) account restricted [case-1]');
+    expect(payload.ticket.comment.public).toBe(false);
+    expect(payload.ticket.tags).toEqual(['age-review', 'age-band-age_16_plus_claimed', 'internal']);
+    expect(payload.ticket.custom_fields).toEqual([
+      { id: 1001, value: 'trust___safety' },
+      { id: 1002, value: 'age_review' },
+      { id: 1003, value: '2026-05-30' },
+    ]);
+
+    const ticketStoreCall = bindCalls.find(
+      (call) => call.sql.includes('SET zendesk_ticket_id = ?') && call.params[0] === 321 && call.params[1] === 'case-1'
+    );
+    expect(ticketStoreCall).toBeTruthy();
+
+    vi.unstubAllGlobals();
+  });
 });
 
 // -- handleGetModerationStatus ------------------------------------------------

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -21,6 +21,11 @@ interface AgeReviewEnv {
   ZENDESK_FIELD_AGE_REVIEW_DEADLINE?: string;
 }
 
+interface ZendeskClientConfig {
+  auth: string;
+  baseUrl: string;
+}
+
 // ---------------------------------------------------------------------------
 // Admin API handlers (behind verifyAdminAccess)
 // ---------------------------------------------------------------------------
@@ -179,7 +184,7 @@ export async function handleUpdateAgeReviewCase(
     `UPDATE age_review_cases SET ${updates.join(', ')} WHERE id = ?`
   ).bind(...binds).run();
 
-  const updated = await env.DB.prepare('SELECT * FROM age_review_cases WHERE id = ?')
+  let updated = await env.DB.prepare('SELECT * FROM age_review_cases WHERE id = ?')
     .bind(caseId).first<AgeReviewCase>();
 
   // Non-critical: sync Zendesk ticket when case reaches terminal state
@@ -200,17 +205,19 @@ export async function handleUpdateAgeReviewCase(
     body.state &&
     (body.state as string).startsWith('restricted_') &&
     !existing.zendesk_ticket_id &&
-    updated &&
-    !updated.zendesk_ticket_id
+    !updated?.zendesk_ticket_id
   ) {
     try {
-      await createAgeReviewInternalTicket(
+      const zendeskTicketId = await createAgeReviewInternalTicket(
         caseId,
         existing.pubkey,
-        (updated.suspected_age_band ?? existing.suspected_age_band) as AgeBand,
-        updated.deadline_at ?? existing.deadline_at,
+        (updated?.suspected_age_band ?? existing.suspected_age_band) as AgeBand,
+        updated?.deadline_at ?? existing.deadline_at,
         env,
       );
+      if (updated && zendeskTicketId) {
+        updated = { ...updated, zendesk_ticket_id: zendeskTicketId };
+      }
     } catch (error) {
       console.error('[age-review] Failed to create internal Zendesk ticket:', error);
     }
@@ -385,24 +392,19 @@ const BAND_DISPLAY: Record<AgeBand, string> = {
   age_16_plus_claimed: '16+ (claimed)',
 };
 
-async function createAgeReviewTicket(
-  caseId: string,
-  parentEmail: string,
-  ageBand: AgeBand,
-  deadlineAt: string | null,
-  env: AgeReviewEnv,
-): Promise<void> {
+function getZendeskClientConfig(env: AgeReviewEnv): ZendeskClientConfig | null {
   if (!env.ZENDESK_SUBDOMAIN || !env.ZENDESK_API_TOKEN || !env.ZENDESK_EMAIL) {
-    console.warn('[age-review] Missing Zendesk credentials, skipping ticket creation');
-    return;
+    return null;
   }
-  if (!env.DB) return;
 
-  const auth = btoa(`${env.ZENDESK_EMAIL}/token:${env.ZENDESK_API_TOKEN}`);
-  const url = `https://${env.ZENDESK_SUBDOMAIN}.zendesk.com/api/v2/tickets`;
+  return {
+    auth: btoa(`${env.ZENDESK_EMAIL}/token:${env.ZENDESK_API_TOKEN}`),
+    baseUrl: `https://${env.ZENDESK_SUBDOMAIN}.zendesk.com/api/v2`,
+  };
+}
 
-  const subject = `Age review: parental verification needed [${caseId}]`;
-  const body = [
+function buildParentOutreachBody(ageBand: AgeBand): string {
+  return [
     'Hello,',
     '',
     'We received a report that an account on Divine may belong to a minor in the ' +
@@ -416,27 +418,55 @@ async function createAgeReviewTicket(
     'Thank you,',
     'Divine Trust & Safety',
   ].join('\n');
+}
 
+function buildAgeReviewCustomFields(
+  env: AgeReviewEnv,
+  deadlineAt: string | null,
+): { id: number; value: string }[] {
   const customFields: { id: number; value: string }[] = [];
+
   if (env.ZENDESK_FIELD_CATEGORY && env.ZENDESK_FIELD_ISSUE) {
     customFields.push(
       { id: parseInt(env.ZENDESK_FIELD_CATEGORY, 10), value: 'trust___safety' },
       { id: parseInt(env.ZENDESK_FIELD_ISSUE, 10), value: 'age_review' },
     );
   }
+
   const deadlineField = buildDeadlineCustomField(deadlineAt, env);
   if (deadlineField) customFields.push(deadlineField);
 
-  const res = await fetch(url, {
+  return customFields;
+}
+
+async function createAgeReviewTicket(
+  caseId: string,
+  parentEmail: string,
+  ageBand: AgeBand,
+  deadlineAt: string | null,
+  env: AgeReviewEnv,
+): Promise<void> {
+  const zendesk = getZendeskClientConfig(env);
+  if (!zendesk) {
+    console.warn('[age-review] Missing Zendesk credentials, skipping ticket creation');
+    return;
+  }
+  if (!env.DB) return;
+
+  const subject = `Age review: parental verification needed [${caseId}]`;
+  const outreachBody = buildParentOutreachBody(ageBand);
+  const customFields = buildAgeReviewCustomFields(env, deadlineAt);
+
+  const res = await fetch(`${zendesk.baseUrl}/tickets`, {
     method: 'POST',
     headers: {
-      'Authorization': `Basic ${auth}`,
+      'Authorization': `Basic ${zendesk.auth}`,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
       ticket: {
         subject,
-        comment: { body, public: true },
+        comment: { body: outreachBody, public: true },
         requester: { email: parentEmail, name: 'Parent/Guardian' },
         tags: ['age-review', `age-band-${ageBand}`],
         priority: 'high',
@@ -465,30 +495,15 @@ async function updateTicketWithParentContact(
   ageBand: AgeBand,
   env: AgeReviewEnv,
 ): Promise<void> {
-  if (!env.ZENDESK_SUBDOMAIN || !env.ZENDESK_API_TOKEN || !env.ZENDESK_EMAIL) return;
+  const zendesk = getZendeskClientConfig(env);
+  if (!zendesk) return;
 
-  const auth = btoa(`${env.ZENDESK_EMAIL}/token:${env.ZENDESK_API_TOKEN}`);
-  const url = `https://${env.ZENDESK_SUBDOMAIN}.zendesk.com/api/v2/tickets/${ticketId}`;
+  const outreachBody = buildParentOutreachBody(ageBand);
 
-  const outreachBody = [
-    'Hello,',
-    '',
-    'We received a report that an account on Divine may belong to a minor in the ' +
-      `${BAND_DISPLAY[ageBand]} age range. As part of our safety process, we need a ` +
-      'parent or guardian to verify they are aware of and approve this account.',
-    '',
-    'Please reply to this email to confirm you are the parent or legal guardian of the account holder.',
-    '',
-    'If you have questions, you can reply directly to this email or contact us at contact@divine.video.',
-    '',
-    'Thank you,',
-    'Divine Trust & Safety',
-  ].join('\n');
-
-  const res = await fetch(url, {
+  const res = await fetch(`${zendesk.baseUrl}/tickets/${ticketId}`, {
     method: 'PUT',
     headers: {
-      'Authorization': `Basic ${auth}`,
+      'Authorization': `Basic ${zendesk.auth}`,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
@@ -523,15 +538,13 @@ async function createAgeReviewInternalTicket(
   ageBand: AgeBand,
   deadlineAt: string | null,
   env: AgeReviewEnv,
-): Promise<void> {
-  if (!env.ZENDESK_SUBDOMAIN || !env.ZENDESK_API_TOKEN || !env.ZENDESK_EMAIL) {
+): Promise<number | null> {
+  const zendesk = getZendeskClientConfig(env);
+  if (!zendesk) {
     console.warn('[age-review] Missing Zendesk credentials, skipping internal ticket creation');
-    return;
+    return null;
   }
-  if (!env.DB) return;
-
-  const auth = btoa(`${env.ZENDESK_EMAIL}/token:${env.ZENDESK_API_TOKEN}`);
-  const url = `https://${env.ZENDESK_SUBDOMAIN}.zendesk.com/api/v2/tickets`;
+  if (!env.DB) return null;
 
   const subject = `Age review: ${BAND_DISPLAY[ageBand]} account restricted [${caseId}]`;
   const note = [
@@ -543,20 +556,12 @@ async function createAgeReviewInternalTicket(
     'It will be updated if a parent/guardian email is provided or the case is resolved.',
   ].join('\n');
 
-  const customFields: { id: number; value: string }[] = [];
-  if (env.ZENDESK_FIELD_CATEGORY && env.ZENDESK_FIELD_ISSUE) {
-    customFields.push(
-      { id: parseInt(env.ZENDESK_FIELD_CATEGORY, 10), value: 'trust___safety' },
-      { id: parseInt(env.ZENDESK_FIELD_ISSUE, 10), value: 'age_review' },
-    );
-  }
-  const deadlineField = buildDeadlineCustomField(deadlineAt, env);
-  if (deadlineField) customFields.push(deadlineField);
+  const customFields = buildAgeReviewCustomFields(env, deadlineAt);
 
-  const res = await fetch(url, {
+  const res = await fetch(`${zendesk.baseUrl}/tickets`, {
     method: 'POST',
     headers: {
-      'Authorization': `Basic ${auth}`,
+      'Authorization': `Basic ${zendesk.auth}`,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
@@ -581,7 +586,10 @@ async function createAgeReviewInternalTicket(
       'UPDATE age_review_cases SET zendesk_ticket_id = ? WHERE id = ?'
     ).bind(data.ticket.id, caseId).run();
     console.log(`[age-review] Created internal Zendesk ticket #${data.ticket.id} for case ${caseId}`);
+    return data.ticket.id;
   }
+
+  return null;
 }
 
 export async function syncAgeReviewTicketResolution(
@@ -590,7 +598,10 @@ export async function syncAgeReviewTicketResolution(
   resolutionNote: string | null,
   env: AgeReviewEnv,
 ): Promise<void> {
-  if (!env.DB || !env.ZENDESK_SUBDOMAIN || !env.ZENDESK_API_TOKEN || !env.ZENDESK_EMAIL) return;
+  if (!env.DB) return;
+
+  const zendesk = getZendeskClientConfig(env);
+  if (!zendesk) return;
 
   const row = await env.DB.prepare(
     'SELECT zendesk_ticket_id FROM age_review_cases WHERE id = ?'
@@ -599,8 +610,6 @@ export async function syncAgeReviewTicketResolution(
   if (!row?.zendesk_ticket_id) return;
 
   const ticketId = row.zendesk_ticket_id;
-  const auth = btoa(`${env.ZENDESK_EMAIL}/token:${env.ZENDESK_API_TOKEN}`);
-  const url = `https://${env.ZENDESK_SUBDOMAIN}.zendesk.com/api/v2/tickets/${ticketId}`;
 
   const noteLines = [
     `Age review case ${caseId} resolved: **${state}**`,
@@ -625,10 +634,10 @@ export async function syncAgeReviewTicketResolution(
 
   // Catches Zendesk API/network errors here; callers also wrap in try/catch for unexpected errors (e.g. D1 failure on the SELECT above)
   try {
-    const res = await fetch(url, {
+    const res = await fetch(`${zendesk.baseUrl}/tickets/${ticketId}`, {
       method: 'PUT',
       headers: {
-        'Authorization': `Basic ${auth}`,
+        'Authorization': `Basic ${zendesk.auth}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(payload),

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -18,6 +18,7 @@ interface AgeReviewEnv {
   ZENDESK_EMAIL?: string;
   ZENDESK_FIELD_CATEGORY?: string;
   ZENDESK_FIELD_ISSUE?: string;
+  ZENDESK_FIELD_AGE_REVIEW_DEADLINE?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -192,6 +193,29 @@ export async function handleUpdateAgeReviewCase(
     }
   }
 
+  // Non-critical: create internal Zendesk ticket when moderator restricts an account
+  // (parent-contact flow creates its own ticket with requester email; this covers
+  // moderator-initiated restriction where no parent email exists yet)
+  if (
+    body.state &&
+    (body.state as string).startsWith('restricted_') &&
+    !existing.zendesk_ticket_id &&
+    updated &&
+    !updated.zendesk_ticket_id
+  ) {
+    try {
+      await createAgeReviewInternalTicket(
+        caseId,
+        existing.pubkey,
+        (updated.suspected_age_band ?? existing.suspected_age_band) as AgeBand,
+        updated.deadline_at ?? existing.deadline_at,
+        env,
+      );
+    } catch (error) {
+      console.error('[age-review] Failed to create internal Zendesk ticket:', error);
+    }
+  }
+
   return json({ success: true, case: updated }, 200, corsHeaders);
 }
 
@@ -325,12 +349,24 @@ export async function handleParentContact(
     `).bind(body.email, now.toISOString(), remainingDays, caseId).run();
   }
 
-  // Non-critical: create Zendesk ticket for parent outreach (skip if one already exists)
+  // Non-critical: Zendesk ticket handling
+  // If an internal ticket already exists (from moderator restriction), update it
+  // to add the parent as requester and send them the outreach email.
+  // Otherwise create a new ticket from scratch.
   if (activeCase.zendesk_ticket_id) {
-    console.log(`[age-review] Case ${caseId} already has Zendesk ticket #${activeCase.zendesk_ticket_id}, skipping creation`);
+    try {
+      await updateTicketWithParentContact(
+        activeCase.zendesk_ticket_id,
+        body.email,
+        activeCase.suspected_age_band as AgeBand,
+        env,
+      );
+    } catch (error) {
+      console.error('[age-review] Failed to update Zendesk ticket with parent contact:', error);
+    }
   } else {
     try {
-      await createAgeReviewTicket(caseId, body.email, activeCase.suspected_age_band as AgeBand, env);
+      await createAgeReviewTicket(caseId, body.email, activeCase.suspected_age_band as AgeBand, activeCase.deadline_at, env);
     } catch (error) {
       console.error('[age-review] Failed to create Zendesk ticket:', error);
     }
@@ -353,6 +389,7 @@ async function createAgeReviewTicket(
   caseId: string,
   parentEmail: string,
   ageBand: AgeBand,
+  deadlineAt: string | null,
   env: AgeReviewEnv,
 ): Promise<void> {
   if (!env.ZENDESK_SUBDOMAIN || !env.ZENDESK_API_TOKEN || !env.ZENDESK_EMAIL) {
@@ -380,6 +417,16 @@ async function createAgeReviewTicket(
     'Divine Trust & Safety',
   ].join('\n');
 
+  const customFields: { id: number; value: string }[] = [];
+  if (env.ZENDESK_FIELD_CATEGORY && env.ZENDESK_FIELD_ISSUE) {
+    customFields.push(
+      { id: parseInt(env.ZENDESK_FIELD_CATEGORY, 10), value: 'trust___safety' },
+      { id: parseInt(env.ZENDESK_FIELD_ISSUE, 10), value: 'age_review' },
+    );
+  }
+  const deadlineField = buildDeadlineCustomField(deadlineAt, env);
+  if (deadlineField) customFields.push(deadlineField);
+
   const res = await fetch(url, {
     method: 'POST',
     headers: {
@@ -393,6 +440,7 @@ async function createAgeReviewTicket(
         requester: { email: parentEmail, name: 'Parent/Guardian' },
         tags: ['age-review', `age-band-${ageBand}`],
         priority: 'high',
+        custom_fields: customFields.length > 0 ? customFields : undefined,
       },
     }),
   });
@@ -408,6 +456,131 @@ async function createAgeReviewTicket(
       'UPDATE age_review_cases SET zendesk_ticket_id = ? WHERE id = ?'
     ).bind(data.ticket.id, caseId).run();
     console.log(`[age-review] Created Zendesk ticket #${data.ticket.id} for case ${caseId}`);
+  }
+}
+
+async function updateTicketWithParentContact(
+  ticketId: number,
+  parentEmail: string,
+  ageBand: AgeBand,
+  env: AgeReviewEnv,
+): Promise<void> {
+  if (!env.ZENDESK_SUBDOMAIN || !env.ZENDESK_API_TOKEN || !env.ZENDESK_EMAIL) return;
+
+  const auth = btoa(`${env.ZENDESK_EMAIL}/token:${env.ZENDESK_API_TOKEN}`);
+  const url = `https://${env.ZENDESK_SUBDOMAIN}.zendesk.com/api/v2/tickets/${ticketId}`;
+
+  const outreachBody = [
+    'Hello,',
+    '',
+    'We received a report that an account on Divine may belong to a minor in the ' +
+      `${BAND_DISPLAY[ageBand]} age range. As part of our safety process, we need a ` +
+      'parent or guardian to verify they are aware of and approve this account.',
+    '',
+    'Please reply to this email to confirm you are the parent or legal guardian of the account holder.',
+    '',
+    'If you have questions, you can reply directly to this email or contact us at contact@divine.video.',
+    '',
+    'Thank you,',
+    'Divine Trust & Safety',
+  ].join('\n');
+
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      'Authorization': `Basic ${auth}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      ticket: {
+        requester: { email: parentEmail, name: 'Parent/Guardian' },
+        comment: { body: outreachBody, public: true },
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text();
+    throw new Error(`Zendesk ticket update failed: ${res.status} - ${errorText}`);
+  }
+  console.log(`[age-review] Updated Zendesk ticket #${ticketId} with parent contact ${parentEmail}`);
+}
+
+function buildDeadlineCustomField(
+  deadlineAt: string | null,
+  env: AgeReviewEnv,
+): { id: number; value: string } | null {
+  if (!env.ZENDESK_FIELD_AGE_REVIEW_DEADLINE || !deadlineAt) return null;
+  return {
+    id: parseInt(env.ZENDESK_FIELD_AGE_REVIEW_DEADLINE, 10),
+    value: deadlineAt.split('T')[0],
+  };
+}
+
+async function createAgeReviewInternalTicket(
+  caseId: string,
+  pubkey: string,
+  ageBand: AgeBand,
+  deadlineAt: string | null,
+  env: AgeReviewEnv,
+): Promise<void> {
+  if (!env.ZENDESK_SUBDOMAIN || !env.ZENDESK_API_TOKEN || !env.ZENDESK_EMAIL) {
+    console.warn('[age-review] Missing Zendesk credentials, skipping internal ticket creation');
+    return;
+  }
+  if (!env.DB) return;
+
+  const auth = btoa(`${env.ZENDESK_EMAIL}/token:${env.ZENDESK_API_TOKEN}`);
+  const url = `https://${env.ZENDESK_SUBDOMAIN}.zendesk.com/api/v2/tickets`;
+
+  const subject = `Age review: ${BAND_DISPLAY[ageBand]} account restricted [${caseId}]`;
+  const note = [
+    `Account \`${pubkey}\` restricted for age review.`,
+    `Suspected age band: ${BAND_DISPLAY[ageBand]}`,
+    deadlineAt ? `Deadline: ${deadlineAt.split('T')[0]}` : 'No deadline set',
+    '',
+    'This ticket was created automatically when a moderator restricted the account.',
+    'It will be updated if a parent/guardian email is provided or the case is resolved.',
+  ].join('\n');
+
+  const customFields: { id: number; value: string }[] = [];
+  if (env.ZENDESK_FIELD_CATEGORY && env.ZENDESK_FIELD_ISSUE) {
+    customFields.push(
+      { id: parseInt(env.ZENDESK_FIELD_CATEGORY, 10), value: 'trust___safety' },
+      { id: parseInt(env.ZENDESK_FIELD_ISSUE, 10), value: 'age_review' },
+    );
+  }
+  const deadlineField = buildDeadlineCustomField(deadlineAt, env);
+  if (deadlineField) customFields.push(deadlineField);
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Basic ${auth}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      ticket: {
+        subject,
+        comment: { body: note, public: false },
+        tags: ['age-review', `age-band-${ageBand}`, 'internal'],
+        priority: 'high',
+        custom_fields: customFields.length > 0 ? customFields : undefined,
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text();
+    throw new Error(`Zendesk internal ticket creation failed: ${res.status} - ${errorText}`);
+  }
+
+  const data = await res.json() as { ticket?: { id: number } };
+  if (data.ticket?.id) {
+    await env.DB.prepare(
+      'UPDATE age_review_cases SET zendesk_ticket_id = ? WHERE id = ?'
+    ).bind(data.ticket.id, caseId).run();
+    console.log(`[age-review] Created internal Zendesk ticket #${data.ticket.id} for case ${caseId}`);
   }
 }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -59,6 +59,7 @@ interface Env {
   ZENDESK_FIELD_ACTION_REQUESTED?: string;
   ZENDESK_FIELD_CATEGORY?: string;       // For auto-solve required fields
   ZENDESK_FIELD_ISSUE?: string;          // For auto-solve required fields
+  ZENDESK_FIELD_AGE_REVIEW_DEADLINE?: string;
   KV?: KVNamespace;
   DB?: D1Database;
   // Relay management configuration

--- a/worker/wrangler.prod.toml
+++ b/worker/wrangler.prod.toml
@@ -65,6 +65,8 @@ ZENDESK_FIELD_ACTION_REQUESTED = "14545826900367"
 # Zendesk custom field IDs for auto-solve required fields
 ZENDESK_FIELD_CATEGORY = "14559549220879"
 ZENDESK_FIELD_ISSUE = "14560383908879"
+# Age review deadline date field — create in Zendesk admin, then set the ID here
+# ZENDESK_FIELD_AGE_REVIEW_DEADLINE = ""
 
 # D1 Database for moderation decision log (production)
 [[d1_databases]]

--- a/worker/wrangler.staging.toml
+++ b/worker/wrangler.staging.toml
@@ -64,6 +64,8 @@ ZENDESK_FIELD_ACTION_REQUESTED = "14545826900367"
 # Zendesk custom field IDs for auto-solve required fields
 ZENDESK_FIELD_CATEGORY = "14559549220879"
 ZENDESK_FIELD_ISSUE = "14560383908879"
+# Age review deadline date field — create in Zendesk admin, then set the ID here
+# ZENDESK_FIELD_AGE_REVIEW_DEADLINE = ""
 
 # D1 Database for moderation decision log (staging)
 [[d1_databases]]


### PR DESCRIPTION
## Summary

- Create an internal Zendesk ticket when a moderator restricts an account (state -> `restricted_*`), giving T&S visibility before any parent email arrives
- When a parent email comes in later, update the existing ticket with the parent as requester and send the outreach email (no duplicate tickets)
- Set `ZENDESK_FIELD_AGE_REVIEW_DEADLINE` date custom field on all age review tickets (dormant until field is created in Zendesk admin and ID is set in wrangler config)
- Add `ZENDESK_FIELD_CATEGORY` / `ZENDESK_FIELD_ISSUE` to parent-contact tickets for solve consistency
- Add `ZENDESK_FIELD_AGE_REVIEW_DEADLINE` to top-level `Env` interface

All Zendesk operations are non-critical side effects wrapped in try/catch.

Closes #74