### PR TITLE
config: wire ZENDESK_FIELD_AGE_REVIEW_DEADLINE

### DIFF
--- a/worker/wrangler.prod.toml
+++ b/worker/wrangler.prod.toml
@@ -65,8 +65,7 @@ ZENDESK_FIELD_ACTION_REQUESTED = "14545826900367"
 # Zendesk custom field IDs for auto-solve required fields
 ZENDESK_FIELD_CATEGORY = "14559549220879"
 ZENDESK_FIELD_ISSUE = "14560383908879"
-# Age review deadline date field — create in Zendesk admin, then set the ID here
-# ZENDESK_FIELD_AGE_REVIEW_DEADLINE = ""
+ZENDESK_FIELD_AGE_REVIEW_DEADLINE = "16123853180303"
 
 # D1 Database for moderation decision log (production)
 [[d1_databases]]

--- a/worker/wrangler.staging.toml
+++ b/worker/wrangler.staging.toml
@@ -64,8 +64,7 @@ ZENDESK_FIELD_ACTION_REQUESTED = "14545826900367"
 # Zendesk custom field IDs for auto-solve required fields
 ZENDESK_FIELD_CATEGORY = "14559549220879"
 ZENDESK_FIELD_ISSUE = "14560383908879"
-# Age review deadline date field — create in Zendesk admin, then set the ID here
-# ZENDESK_FIELD_AGE_REVIEW_DEADLINE = ""
+ZENDESK_FIELD_AGE_REVIEW_DEADLINE = "16123853180303"
 
 # D1 Database for moderation decision log (staging)
 [[d1_databases]]


### PR DESCRIPTION
## Summary
- Sets `ZENDESK_FIELD_AGE_REVIEW_DEADLINE` to the existing Zendesk field ID (`16123853180303`) in both staging and production wrangler configs
- Age review tickets will now include the 15-day deadline date
- Already deployed to both workers ahead of this PR to unblock functionality

## Test plan
- [x] Verified field exists in Zendesk (`Age Review Deadline`, type: date)
- [ ] Confirm deadline appears on next age review ticket creation