### PR TITLE
feat: realign moderation actions with explicit delete and age review workflows

### DIFF
--- a/shared/bulk-moderation.ts
+++ b/shared/bulk-moderation.ts
@@ -1,0 +1,10 @@
+export const VALID_BULK_ACTIONS = ['age-restrict-all', 'un-age-restrict-all', 'delete-all'] as const;
+
+export type BulkAction = typeof VALID_BULK_ACTIONS[number];
+
+export interface BulkModerateResult {
+  success: boolean;
+  eventsProcessed: number;
+  mediaProcessed: number;
+  failures: string[];
+}

--- a/shared/media-hashes.ts
+++ b/shared/media-hashes.ts
@@ -1,0 +1,42 @@
+const SHA256_PATTERN = /\b([a-f0-9]{64})\b/gi;
+
+export function extractMediaHashes(content: string, tags: string[][]): string[] {
+  const hashes = new Set<string>();
+
+  const addHashesFromText = (value: string) => {
+    let match: RegExpExecArray | null;
+    SHA256_PATTERN.lastIndex = 0;
+    while ((match = SHA256_PATTERN.exec(value)) !== null) {
+      hashes.add(match[1].toLowerCase());
+    }
+  };
+
+  addHashesFromText(content);
+
+  for (const tag of tags) {
+    if (tag[0] === 'imeta') {
+      const mime = tag.find((part) => part.toLowerCase().startsWith('m '))?.split(/\s+/)[1];
+      if (mime?.toLowerCase().startsWith('video/')) {
+        for (const part of tag.slice(1)) {
+          const [key, ...values] = part.split(/\s+/);
+          if (key === 'url' || key === 'x') {
+            addHashesFromText(values.join(' '));
+          }
+        }
+      } else {
+        addHashesFromText(tag.join(' '));
+      }
+      continue;
+    }
+
+    if (tag[0] === 'url' || tag[0] === 'x') {
+      addHashesFromText(tag.join(' '));
+    }
+
+    if (tag[0] === 'x' && tag[1] && /^[a-f0-9]{64}$/i.test(tag[1])) {
+      hashes.add(tag[1].toLowerCase());
+    }
+  }
+
+  return Array.from(hashes);
+}

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -6,11 +6,13 @@ import { AgeReviewDetail } from './AgeReviewDetail';
 import type { AgeReviewCase, AgeBand, AgeReviewState } from '../../shared/age-review';
 
 const updateAgeReviewCase = vi.fn().mockResolvedValue({ success: true });
+const getAgeReviewConfig = vi.fn().mockResolvedValue({ auto_delete_on_deny: false });
 const writeText = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('@/hooks/useAdminApi', () => ({
   useAdminApi: () => ({
     updateAgeReviewCase,
+    getAgeReviewConfig,
   }),
 }));
 
@@ -60,6 +62,8 @@ function renderDetail(caseData: AgeReviewCase) {
 describe('AgeReviewDetail', () => {
   beforeEach(() => {
     updateAgeReviewCase.mockClear();
+    getAgeReviewConfig.mockClear();
+    getAgeReviewConfig.mockResolvedValue({ auto_delete_on_deny: false });
     writeText.mockClear();
     Object.assign(navigator, {
       clipboard: {
@@ -80,6 +84,21 @@ describe('AgeReviewDetail', () => {
     await waitFor(() => {
       expect(updateAgeReviewCase).toHaveBeenCalledWith('case-1', { state: expectedState });
     });
+  });
+
+  it('shows Deny & Close without confirmation when auto-delete is off', () => {
+    renderDetail(makeCase());
+    expect(screen.getByRole('button', { name: /Deny.*Close/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Deny.*Delete/ })).not.toBeInTheDocument();
+  });
+
+  it('shows Deny & Delete with confirmation when auto-delete is on', async () => {
+    getAgeReviewConfig.mockResolvedValue({ auto_delete_on_deny: true });
+    renderDetail(makeCase());
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Deny.*Delete/ })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: /Deny.*Close/ })).not.toBeInTheDocument();
   });
 
   it('copies the raw hex pubkey from the moderator control', async () => {

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -341,10 +341,12 @@ export function AgeReviewDetail({ caseData: c }: Props) {
                     }
                     title="Deny & Delete Content"
                     summary="Denying this case will permanently delete all events and media for this user. This cannot be undone."
-                    onConfirm={() => updateCase.mutateAsync({
-                      state: 'denied_closed',
-                      resolution_note: resolutionNote || undefined,
-                    })}
+                    onConfirm={async () => {
+                      await updateCase.mutateAsync({
+                        state: 'denied_closed',
+                        resolution_note: resolutionNote || undefined,
+                      });
+                    }}
                     isPending={updateCase.isPending}
                   />
                 ) : (

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAdminApi } from "@/hooks/useAdminApi";
+import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
+import { UserActions } from "@/components/UserActions";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -98,6 +100,11 @@ export function AgeReviewDetail({ caseData: c }: Props) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['age-review-cases'] });
     },
+  });
+
+  const { data: ageReviewConfig } = useQuery({
+    queryKey: ['age-review-config'],
+    queryFn: () => api.getAgeReviewConfig(),
   });
 
   return (
@@ -324,19 +331,37 @@ export function AgeReviewDetail({ caseData: c }: Props) {
                   <CheckCircle className="h-3 w-3 mr-1" />
                   Clear
                 </Button>
-                <Button
-                  size="sm"
-                  variant="destructive"
-                  className="h-7 text-xs"
-                  disabled={updateCase.isPending}
-                  onClick={() => updateCase.mutate({
-                    state: 'denied_closed',
-                    resolution_note: resolutionNote || undefined,
-                  })}
-                >
-                  <XCircle className="h-3 w-3 mr-1" />
-                  Deny &amp; Close
-                </Button>
+                {ageReviewConfig?.auto_delete_on_deny ? (
+                  <DeleteConfirmDialog
+                    trigger={
+                      <Button size="sm" variant="destructive" className="h-7 text-xs" disabled={updateCase.isPending}>
+                        <XCircle className="h-3 w-3 mr-1" />
+                        Deny &amp; Delete
+                      </Button>
+                    }
+                    title="Deny & Delete Content"
+                    summary="Denying this case will permanently delete all events and media for this user. This cannot be undone."
+                    onConfirm={() => updateCase.mutateAsync({
+                      state: 'denied_closed',
+                      resolution_note: resolutionNote || undefined,
+                    })}
+                    isPending={updateCase.isPending}
+                  />
+                ) : (
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    className="h-7 text-xs"
+                    disabled={updateCase.isPending}
+                    onClick={() => updateCase.mutate({
+                      state: 'denied_closed',
+                      resolution_note: resolutionNote || undefined,
+                    })}
+                  >
+                    <XCircle className="h-3 w-3 mr-1" />
+                    Deny &amp; Close
+                  </Button>
+                )}
               </div>
 
               {updateCase.isPending && (
@@ -362,6 +387,17 @@ export function AgeReviewDetail({ caseData: c }: Props) {
               <p className="text-sm">{c.resolution_note}</p>
             </div>
           </>
+        )}
+
+        {isTerminal && c.state === 'denied_closed' && !ageReviewConfig?.auto_delete_on_deny && (
+          <div className="border-t pt-4 mt-4">
+            <p className="text-xs text-muted-foreground mb-2">Auto-delete is disabled. You can manually delete content:</p>
+            <UserActions
+              pubkey={c.pubkey}
+              context="age-review"
+              onActionComplete={() => queryClient.invalidateQueries({ queryKey: ['age-review-cases'] })}
+            />
+          </div>
         )}
 
       </div>

--- a/src/components/AutoHideSettings.tsx
+++ b/src/components/AutoHideSettings.tsx
@@ -10,12 +10,13 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { useAppContext } from "@/hooks/useAppContext";
 import { useToast } from "@/hooks/useToast";
 import { getApiHeaders } from "@/lib/adminApi";
-import { Shield, X, Plus, Save, AlertTriangle } from "lucide-react";
+import { Shield, X, Plus, Save, AlertTriangle, Clock } from "lucide-react";
 import {
   isImmediateAutoHideTier,
   type AutoHideConfig,
   type AutoHideTier,
 } from "../../shared/autohide";
+import { useAdminApi } from "@/hooks/useAdminApi";
 
 function ChipList({
   items,
@@ -274,6 +275,54 @@ export function AutoHideSettings() {
           <Save className="h-4 w-4 mr-2" />
           {mutation.isPending ? "Saving..." : "Save Configuration"}
         </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function AgeReviewSettings() {
+  const api = useAdminApi();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const { data: ageReviewConfig, isLoading } = useQuery({
+    queryKey: ['age-review-config'],
+    queryFn: () => api.getAgeReviewConfig(),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (config: { auto_delete_on_deny: boolean }) => api.updateAgeReviewConfig(config),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['age-review-config'] });
+      toast({ title: 'Age review configuration updated' });
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to update config', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Clock className="h-4 w-4" />
+          Age Review Configuration
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <Label>Auto-delete on deny/expire</Label>
+            <p className="text-xs text-muted-foreground">
+              Automatically delete all events and media when an age review case is denied or expires.
+            </p>
+          </div>
+          <Switch
+            checked={ageReviewConfig?.auto_delete_on_deny ?? true}
+            onCheckedChange={(checked) => updateMutation.mutate({ auto_delete_on_deny: checked })}
+            disabled={isLoading || updateMutation.isPending}
+          />
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/components/DeleteConfirmDialog.test.tsx
+++ b/src/components/DeleteConfirmDialog.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DeleteConfirmDialog } from './DeleteConfirmDialog';
+
+describe('DeleteConfirmDialog', () => {
+  it('shows summary on first click and executes on confirm', async () => {
+    const onConfirm = vi.fn();
+    render(
+      <DeleteConfirmDialog
+        trigger={<button>Delete</button>}
+        title="Delete User Content"
+        summary="This will permanently delete 5 events and 3 media files."
+        onConfirm={onConfirm}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Delete'));
+    expect(screen.getByText(/permanently delete 5 events/)).toBeInTheDocument();
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /Confirm Delete/i }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('does not call onConfirm when cancelled', () => {
+    const onConfirm = vi.fn();
+    render(
+      <DeleteConfirmDialog
+        trigger={<button>Delete</button>}
+        title="Delete"
+        summary="Gone forever."
+        onConfirm={onConfirm}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Delete'));
+    fireEvent.click(screen.getByRole('button', { name: /Cancel/i }));
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('shows custom confirm label', () => {
+    render(
+      <DeleteConfirmDialog
+        trigger={<button>Delete</button>}
+        title="Delete"
+        summary="Summary"
+        onConfirm={() => {}}
+        confirmLabel="Yes, Nuke It"
+      />
+    );
+
+    fireEvent.click(screen.getByText('Delete'));
+    expect(screen.getByRole('button', { name: /Yes, Nuke It/i })).toBeInTheDocument();
+  });
+
+  it('shows pending state', () => {
+    render(
+      <DeleteConfirmDialog
+        trigger={<button>Delete</button>}
+        title="Delete"
+        summary="Summary"
+        onConfirm={() => {}}
+        isPending={true}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Delete'));
+    expect(screen.getByRole('button', { name: /Deleting.../i })).toBeDisabled();
+  });
+});

--- a/src/components/DeleteConfirmDialog.tsx
+++ b/src/components/DeleteConfirmDialog.tsx
@@ -1,0 +1,57 @@
+import { useState, type ReactNode } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+
+interface DeleteConfirmDialogProps {
+  trigger: ReactNode;
+  title: string;
+  summary: string;
+  onConfirm: () => void | Promise<void>;
+  confirmLabel?: string;
+  isPending?: boolean;
+}
+
+export function DeleteConfirmDialog({
+  trigger,
+  title,
+  summary,
+  onConfirm,
+  confirmLabel = 'Confirm Delete',
+  isPending = false,
+}: DeleteConfirmDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{summary}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={async () => {
+              await onConfirm();
+              setOpen(false);
+            }}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            disabled={isPending}
+          >
+            {isPending ? 'Deleting...' : confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/EventActions.test.tsx
+++ b/src/components/EventActions.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { describe, expect, it, vi } from 'vitest';
+import { EventActions } from './EventActions';
+
+vi.mock('@/hooks/useAdminApi', () => ({
+  useAdminApi: () => ({
+    deleteEvent: vi.fn().mockResolvedValue({ success: true }),
+    moderateMedia: vi.fn().mockResolvedValue({ success: true }),
+    deleteMedia: vi.fn().mockResolvedValue({ success: true }),
+    publishDeletionRequest: vi.fn().mockResolvedValue({ success: true }),
+    callRelayRpc: vi.fn().mockResolvedValue({ success: true }),
+    logDecision: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+function renderWithProvider(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>{ui}</TooltipProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe('EventActions', () => {
+  it('renders ban and delete buttons for events without media', () => {
+    renderWithProvider(
+      <EventActions eventId="event-1" pubkey={'a'.repeat(64)} />
+    );
+    expect(screen.getByRole('button', { name: /Ban Event/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Delete Event/i })).toBeInTheDocument();
+    expect(screen.queryByText(/Block Media/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Delete Media/i)).not.toBeInTheDocument();
+  });
+
+  it('renders media actions when mediaHashes provided', () => {
+    renderWithProvider(
+      <EventActions eventId="event-1" pubkey={'a'.repeat(64)} mediaHashes={['abc123']} />
+    );
+    expect(screen.getByRole('button', { name: /Block Media/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Age Restrict/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Delete Media/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Delete Event & Media/i })).toBeInTheDocument();
+  });
+
+  it('renders restore button when event is banned', () => {
+    renderWithProvider(
+      <EventActions eventId="event-1" pubkey={'a'.repeat(64)} isEventBanned={true} />
+    );
+    expect(screen.getByRole('button', { name: /Restore Event/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Ban Event/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Delete Event$/i })).not.toBeInTheDocument();
+  });
+
+  it('renders unblock when media is blocked', () => {
+    renderWithProvider(
+      <EventActions eventId="event-1" pubkey={'a'.repeat(64)} mediaHashes={['abc']} hasBlockedMedia={true} />
+    );
+    expect(screen.getByRole('button', { name: /Unblock Media/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Block Media/i })).not.toBeInTheDocument();
+  });
+
+  it('renders remove restriction when media is restricted', () => {
+    renderWithProvider(
+      <EventActions eventId="event-1" pubkey={'a'.repeat(64)} mediaHashes={['abc']} hasRestrictedMedia={true} />
+    );
+    expect(screen.getByRole('button', { name: /Remove Restriction/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Age Restrict/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/EventActions.tsx
+++ b/src/components/EventActions.tsx
@@ -1,0 +1,323 @@
+import { useMutation } from '@tanstack/react-query';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useToast } from '@/hooks/useToast';
+import { useAdminApi } from '@/hooks/useAdminApi';
+import { DeleteConfirmDialog } from './DeleteConfirmDialog';
+import { ShieldX, Undo2, Video, ShieldAlert, Unlock, Trash2 } from 'lucide-react';
+
+interface EventActionsProps {
+  eventId: string;
+  pubkey: string;
+  mediaHashes?: string[];
+  isEventBanned?: boolean;
+  hasBlockedMedia?: boolean;
+  hasRestrictedMedia?: boolean;
+  onActionComplete?: () => void;
+}
+
+export function EventActions({
+  eventId,
+  pubkey,
+  mediaHashes = [],
+  isEventBanned = false,
+  hasBlockedMedia = false,
+  hasRestrictedMedia = false,
+  onActionComplete,
+}: EventActionsProps) {
+  const { toast } = useToast();
+  const api = useAdminApi();
+  const hasMedia = mediaHashes.length > 0;
+
+  const banEventMutation = useMutation({
+    mutationFn: async () => {
+      await api.deleteEvent(eventId, 'Banned by moderator', pubkey);
+      await api.logDecision({
+        targetType: 'event',
+        targetId: eventId,
+        action: 'ban_event',
+        reason: 'Banned by moderator',
+      });
+    },
+    onSuccess: () => {
+      toast({ title: 'Event banned from relay' });
+      onActionComplete?.();
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to ban event', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const restoreEventMutation = useMutation({
+    mutationFn: async () => {
+      await api.callRelayRpc('allowevent', [eventId]);
+      await api.logDecision({
+        targetType: 'event',
+        targetId: eventId,
+        action: 'restore_event',
+        reason: 'Restored by moderator',
+      });
+    },
+    onSuccess: () => {
+      toast({ title: 'Event restored' });
+      onActionComplete?.();
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to restore event', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const deleteEventMutation = useMutation({
+    mutationFn: async () => {
+      await api.deleteEvent(eventId, 'Permanently deleted by moderator', pubkey);
+      await api.publishDeletionRequest(eventId, 'Permanently deleted by moderator');
+      await api.logDecision({
+        targetType: 'event',
+        targetId: eventId,
+        action: 'delete_event_permanent',
+        reason: 'Permanently deleted (banevent + kind 5)',
+      });
+    },
+    onSuccess: () => {
+      toast({ title: 'Event permanently deleted', description: 'Banned from relay + NIP-09 deletion published' });
+      onActionComplete?.();
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to delete event', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const blockMediaMutation = useMutation({
+    mutationFn: async () => {
+      for (const hash of mediaHashes) {
+        await api.moderateMedia(hash, 'PERMANENT_BAN', 'Blocked by moderator');
+      }
+      await api.logDecision({
+        targetType: 'event',
+        targetId: eventId,
+        action: 'block_media',
+        reason: `Blocked ${mediaHashes.length} media file(s)`,
+      });
+    },
+    onSuccess: () => {
+      toast({ title: `Blocked ${mediaHashes.length} media file(s)` });
+      onActionComplete?.();
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to block media', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const ageRestrictMutation = useMutation({
+    mutationFn: async () => {
+      for (const hash of mediaHashes) {
+        await api.moderateMedia(hash, 'AGE_RESTRICTED', 'Age restricted by moderator');
+      }
+      await api.logDecision({
+        targetType: 'event',
+        targetId: eventId,
+        action: 'age_restrict_media',
+        reason: `Age restricted ${mediaHashes.length} media file(s)`,
+      });
+    },
+    onSuccess: () => {
+      toast({ title: `Age restricted ${mediaHashes.length} media file(s)` });
+      onActionComplete?.();
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to age restrict', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const unblockMediaMutation = useMutation({
+    mutationFn: async () => {
+      for (const hash of mediaHashes) {
+        await api.moderateMedia(hash, 'SAFE', 'Unblocked by moderator');
+      }
+    },
+    onSuccess: () => {
+      toast({ title: 'Media unblocked' });
+      onActionComplete?.();
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to unblock media', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const deleteMediaMutation = useMutation({
+    mutationFn: async () => {
+      for (const hash of mediaHashes) {
+        await api.deleteMedia(hash, 'Permanently deleted by moderator');
+      }
+      await api.logDecision({
+        targetType: 'event',
+        targetId: eventId,
+        action: 'delete_media',
+        reason: `Deleted ${mediaHashes.length} media file(s)`,
+      });
+    },
+    onSuccess: () => {
+      toast({ title: `Deleted ${mediaHashes.length} media file(s)` });
+      onActionComplete?.();
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to delete media', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const deleteEventAndMediaMutation = useMutation({
+    mutationFn: async () => {
+      await api.deleteEvent(eventId, 'Permanently deleted by moderator', pubkey);
+      await api.publishDeletionRequest(eventId, 'Permanently deleted by moderator');
+      for (const hash of mediaHashes) {
+        await api.deleteMedia(hash, 'Permanently deleted by moderator');
+      }
+      await api.logDecision({
+        targetType: 'event',
+        targetId: eventId,
+        action: 'delete_event_and_media',
+        reason: `Permanently deleted event + ${mediaHashes.length} media file(s)`,
+      });
+    },
+    onSuccess: () => {
+      toast({ title: 'Event and media permanently deleted' });
+      onActionComplete?.();
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to delete', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const anyPending = banEventMutation.isPending || restoreEventMutation.isPending ||
+    deleteEventMutation.isPending || blockMediaMutation.isPending || ageRestrictMutation.isPending ||
+    unblockMediaMutation.isPending || deleteMediaMutation.isPending || deleteEventAndMediaMutation.isPending;
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {/* Ban / Restore Event (reversible) */}
+      {isEventBanned ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="outline" onClick={() => restoreEventMutation.mutate()} disabled={anyPending}>
+              <Undo2 className="h-4 w-4 mr-1" />
+              {restoreEventMutation.isPending ? 'Restoring...' : 'Restore Event'}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent><p>Restore this event to the relay. Reverses the ban.</p></TooltipContent>
+        </Tooltip>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="outline" onClick={() => banEventMutation.mutate()} disabled={anyPending}>
+              <ShieldX className="h-4 w-4 mr-1" />
+              {banEventMutation.isPending ? 'Banning...' : 'Ban Event'}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent><p>Ban this event from the relay. Can be reversed.</p></TooltipContent>
+        </Tooltip>
+      )}
+
+      {/* Delete Event (irreversible) */}
+      {!isEventBanned && (
+        <DeleteConfirmDialog
+          trigger={
+            <Button variant="destructive" disabled={anyPending}>
+              <Trash2 className="h-4 w-4 mr-1" />
+              Delete Event
+            </Button>
+          }
+          title="Delete Event"
+          summary="This will permanently ban the event from the relay and publish a NIP-09 deletion request. This cannot be undone."
+          onConfirm={() => deleteEventMutation.mutateAsync()}
+          isPending={deleteEventMutation.isPending}
+        />
+      )}
+
+      {/* Media actions - only when media present */}
+      {hasMedia && (
+        <>
+          {/* Reversible media actions */}
+          {hasBlockedMedia && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="outline" className="border-green-500 text-green-600 hover:bg-green-50"
+                  onClick={() => unblockMediaMutation.mutate()} disabled={anyPending}>
+                  <Unlock className="h-4 w-4 mr-1" />
+                  {unblockMediaMutation.isPending ? 'Unblocking...' : 'Unblock Media'}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent><p>Unblock media. Content will be served again.</p></TooltipContent>
+            </Tooltip>
+          )}
+
+          {hasRestrictedMedia && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="outline" className="border-green-500 text-green-600 hover:bg-green-50"
+                  onClick={() => unblockMediaMutation.mutate()} disabled={anyPending}>
+                  <Unlock className="h-4 w-4 mr-1" />
+                  {unblockMediaMutation.isPending ? 'Removing...' : 'Remove Restriction'}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent><p>Remove age restriction. Media will be publicly accessible.</p></TooltipContent>
+            </Tooltip>
+          )}
+
+          {!hasBlockedMedia && !hasRestrictedMedia && (
+            <>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" onClick={() => blockMediaMutation.mutate()} disabled={anyPending}>
+                    <Video className="h-4 w-4 mr-1" />
+                    {blockMediaMutation.isPending ? 'Blocking...' : `Block Media (${mediaHashes.length})`}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent><p>Block media by hash. Can be reversed.</p></TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" className="border-orange-500 text-orange-600 hover:bg-orange-50"
+                    onClick={() => ageRestrictMutation.mutate()} disabled={anyPending}>
+                    <ShieldAlert className="h-4 w-4 mr-1" />
+                    {ageRestrictMutation.isPending ? 'Restricting...' : `Age Restrict (${mediaHashes.length})`}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent><p>Age-restrict media. Owner can still view, gated for others. Can be reversed.</p></TooltipContent>
+              </Tooltip>
+            </>
+          )}
+
+          {/* Delete Media (irreversible) */}
+          <DeleteConfirmDialog
+            trigger={
+              <Button variant="destructive" disabled={anyPending}>
+                <Trash2 className="h-4 w-4 mr-1" />
+                {`Delete Media (${mediaHashes.length})`}
+              </Button>
+            }
+            title="Delete Media"
+            summary={`This will permanently delete ${mediaHashes.length} media file(s). This cannot be undone.`}
+            onConfirm={() => deleteMediaMutation.mutateAsync()}
+            isPending={deleteMediaMutation.isPending}
+          />
+
+          {/* Delete Event & Media (irreversible, combined) */}
+          {!isEventBanned && (
+            <DeleteConfirmDialog
+              trigger={
+                <Button variant="destructive" disabled={anyPending}>
+                  <Trash2 className="h-4 w-4 mr-1" />
+                  Delete Event & Media
+                </Button>
+              }
+              title="Delete Event & Media"
+              summary={`This will permanently delete the event (ban + NIP-09 deletion) and ${mediaHashes.length} media file(s). This cannot be undone.`}
+              onConfirm={() => deleteEventAndMediaMutation.mutateAsync()}
+              isPending={deleteEventAndMediaMutation.isPending}
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/EventActions.tsx
+++ b/src/components/EventActions.tsx
@@ -134,6 +134,12 @@ export function EventActions({
       for (const hash of mediaHashes) {
         await api.moderateMedia(hash, 'SAFE', 'Unblocked by moderator');
       }
+      await api.logDecision({
+        targetType: 'event',
+        targetId: eventId,
+        action: 'unblock_media',
+        reason: `Unblocked/unrestricted ${mediaHashes.length} media file(s)`,
+      });
     },
     onSuccess: () => {
       toast({ title: 'Media unblocked' });

--- a/src/components/EventActions.tsx
+++ b/src/components/EventActions.tsx
@@ -31,7 +31,7 @@ export function EventActions({
 
   const banEventMutation = useMutation({
     mutationFn: async () => {
-      await api.deleteEvent(eventId, 'Banned by moderator', pubkey);
+      await api.callRelayRpc('banevent', [eventId, 'Banned by moderator']);
       await api.logDecision({
         targetType: 'event',
         targetId: eventId,

--- a/src/components/EventModeration.tsx
+++ b/src/components/EventModeration.tsx
@@ -10,19 +10,10 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { useToast } from "@/hooks/useToast";
-import { Shield, ShieldCheck, ShieldX, Plus, AlertTriangle, CheckCircle, XCircle, Loader2, Undo2 } from "lucide-react";
+import { Shield, ShieldCheck, ShieldX, Plus, AlertTriangle, CheckCircle, XCircle, Loader2 } from "lucide-react";
 import { useAdminApi } from "@/hooks/useAdminApi";
+import { EventActions } from "@/components/EventActions";
 
 interface EventNeedingModeration {
   id: string;
@@ -47,7 +38,6 @@ export function EventModeration() {
     success: boolean;
     message: string;
   } | null>(null);
-  const [confirmUnbanEventId, setConfirmUnbanEventId] = useState<string | null>(null);
 
   // Query for events needing moderation
   const { data: eventsNeedingModeration, isLoading: loadingPending, error: pendingError } = useQuery({
@@ -131,26 +121,6 @@ export function EventModeration() {
   });
 
   // Mutation for unbanning events (restoring)
-  const unbanEventMutation = useMutation({
-    mutationFn: async ({ eventId }: { eventId: string }) => {
-      await callRelayRpc('allowevent', [eventId]);
-      return eventId;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['banned-events'] });
-      queryClient.invalidateQueries({ queryKey: ['events-needing-moderation'] });
-      toast({ title: "Event unbanned", description: "Event has been restored" });
-      setConfirmUnbanEventId(null);
-    },
-    onError: (error: Error) => {
-      toast({
-        title: "Failed to unban event",
-        description: error.message,
-        variant: "destructive"
-      });
-    },
-  });
-
   const handleBanEvent = () => {
     if (!newEventId.trim()) {
       toast({ 
@@ -174,35 +144,6 @@ export function EventModeration() {
 
   return (
     <div className="space-y-6">
-      {/* Unban Event Confirmation Dialog */}
-      <AlertDialog open={!!confirmUnbanEventId} onOpenChange={(open) => !open && setConfirmUnbanEventId(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Unban Event?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will restore the event and allow it to be served by the relay again.
-              <br />
-              <code className="text-xs bg-muted px-1 py-0.5 rounded mt-2 inline-block">
-                {confirmUnbanEventId?.slice(0, 24)}...
-              </code>
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={unbanEventMutation.isPending}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                if (confirmUnbanEventId) {
-                  unbanEventMutation.mutate({ eventId: confirmUnbanEventId });
-                }
-              }}
-              disabled={unbanEventMutation.isPending}
-            >
-              {unbanEventMutation.isPending ? 'Unbanning...' : 'Unban Event'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-2xl font-bold">Event Moderation</h2>
@@ -432,15 +373,15 @@ export function EventModeration() {
                           <p className="text-sm text-muted-foreground mt-1">{event.reason}</p>
                         )}
                       </div>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setConfirmUnbanEventId(event.id)}
-                        disabled={unbanEventMutation.isPending}
-                      >
-                        <Undo2 className="h-4 w-4 mr-1" />
-                        Unban
-                      </Button>
+                      <EventActions
+                        eventId={event.id}
+                        pubkey=""
+                        isEventBanned={true}
+                        onActionComplete={() => {
+                          queryClient.invalidateQueries({ queryKey: ['banned-events'] });
+                          queryClient.invalidateQueries({ queryKey: ['pending-events'] });
+                        }}
+                      />
                     </div>
                   ))}
                 </div>

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -1064,7 +1064,7 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
                 eventId={context.target.value}
                 pubkey={context.reportedUser.pubkey || ''}
                 mediaHashes={mediaHashes}
-                isEventBanned={isEventDeleted}
+                isEventBanned={isEventDeleted ?? undefined}
                 hasBlockedMedia={mediaStatus.hasBlockedMedia}
                 hasRestrictedMedia={mediaStatus.hasRestrictedMedia}
                 onActionComplete={handleActionComplete}
@@ -1076,7 +1076,7 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
               <UserActions
                 pubkey={context.reportedUser.pubkey}
                 context="report"
-                isBanned={isUserBanned}
+                isBanned={isUserBanned ?? undefined}
                 onActionComplete={handleActionComplete}
               />
             )}

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Full detail view for a selected report in the split-pane layout
 // ABOUTME: Combines thread context, user profile, AI summary, and action buttons
 
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -19,7 +19,6 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -38,18 +37,18 @@ import { LabelPublisherInline } from "@/components/LabelPublisher";
 import { ThreadModal } from "@/components/ThreadModal";
 import { useAdminApi } from "@/hooks/useAdminApi";
 import { useAppContext } from "@/hooks/useAppContext";
-import { extractMediaHashes, type ResolutionStatus, type ModerationAction } from "@/lib/adminApi";
+import { extractMediaHashes, type ResolutionStatus } from "@/lib/adminApi";
 import { useMediaStatus } from "@/hooks/useMediaStatus";
 import { useDecisionLog } from "@/hooks/useDecisionLog";
 import { HiveAIReport } from "@/components/HiveAIReport";
 import { AIDetectionReport } from "@/components/AIDetectionReport";
 import { MediaPreview } from "@/components/MediaPreview";
 import { BulkDeleteByKind } from "@/components/BulkDeleteByKind";
-import { CATEGORY_LABELS, HIGH_PRIORITY_CATEGORIES, getReportCategory, buildReasonString } from "@/lib/constants";
+import { EventActions } from "@/components/EventActions";
+import { UserActions } from "@/components/UserActions";
+import { CATEGORY_LABELS, HIGH_PRIORITY_CATEGORIES, getReportCategory } from "@/lib/constants";
 import { KIND_NAMES } from "@/lib/kindNames";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
-import { UserX, UserCheck, Tag, Flag, Trash2, CheckCircle, Video, History, Ban, ShieldX, ShieldAlert, Link2, User, FileText, Unlock, Repeat2, FileCode, Loader2, XCircle, RefreshCw, Undo2, EyeOff, Eye } from "lucide-react";
+import { Tag, Flag, CheckCircle, History, Ban, ShieldX, Link2, User, FileText, Repeat2, FileCode, RefreshCw, EyeOff, Eye } from "lucide-react";
 import { CopyableId, CopyableTags } from "@/components/CopyableId";
 import type { NostrEvent } from "@nostrify/nostrify";
 
@@ -81,85 +80,20 @@ function getReportTarget(event: NostrEvent): { type: 'event' | 'pubkey'; value: 
   return null;
 }
 
-// Deduplicated category labels for the reason selector dropdown.
-// Also builds a map from any raw key to its canonical (first-seen) key,
-// so getReportCategory() values always match a SelectItem.
-const { UNIQUE_CATEGORY_ENTRIES, CANONICAL_KEY } = (() => {
-  const seen = new Map<string, string>(); // label → first key
-  const entries: [string, string][] = [];
-  const canonical: Record<string, string> = {};
-  for (const [key, label] of Object.entries(CATEGORY_LABELS)) {
-    if (!seen.has(label)) {
-      seen.set(label, key);
-      entries.push([key, label]);
-    }
-    canonical[key] = seen.get(label)!;
-  }
-  return { UNIQUE_CATEGORY_ENTRIES: entries, CANONICAL_KEY: canonical };
-})();
 
 export function ReportDetail({ report, allReportsForTarget, allReports = [], onDismiss }: ReportDetailProps) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const {
-    banPubkey, deleteEvent, markAsReviewed, moderateMedia, unblockMedia,
-    logDecision, deleteDecisions, verifyModerationAction, verifyPubkeyBanned,
-    verifyPubkeyUnbanned, verifyEventDeleted, verifyMediaBlocked, verifyAgeRestricted,
-    unbanPubkey, callRelayRpc,
+    deleteEvent, markAsReviewed, logDecision, deleteDecisions, callRelayRpc,
   } = useAdminApi();
   const { config } = useAppContext();
   const navigate = useNavigate();
   const [showThreadModal, setShowThreadModal] = useState(false);
   const [showLabelForm, setShowLabelForm] = useState(false);
-  const [confirmBan, setConfirmBan] = useState(false);
-  const [confirmDelete, setConfirmDelete] = useState(false);
   const [confirmDismiss, setConfirmDismiss] = useState(false);
   const [dismissReason, setDismissReason] = useState("");
-  const [confirmBlockMedia, setConfirmBlockMedia] = useState(false);
-  const [confirmAgeRestrict, setConfirmAgeRestrict] = useState(false);
-  const [confirmBlockAndDelete, setConfirmBlockAndDelete] = useState(false);
-  const [banOptions, setBanOptions] = useState({ deleteEvents: true, blockMedia: true });
-  const [actionReason, setActionReason] = useState('');
-  const [actionNote, setActionNote] = useState('');
 
-  // Initialize reason from report category when report changes
-  const defaultReason = report ? (CANONICAL_KEY[getReportCategory(report)] || getReportCategory(report)) : '';
-  useEffect(() => {
-    if (report) {
-      setActionReason(defaultReason);
-      setActionNote('');
-    }
-  }, [report, defaultReason]);
-
-  const reasonSelector = (
-    <div className="space-y-2 pt-2 border-t">
-      <Label className="text-sm font-medium">Reason</Label>
-      <Select value={actionReason} onValueChange={setActionReason}>
-        <SelectTrigger>
-          <SelectValue placeholder="Select reason..." />
-        </SelectTrigger>
-        <SelectContent>
-          {UNIQUE_CATEGORY_ENTRIES.map(([key, label]) => (
-            <SelectItem key={key} value={key}>{label}</SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-      <Textarea
-        placeholder="Add a note (optional)..."
-        value={actionNote}
-        onChange={(e) => setActionNote(e.target.value)}
-        rows={2}
-        maxLength={500}
-      />
-    </div>
-  );
-
-  const [isVerifying, setIsVerifying] = useState(false);
-  const [verificationResult, setVerificationResult] = useState<{
-    type: 'ban' | 'delete' | 'media';
-    success: boolean;
-    message: string;
-  } | null>(null);
   const context = useReportContext(report);
 
   // Banned event fallback: if thread found no event and target is an event ID, try management API
@@ -241,221 +175,6 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
     return { userReports, eventReports };
   }, [allReports, context.reportedUser.pubkey, context.target]);
 
-  const banMutation = useMutation({
-    mutationFn: async ({ pubkey, reason, deleteEvents, blockMedia }: {
-      pubkey: string;
-      reason: string;
-      deleteEvents?: boolean;
-      blockMedia?: boolean;
-    }) => {
-      const results = { banned: false, eventsDeleted: 0, mediaBlocked: 0 };
-
-      // Ban the pubkey
-      await banPubkey(pubkey, reason);
-      results.banned = true;
-
-      // Log the ban decision
-      await logDecision({
-        targetType: 'pubkey',
-        targetId: pubkey,
-        action: 'ban_user',
-        reason,
-        reportId: report?.id,
-      });
-
-      // Always delete the reported event when banning a user
-      if (context.target?.type === 'event' && context.target.value) {
-        try {
-          await deleteEvent(context.target.value, `User banned: ${reason}`);
-          await logDecision({
-            targetType: 'event',
-            targetId: context.target.value,
-            action: 'delete_event',
-            reason: `User banned: ${reason}`,
-            reportId: report?.id,
-          });
-          results.eventsDeleted++;
-        } catch {
-          // Continue even if this fails
-        }
-      }
-
-      // Optionally delete all their other events
-      if (deleteEvents && context.userStats?.recentPosts) {
-        const alreadyDeleted = context.target?.type === 'event' ? context.target.value : null;
-        for (const event of context.userStats.recentPosts) {
-          if (event.id === alreadyDeleted) continue; // Already deleted above
-          try {
-            await deleteEvent(event.id, `User banned: ${reason}`);
-            await logDecision({
-              targetType: 'event',
-              targetId: event.id,
-              action: 'delete_event',
-              reason: `User banned: ${reason}`,
-              reportId: report?.id,
-            });
-            results.eventsDeleted++;
-          } catch {
-            // Continue even if some fail
-          }
-        }
-      }
-
-      // Optionally block all their media
-      if (blockMedia) {
-        const allHashes = new Set<string>();
-        // Include media from the reported event
-        if (context.thread?.event) {
-          const hashes = extractMediaHashes(context.thread.event.content, context.thread.event.tags);
-          hashes.forEach(h => allHashes.add(h));
-        }
-        if (context.thread?.repostedEvent) {
-          const hashes = extractMediaHashes(context.thread.repostedEvent.content, context.thread.repostedEvent.tags);
-          hashes.forEach(h => allHashes.add(h));
-        }
-        // Include media from other recent posts
-        if (context.userStats?.recentPosts) {
-          for (const event of context.userStats.recentPosts) {
-            const hashes = extractMediaHashes(event.content, event.tags);
-            hashes.forEach(h => allHashes.add(h));
-          }
-        }
-        for (const hash of allHashes) {
-          try {
-            await moderateMedia(hash, 'PERMANENT_BAN', `User banned: ${reason}`);
-            await logDecision({
-              targetType: 'media',
-              targetId: hash,
-              action: 'block_media',
-              reason: `User banned: ${reason}`,
-              reportId: report?.id,
-            });
-            results.mediaBlocked++;
-          } catch {
-            // Continue even if some fail
-          }
-        }
-      }
-
-      return results;
-    },
-    onSuccess: async (results, variables) => {
-      queryClient.invalidateQueries({ queryKey: ['banned-users'] });
-      queryClient.invalidateQueries({ queryKey: ['banned-pubkeys'] });
-      queryClient.invalidateQueries({ queryKey: ['banned-events'] });
-      queryClient.invalidateQueries({ queryKey: ['decisions'] });
-      moderationStatus.recheck();
-      decisionLog.refetch();
-
-      let message = "User banned";
-      if (results.eventsDeleted > 0) {
-        message += `, ${results.eventsDeleted} event(s) deleted`;
-      }
-      if (results.mediaBlocked > 0) {
-        message += `, ${results.mediaBlocked} media file(s) blocked`;
-      }
-
-      toast({ title: message, description: "Verifying..." });
-      setConfirmBan(false);
-
-      // Verify the ban worked
-      setIsVerifying(true);
-      setVerificationResult(null);
-      try {
-        const verified = await verifyPubkeyBanned(variables.pubkey);
-        setVerificationResult({
-          type: 'ban',
-          success: verified,
-          message: verified
-            ? 'Ban verified - user is in banned list'
-            : 'Warning: User may not be banned',
-        });
-        toast({
-          title: verified ? "Ban Verified" : "Verification Warning",
-          description: verified
-            ? "User confirmed banned on relay"
-            : "Could not confirm ban - check manually",
-          variant: verified ? "default" : "destructive",
-        });
-      } catch {
-        setVerificationResult({
-          type: 'ban',
-          success: false,
-          message: 'Could not verify ban status',
-        });
-      } finally {
-        setIsVerifying(false);
-      }
-    },
-    onError: (error: Error) => {
-      toast({
-        title: "Failed to ban user",
-        description: error.message,
-        variant: "destructive",
-      });
-    },
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: async ({ eventId, reason }: { eventId: string; reason: string }) => {
-      await deleteEvent(eventId, reason, context.reportedUser?.pubkey ?? undefined);
-      // Log the decision
-      await logDecision({
-        targetType: 'event',
-        targetId: eventId,
-        action: 'delete_event',
-        reason,
-        reportId: report?.id,
-      });
-      return eventId;
-    },
-    onSuccess: async (eventId) => {
-      queryClient.invalidateQueries({ queryKey: ['reports'] });
-      queryClient.invalidateQueries({ queryKey: ['banned-events'] });
-      queryClient.invalidateQueries({ queryKey: ['decisions'] });
-      moderationStatus.recheck();
-      decisionLog.refetch();
-      toast({ title: "Event deleted from relay", description: "Verifying..." });
-      setConfirmDelete(false);
-
-      // Verify the delete worked
-      setIsVerifying(true);
-      setVerificationResult(null);
-      try {
-        const isDeleted = await verifyEventDeleted(eventId);
-        setVerificationResult({
-          type: 'delete',
-          success: isDeleted,
-          message: isDeleted
-            ? 'Delete verified - event removed from relay'
-            : 'Warning: Event may still exist on relay',
-        });
-        toast({
-          title: isDeleted ? "Delete Verified" : "Verification Warning",
-          description: isDeleted
-            ? "Event confirmed removed from relay"
-            : "Could not confirm event removal - check manually",
-          variant: isDeleted ? "default" : "destructive",
-        });
-      } catch {
-        setVerificationResult({
-          type: 'delete',
-          success: false,
-          message: 'Could not verify delete status',
-        });
-      } finally {
-        setIsVerifying(false);
-      }
-    },
-    onError: (error: Error) => {
-      toast({
-        title: "Failed to delete event",
-        description: error.message,
-        variant: "destructive",
-      });
-    },
-  });
-
   const reviewMutation = useMutation({
     mutationFn: async ({ status, comment }: { status: ResolutionStatus; comment?: string }) => {
       if (!context.target) throw new Error('No target');
@@ -518,151 +237,6 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
     },
   });
 
-  const blockMediaMutation = useMutation({
-    mutationFn: async ({ hashes, action, reason }: { hashes: string[]; action: ModerationAction; reason: string }) => {
-      // Block all media hashes found in the event
-      const results = await Promise.all(
-        hashes.map(sha256 => moderateMedia(sha256, action, reason))
-      );
-      // Log decisions for each hash
-      await Promise.all(
-        hashes.map(sha256 => logDecision({
-          targetType: 'media',
-          targetId: sha256,
-          action: 'block_media',
-          reason,
-          reportId: report?.id,
-        }))
-      );
-      return { results, hashes };
-    },
-    onSuccess: async ({ hashes }) => {
-      queryClient.invalidateQueries({ queryKey: ['decisions'] });
-      queryClient.invalidateQueries({ queryKey: ['media-status'] });
-      decisionLog.refetch();
-      toast({
-        title: "Media blocked",
-        description: `${hashes.length} media file(s) permanently banned. Verifying...`,
-      });
-      setConfirmBlockMedia(false);
-
-      // Verify the media block worked
-      setIsVerifying(true);
-      setVerificationResult(null);
-      try {
-        // Verify each hash individually
-        const verificationResults = await Promise.all(
-          hashes.map(async (hash) => ({
-            hash,
-            blocked: await verifyMediaBlocked(hash),
-          }))
-        );
-        const allBlocked = verificationResults.every(v => v.blocked);
-        const failedCount = verificationResults.filter(v => !v.blocked).length;
-        setVerificationResult({
-          type: 'media',
-          success: allBlocked,
-          message: allBlocked
-            ? 'Media block verified - all files blocked'
-            : `Warning: ${failedCount} file(s) may not be blocked`,
-        });
-        toast({
-          title: allBlocked ? "Block Verified" : "Verification Warning",
-          description: allBlocked
-            ? "All media confirmed blocked"
-            : "Some media may not be blocked - check manually",
-          variant: allBlocked ? "default" : "destructive",
-        });
-      } catch {
-        setVerificationResult({
-          type: 'media',
-          success: false,
-          message: 'Could not verify media block status',
-        });
-      } finally {
-        setIsVerifying(false);
-      }
-    },
-    onError: (error: Error) => {
-      toast({
-        title: "Failed to block media",
-        description: error.message,
-        variant: "destructive",
-      });
-    },
-  });
-
-  const ageRestrictMediaMutation = useMutation({
-    mutationFn: async ({ hashes, reason }: { hashes: string[]; reason: string }) => {
-      const results = await Promise.all(
-        hashes.map(sha256 => moderateMedia(sha256, 'AGE_RESTRICTED', reason))
-      );
-      await Promise.all(
-        hashes.map(sha256 => logDecision({
-          targetType: 'media',
-          targetId: sha256,
-          action: 'restrict_media',
-          reason,
-          reportId: report?.id,
-        }))
-      );
-      return { results, hashes };
-    },
-    onSuccess: async ({ hashes }) => {
-      queryClient.invalidateQueries({ queryKey: ['decisions'] });
-      queryClient.invalidateQueries({ queryKey: ['media-status'] });
-      decisionLog.refetch();
-      toast({
-        title: "Media age-restricted",
-        description: `${hashes.length} media file(s) age-restricted. Verifying...`,
-      });
-      setConfirmAgeRestrict(false);
-
-      // Verify the age restriction landed (same pattern as blockMediaMutation)
-      setIsVerifying(true);
-      setVerificationResult(null);
-      try {
-        const verificationResults = await Promise.all(
-          hashes.map(async (hash) => ({
-            hash,
-            restricted: await verifyAgeRestricted(hash),
-          }))
-        );
-        const allRestricted = verificationResults.every(v => v.restricted);
-        const failedCount = verificationResults.filter(v => !v.restricted).length;
-        setVerificationResult({
-          type: 'media',
-          success: allRestricted,
-          message: allRestricted
-            ? 'Age restriction verified - all files restricted'
-            : `Warning: ${failedCount} file(s) may not be restricted`,
-        });
-        toast({
-          title: allRestricted ? "Restriction Verified" : "Verification Warning",
-          description: allRestricted
-            ? "All media confirmed age-restricted"
-            : "Some media may not be restricted - check manually",
-          variant: allRestricted ? "default" : "destructive",
-        });
-      } catch {
-        setVerificationResult({
-          type: 'media',
-          success: false,
-          message: 'Could not verify age restriction status',
-        });
-      } finally {
-        setIsVerifying(false);
-      }
-    },
-    onError: (error: Error) => {
-      toast({
-        title: "Failed to age-restrict media",
-        description: error.message,
-        variant: "destructive",
-      });
-    },
-  });
-
   // Extract media hashes from the reported event AND reposted event if it's a repost
   const mediaHashes = useMemo(() => {
     const hashes = new Set<string>();
@@ -693,122 +267,6 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
       return HIGH_PRIORITY_CATEGORIES.includes(cat);
     });
   }, [allReportsForTarget]);
-
-  const unblockMediaMutation = useMutation({
-    mutationFn: async ({ hashes, reason, logAction = 'unblock_media' }: { hashes: string[]; reason: string; logAction?: 'unblock_media' | 'unrestrict_media' }) => {
-      // Unblock all media hashes (sends SAFE to moderation-service)
-      const results = await Promise.all(
-        hashes.map(sha256 => unblockMedia(sha256, reason))
-      );
-      // Log decisions for each hash
-      await Promise.all(
-        hashes.map(sha256 => logDecision({
-          targetType: 'media',
-          targetId: sha256,
-          action: logAction,
-          reason,
-          reportId: report?.id,
-        }))
-      );
-      return results;
-    },
-    onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: ['decisions'] });
-      queryClient.invalidateQueries({ queryKey: ['media-status'] });
-      mediaStatus.refetch();
-      decisionLog.refetch();
-      toast({
-        title: variables.logAction === 'unrestrict_media' ? "Restriction removed" : "Media unblocked",
-        description: `${variables.hashes.length} media file(s) ${variables.logAction === 'unrestrict_media' ? 'unrestricted' : 'unblocked'}`,
-      });
-    },
-    onError: (error: Error) => {
-      toast({
-        title: "Failed to unblock media",
-        description: error.message,
-        variant: "destructive",
-      });
-    },
-  });
-
-  const unbanUserMutation = useMutation({
-    mutationFn: async ({ pubkey }: { pubkey: string }) => {
-      await unbanPubkey(pubkey);
-      await logDecision({
-        targetType: 'pubkey',
-        targetId: pubkey,
-        action: 'unban_user',
-        reason: 'Unbanned from report viewer',
-        reportId: report?.id,
-      });
-      return pubkey;
-    },
-    onSuccess: async (pubkey) => {
-      queryClient.invalidateQueries({ queryKey: ['banned-users'] });
-      queryClient.invalidateQueries({ queryKey: ['banned-pubkeys'] });
-      queryClient.invalidateQueries({ queryKey: ['decisions'] });
-      moderationStatus.recheck();
-      decisionLog.refetch();
-      toast({ title: "User unbanned", description: "Verifying..." });
-
-      setIsVerifying(true);
-      setVerificationResult(null);
-      try {
-        const verified = await verifyPubkeyUnbanned(pubkey);
-        setVerificationResult({
-          type: 'ban',
-          success: verified,
-          message: verified
-            ? 'Unban verified - user is no longer in banned list'
-            : 'Warning: User may still be banned',
-        });
-      } catch {
-        setVerificationResult({
-          type: 'ban',
-          success: false,
-          message: 'Could not verify unban status',
-        });
-      } finally {
-        setIsVerifying(false);
-      }
-    },
-    onError: (error: Error) => {
-      toast({
-        title: "Failed to unban user",
-        description: error.message,
-        variant: "destructive",
-      });
-    },
-  });
-
-  const restoreEventMutation = useMutation({
-    mutationFn: async ({ eventId }: { eventId: string }) => {
-      await callRelayRpc('allowevent', [eventId]);
-      await logDecision({
-        targetType: 'event',
-        targetId: eventId,
-        action: 'restore_event',
-        reason: 'Restored from report viewer',
-        reportId: report?.id,
-      });
-      return eventId;
-    },
-    onSuccess: async () => {
-      queryClient.invalidateQueries({ queryKey: ['reports'] });
-      queryClient.invalidateQueries({ queryKey: ['banned-events'] });
-      queryClient.invalidateQueries({ queryKey: ['decisions'] });
-      moderationStatus.recheck();
-      decisionLog.refetch();
-      toast({ title: "Event restored" });
-    },
-    onError: (error: Error) => {
-      toast({
-        title: "Failed to restore event",
-        description: error.message,
-        variant: "destructive",
-      });
-    },
-  });
 
   // Confirm auto-hidden content (approve the auto-hide decision)
   const confirmAutoHideMutation = useMutation({
@@ -868,100 +326,17 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
     },
   });
 
-  // Combined action: Block media AND delete event
-  const blockAndDeleteMutation = useMutation({
-    mutationFn: async ({ eventId, hashes, reason }: { eventId: string; hashes: string[]; reason: string }) => {
-      const results = { mediaBlocked: 0, eventDeleted: false };
-
-      // First block all media
-      for (const sha256 of hashes) {
-        try {
-          await moderateMedia(sha256, 'PERMANENT_BAN', reason);
-          await logDecision({
-            targetType: 'media',
-            targetId: sha256,
-            action: 'block_media',
-            reason,
-            reportId: report?.id,
-          });
-          results.mediaBlocked++;
-        } catch {
-          // Continue even if some fail
-        }
-      }
-
-      // Then delete the event
-      await deleteEvent(eventId, reason, context.reportedUser?.pubkey ?? undefined);
-      await logDecision({
-        targetType: 'event',
-        targetId: eventId,
-        action: 'delete_event',
-        reason,
-        reportId: report?.id,
-      });
-      results.eventDeleted = true;
-
-      return results;
-    },
-    onSuccess: async (results, variables) => {
-      queryClient.invalidateQueries({ queryKey: ['reports'] });
-      queryClient.invalidateQueries({ queryKey: ['banned-events'] });
-      queryClient.invalidateQueries({ queryKey: ['decisions'] });
-      queryClient.invalidateQueries({ queryKey: ['media-status'] });
-      moderationStatus.recheck();
-      decisionLog.refetch();
-      toast({
-        title: "Content removed",
-        description: `${results.mediaBlocked} media file(s) blocked and event deleted. Verifying...`,
-      });
-      setConfirmBlockAndDelete(false);
-
-      // Verify the moderation action worked
-      setIsVerifying(true);
-      try {
-        const verification = await verifyModerationAction(
-          variables.eventId,
-          variables.hashes
-        );
-
-        if (verification.allSuccessful) {
-          toast({
-            title: "Verified",
-            description: "Event deleted and all media blocked successfully",
-          });
-        } else {
-          const issues: string[] = [];
-          if (!verification.eventDeleted) {
-            issues.push("Event may still be accessible");
-          }
-          const failedMedia = verification.mediaBlocked.filter(m => !m.blocked);
-          if (failedMedia.length > 0) {
-            issues.push(`${failedMedia.length} media file(s) may not be blocked`);
-          }
-          toast({
-            title: "Verification Warning",
-            description: issues.join(". "),
-            variant: "destructive",
-          });
-        }
-      } catch (verifyError) {
-        console.error('Verification failed:', verifyError);
-        toast({
-          title: "Verification unavailable",
-          description: "Could not verify moderation action",
-        });
-      } finally {
-        setIsVerifying(false);
-      }
-    },
-    onError: (error: Error) => {
-      toast({
-        title: "Failed to remove content",
-        description: error.message,
-        variant: "destructive",
-      });
-    },
-  });
+  const handleActionComplete = () => {
+    queryClient.invalidateQueries({ queryKey: ['reports'] });
+    queryClient.invalidateQueries({ queryKey: ['banned-events'] });
+    queryClient.invalidateQueries({ queryKey: ['banned-users'] });
+    queryClient.invalidateQueries({ queryKey: ['banned-pubkeys'] });
+    queryClient.invalidateQueries({ queryKey: ['decisions'] });
+    queryClient.invalidateQueries({ queryKey: ['media-status'] });
+    queryClient.invalidateQueries({ queryKey: ['user-stats', context.reportedUser.pubkey] });
+    moderationStatus.recheck();
+    decisionLog.refetch();
+  };
 
   if (!report) {
     return (
@@ -982,247 +357,6 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
     <div className="h-full flex flex-col overflow-hidden">
       {/* Dialogs - rendered as portals, don't affect flex layout */}
       {/* Ban Confirmation Dialog */}
-      <AlertDialog open={confirmBan} onOpenChange={(open) => { setConfirmBan(open); if (!open) { setActionNote(''); setActionReason(defaultReason); } }}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Ban User?</AlertDialogTitle>
-            <AlertDialogDescription asChild>
-              <div className="space-y-3">
-                <p>This will ban this user from the relay. This can be reversed.</p>
-                {context.reportedUser.pubkey && (
-                  <div className="bg-muted px-2 py-1.5 rounded">
-                    <UserIdentifier
-                      pubkey={context.reportedUser.pubkey}
-                      showAvatar
-                      avatarSize="sm"
-                      variant="block"
-                      linkToProfile
-                    />
-                  </div>
-                )}
-
-                <div className="space-y-2 pt-2">
-                  <div className="flex items-center space-x-2">
-                    <Checkbox
-                      id="deleteEvents"
-                      checked={banOptions.deleteEvents}
-                      onCheckedChange={(checked) =>
-                        setBanOptions(prev => ({ ...prev, deleteEvents: !!checked }))
-                      }
-                    />
-                    <Label htmlFor="deleteEvents" className="text-sm font-normal">
-                      Delete all events from this user ({context.userStats?.recentPosts?.length || 0} found)
-                    </Label>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <Checkbox
-                      id="blockMedia"
-                      checked={banOptions.blockMedia}
-                      onCheckedChange={(checked) =>
-                        setBanOptions(prev => ({ ...prev, blockMedia: !!checked }))
-                      }
-                    />
-                    <Label htmlFor="blockMedia" className="text-sm font-normal">
-                      Block all media/videos from this user
-                    </Label>
-                  </div>
-                </div>
-
-                {reasonSelector}
-              </div>
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={banMutation.isPending}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                if (context.reportedUser.pubkey) {
-                  banMutation.mutate({
-                    pubkey: context.reportedUser.pubkey,
-                    reason: buildReasonString(actionReason, actionNote),
-                    deleteEvents: banOptions.deleteEvents,
-                    blockMedia: banOptions.blockMedia,
-                  });
-                }
-              }}
-              disabled={banMutation.isPending}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {banMutation.isPending ? 'Banning...' : 'Ban User'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
-      {/* Delete Event Confirmation Dialog */}
-      <AlertDialog open={confirmDelete} onOpenChange={(open) => { setConfirmDelete(open); if (!open) { setActionNote(''); setActionReason(defaultReason); } }}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Ban Event?</AlertDialogTitle>
-            <AlertDialogDescription asChild>
-              <div>
-                <p>This will remove this event from the relay. The content will no longer be served. This can be reversed.</p>
-                {context.target?.value && (
-                  <div className="mt-2">
-                    <CopyableId
-                      value={context.target.value}
-                      type="note"
-                      truncateStart={16}
-                      truncateEnd={8}
-                      size="xs"
-                    />
-                  </div>
-                )}
-
-                {reasonSelector}
-              </div>
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleteMutation.isPending}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                if (context.target?.type === 'event' && context.target.value) {
-                  deleteMutation.mutate({
-                    eventId: context.target.value,
-                    reason: buildReasonString(actionReason, actionNote),
-                  });
-                }
-              }}
-              disabled={deleteMutation.isPending}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {deleteMutation.isPending ? 'Banning...' : 'Ban Event'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
-      {/* Block Media Confirmation Dialog */}
-      <AlertDialog open={confirmBlockMedia} onOpenChange={(open) => { setConfirmBlockMedia(open); if (!open) { setActionNote(''); setActionReason(defaultReason); } }}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Block Media?</AlertDialogTitle>
-            <AlertDialogDescription asChild>
-              <div>
-                <p>This will ban {mediaHashes.length} media file(s) from being served. This can be reversed.</p>
-                <div className="mt-2 space-y-1">
-                  {mediaHashes.map(hash => (
-                    <CopyableId
-                      key={hash}
-                      value={hash}
-                      type="hash"
-                      truncateStart={16}
-                      truncateEnd={8}
-                      size="xs"
-                    />
-                  ))}
-                </div>
-
-                {reasonSelector}
-              </div>
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={blockMediaMutation.isPending}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                blockMediaMutation.mutate({
-                  hashes: mediaHashes,
-                  action: 'PERMANENT_BAN',
-                  reason: buildReasonString(actionReason, actionNote),
-                });
-              }}
-              disabled={blockMediaMutation.isPending}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {blockMediaMutation.isPending ? 'Blocking...' : 'Block Media'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
-      {/* Age Restrict Media Confirmation Dialog */}
-      <AlertDialog open={confirmAgeRestrict} onOpenChange={(open) => { setConfirmAgeRestrict(open); if (!open) { setActionNote(''); setActionReason(defaultReason); } }}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Age-Restrict Media?</AlertDialogTitle>
-            <AlertDialogDescription asChild>
-              <div>
-                <p>This will age-restrict {mediaHashes.length} media file(s). The content owner can still view it, but it will be hidden from the public feed and age-gated in supporting clients. This can be reversed.</p>
-                <div className="mt-2 space-y-1">
-                  {mediaHashes.map(hash => (
-                    <CopyableId
-                      key={hash}
-                      value={hash}
-                      type="hash"
-                      truncateStart={16}
-                      truncateEnd={8}
-                      size="xs"
-                    />
-                  ))}
-                </div>
-
-                {reasonSelector}
-              </div>
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={ageRestrictMediaMutation.isPending}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                ageRestrictMediaMutation.mutate({
-                  hashes: mediaHashes,
-                  reason: buildReasonString(actionReason, actionNote),
-                });
-              }}
-              disabled={ageRestrictMediaMutation.isPending}
-              className="bg-orange-600 text-white hover:bg-orange-700"
-            >
-              {ageRestrictMediaMutation.isPending ? 'Restricting...' : 'Age Restrict'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
-      {/* Block Media AND Delete Event Combined Confirmation Dialog */}
-      <AlertDialog open={confirmBlockAndDelete} onOpenChange={(open) => { setConfirmBlockAndDelete(open); if (!open) { setActionNote(''); setActionReason(defaultReason); } }}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Remove Content?</AlertDialogTitle>
-            <AlertDialogDescription asChild>
-              <div className="space-y-2">
-                <p>This will:</p>
-                <ul className="list-disc list-inside space-y-1 text-sm">
-                  <li>Ban {mediaHashes.length} media file(s)</li>
-                  <li>Delete the event from the relay</li>
-                </ul>
-
-                {reasonSelector}
-              </div>
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={blockAndDeleteMutation.isPending}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                if (context.target?.type === 'event' && context.target.value) {
-                  blockAndDeleteMutation.mutate({
-                    eventId: context.target.value,
-                    hashes: mediaHashes,
-                    reason: buildReasonString(actionReason, actionNote),
-                  });
-                }
-              }}
-              disabled={blockAndDeleteMutation.isPending}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {blockAndDeleteMutation.isPending ? 'Removing...' : 'Remove Content'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
       {/* Dismiss Report Dialog */}
       <AlertDialog open={confirmDismiss} onOpenChange={(open) => { setConfirmDismiss(open); if (!open) setDismissReason(''); }}>
         <AlertDialogContent>
@@ -1276,42 +410,6 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
       {/* Scrollable content area */}
       <ScrollArea className="flex-1 min-h-0 [&>div>div]:!block">
         <div className="p-4 space-y-4 overflow-x-hidden max-w-full">
-          {/* Verification Status - for just-completed actions */}
-          {(isVerifying || verificationResult) && (
-            <div
-              className={`p-3 rounded-lg flex items-center gap-3 ${
-                verificationResult?.success
-                  ? "bg-green-100 dark:bg-green-950/50 border border-green-300 dark:border-green-800"
-                  : "bg-red-100 dark:bg-red-950/50 border border-red-300 dark:border-red-800"
-              }`}
-            >
-              {isVerifying ? (
-                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-              ) : verificationResult?.success ? (
-                <CheckCircle className="h-5 w-5 text-green-600" />
-              ) : (
-                <XCircle className="h-5 w-5 text-red-600" />
-              )}
-              <div className="flex-1">
-                <p className={`text-sm font-medium ${verificationResult?.success ? "text-green-800 dark:text-green-300" : "text-red-800 dark:text-red-300"}`}>
-                  {isVerifying
-                    ? "Verifying moderation action..."
-                    : verificationResult?.message}
-                </p>
-              </div>
-              {verificationResult && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setVerificationResult(null)}
-                  className="h-6 px-2"
-                >
-                  Dismiss
-                </Button>
-              )}
-            </div>
-          )}
-
           {/* Pending Review Banner - for auto-hidden items awaiting human review */}
           {isPendingReview && (
             <div className="bg-orange-100 dark:bg-orange-950/50 border border-orange-300 dark:border-orange-800 rounded-lg p-3">
@@ -1690,20 +788,26 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
             stats={context.userStats}
             isLoading={false}
             isFunnelcakeUser={context.reportedUser.isFunnelcakeUser}
-            onDeleteEvent={(eventId) => {
-              deleteMutation.mutate({ eventId, reason: 'Deleted from report review' }, {
-                onSuccess: (deletedId) => {
-                  toast({
-                    title: "Event deleted",
-                    description: "The event has been removed from the relay.",
-                    action: (
-                      <ToastAction altText="Undo delete" onClick={() => restoreEventMutation.mutate({ eventId: deletedId })}>
-                        Undo
-                      </ToastAction>
-                    ),
-                  });
-                },
-              });
+            onDeleteEvent={async (eventId) => {
+              try {
+                await deleteEvent(eventId, 'Deleted from report review');
+                toast({
+                  title: "Event deleted",
+                  description: "The event has been removed from the relay.",
+                  action: (
+                    <ToastAction altText="Undo delete" onClick={async () => {
+                      await callRelayRpc('allowevent', [eventId]);
+                      handleActionComplete();
+                      toast({ title: "Event restored" });
+                    }}>
+                      Undo
+                    </ToastAction>
+                  ),
+                });
+                handleActionComplete();
+              } catch (error) {
+                toast({ title: "Failed to delete event", description: String(error), variant: "destructive" });
+              }
             }}
           />
           </>
@@ -1954,197 +1058,31 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
               </Tooltip>
             </div>
 
-            {/* Primary enforcement action - combined when media present and not already moderated */}
-            {context.target?.type === 'event' && mediaHashes.length > 0 && !isEventDeleted && !mediaStatus.hasModeratedMedia && (
-              <div>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="destructive"
-                      size="lg"
-                      className="w-full"
-                      onClick={() => setConfirmBlockAndDelete(true)}
-                      disabled={blockAndDeleteMutation.isPending || mediaStatus.isLoading || isVerifying}
-                    >
-                      <Trash2 className="h-4 w-4 mr-2" />
-                      {blockAndDeleteMutation.isPending ? 'Removing...' : isVerifying ? 'Verifying...' : mediaStatus.isLoading ? 'Checking media...' : `Block Media & Ban Event`}
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom" className="max-w-xs">
-                    <p>Block all media files (images/videos) AND ban the event from the relay. The media will be blocked by hash so re-uploads are prevented. Both actions can be reversed.</p>
-                  </TooltipContent>
-                </Tooltip>
-              </div>
+            {/* Event & media actions */}
+            {context.target?.type === 'event' && context.target.value && (
+              <EventActions
+                eventId={context.target.value}
+                pubkey={context.reportedUser.pubkey || ''}
+                mediaHashes={mediaHashes}
+                isEventBanned={isEventDeleted}
+                hasBlockedMedia={mediaStatus.hasBlockedMedia}
+                hasRestrictedMedia={mediaStatus.hasRestrictedMedia}
+                onActionComplete={handleActionComplete}
+              />
             )}
 
-            {/* Secondary enforcement actions */}
+            {/* User actions */}
+            {context.reportedUser.pubkey && (
+              <UserActions
+                pubkey={context.reportedUser.pubkey}
+                context="report"
+                isBanned={isUserBanned}
+                onActionComplete={handleActionComplete}
+              />
+            )}
+
+            {/* Report-specific actions */}
             <div className="flex flex-wrap gap-2">
-              {context.target?.type === 'event' && (
-                isEventDeleted ? (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="outline"
-                        onClick={() => {
-                          if (context.target?.type === 'event' && context.target.value) {
-                            restoreEventMutation.mutate({ eventId: context.target.value });
-                          }
-                        }}
-                        disabled={restoreEventMutation.isPending}
-                      >
-                        <Undo2 className="h-4 w-4 mr-1" />
-                        {restoreEventMutation.isPending ? 'Restoring...' : 'Restore Event'}
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" className="max-w-xs">
-                      <p>Restore this event to the relay. This reverses the ban and allows the content to be served again.</p>
-                    </TooltipContent>
-                  </Tooltip>
-                ) : (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="outline"
-                        onClick={() => setConfirmDelete(true)}
-                        disabled={deleteMutation.isPending}
-                      >
-                        <ShieldX className="h-4 w-4 mr-1" />
-                        Ban Event
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" className="max-w-xs">
-                      <p>Ban this event from the relay. The event will no longer be served, but the user can still post new content. This can be reversed.</p>
-                    </TooltipContent>
-                  </Tooltip>
-                )
-              )}
-              {mediaHashes.length > 0 && mediaStatus.hasBlockedMedia && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="outline"
-                      className="border-green-500 text-green-600 hover:bg-green-50"
-                      onClick={() => {
-                        const blockedHashes = mediaStatus.results
-                          .filter(r => r.isBlocked)
-                          .map(r => r.hash);
-                        unblockMediaMutation.mutate({
-                          hashes: blockedHashes,
-                          reason: 'Unblocked by moderator',
-                        });
-                      }}
-                      disabled={unblockMediaMutation.isPending || mediaStatus.isLoading}
-                    >
-                      <Unlock className="h-4 w-4 mr-1" />
-                      {unblockMediaMutation.isPending ? 'Unblocking...' : `Unblock Media (${mediaStatus.blockedCount})`}
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom" className="max-w-xs">
-                    <p>Unblock previously blocked media files. They will be allowed to be served again.</p>
-                  </TooltipContent>
-                </Tooltip>
-              )}
-              {mediaHashes.length > 0 && mediaStatus.hasRestrictedMedia && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="outline"
-                      className="border-green-500 text-green-600 hover:bg-green-50"
-                      onClick={() => {
-                        const restrictedHashes = mediaStatus.results
-                          .filter(r => r.isRestricted)
-                          .map(r => r.hash);
-                        unblockMediaMutation.mutate({
-                          hashes: restrictedHashes,
-                          reason: 'Restriction removed by moderator',
-                          logAction: 'unrestrict_media',
-                        });
-                      }}
-                      disabled={unblockMediaMutation.isPending || mediaStatus.isLoading}
-                    >
-                      <Unlock className="h-4 w-4 mr-1" />
-                      {unblockMediaMutation.isPending ? 'Removing...' : `Remove Restriction (${mediaStatus.restrictedCount})`}
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom" className="max-w-xs">
-                    <p>Remove age restriction from media files. They will be publicly accessible again.</p>
-                  </TooltipContent>
-                </Tooltip>
-              )}
-              {mediaHashes.length > 0 && !mediaStatus.hasModeratedMedia && (
-                <>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="outline"
-                        onClick={() => setConfirmBlockMedia(true)}
-                        disabled={blockMediaMutation.isPending || mediaStatus.isLoading}
-                      >
-                        <Video className="h-4 w-4 mr-1" />
-                        {mediaStatus.isLoading ? 'Checking...' : `Block Media (${mediaHashes.length})`}
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" className="max-w-xs">
-                      <p>Block media files by their hash. They won't be served and re-uploads of the same file will be blocked. This can be reversed.</p>
-                    </TooltipContent>
-                  </Tooltip>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="outline"
-                        className="border-orange-500 text-orange-600 hover:bg-orange-50"
-                        onClick={() => setConfirmAgeRestrict(true)}
-                        disabled={ageRestrictMediaMutation.isPending || mediaStatus.isLoading}
-                      >
-                        <ShieldAlert className="h-4 w-4 mr-1" />
-                        {mediaStatus.isLoading ? 'Checking...' : `Age Restrict (${mediaHashes.length})`}
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" className="max-w-xs">
-                      <p>Age-restrict media files. The owner can still view them, but they will be hidden from the public feed and age-gated. This can be reversed.</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </>
-              )}
-              {context.reportedUser.pubkey && (
-                isUserBanned ? (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="outline"
-                        onClick={() => {
-                          if (context.reportedUser.pubkey) {
-                            unbanUserMutation.mutate({ pubkey: context.reportedUser.pubkey });
-                          }
-                        }}
-                        disabled={unbanUserMutation.isPending}
-                      >
-                        <UserCheck className="h-4 w-4 mr-1" />
-                        {unbanUserMutation.isPending ? 'Unbanning...' : 'Unban User'}
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" className="max-w-xs">
-                      <p>Unban this user from the relay. They will be able to post new content again. This reverses the ban.</p>
-                    </TooltipContent>
-                  </Tooltip>
-                ) : (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="destructive"
-                        onClick={() => setConfirmBan(true)}
-                        disabled={banMutation.isPending}
-                      >
-                        <UserX className="h-4 w-4 mr-1" />
-                        Ban User
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" className="max-w-xs">
-                      <p>Ban this user from the relay. They won't be able to post new content. Optionally delete all their events and block their media. This can be reversed.</p>
-                    </TooltipContent>
-                  </Tooltip>
-                )
-              )}
               {context.reportedUser.pubkey && (
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -2153,12 +1091,7 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
                         pubkey={context.reportedUser.pubkey}
                         logDecision={logDecision}
                         reportId={report?.id}
-                        onComplete={() => {
-                          queryClient.invalidateQueries({ queryKey: ['user-stats', context.reportedUser.pubkey] });
-                          queryClient.invalidateQueries({ queryKey: ['decisions'] });
-                          decisionLog.refetch();
-                          moderationStatus.recheck();
-                        }}
+                        onComplete={handleActionComplete}
                       />
                     </div>
                   </TooltipTrigger>

--- a/src/components/SettingsDashboard.tsx
+++ b/src/components/SettingsDashboard.tsx
@@ -18,7 +18,7 @@ import {
   AlertTriangle, Mail, Tag,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { AutoHideSettings } from "@/components/AutoHideSettings";
+import { AutoHideSettings, AgeReviewSettings } from "@/components/AutoHideSettings";
 
 // ── NIP-11 type (replicated from RelayInfo.tsx to keep this component self-contained) ──
 
@@ -275,6 +275,7 @@ export function SettingsDashboard() {
         </Alert>
 
         <AutoHideSettings />
+        <AgeReviewSettings />
 
         {/* ── 1. Environment & Connection Banner ── */}
         <Card className={cn("border-l-4", envBorderColor(env?.id))}>

--- a/src/components/UserActions.test.tsx
+++ b/src/components/UserActions.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { describe, expect, it, vi } from 'vitest';
+import { UserActions } from './UserActions';
+
+vi.mock('@/hooks/useAdminApi', () => ({
+  useAdminApi: () => ({
+    bulkModerate: vi.fn().mockResolvedValue({ success: true, eventsProcessed: 3, mediaProcessed: 2, failures: [] }),
+    banPubkey: vi.fn().mockResolvedValue({ success: true }),
+    unbanPubkey: vi.fn().mockResolvedValue({ success: true }),
+    logDecision: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+function renderWithProvider(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>{ui}</TooltipProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe('UserActions', () => {
+  it('renders ban, bulk age-restrict, and bulk delete', () => {
+    renderWithProvider(
+      <UserActions pubkey={'a'.repeat(64)} />
+    );
+    expect(screen.getByRole('button', { name: /Ban User/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Age Restrict All/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Delete All Content/i })).toBeInTheDocument();
+  });
+
+  it('renders unban when user is banned', () => {
+    renderWithProvider(
+      <UserActions pubkey={'a'.repeat(64)} isBanned={true} />
+    );
+    expect(screen.getByRole('button', { name: /Unban User/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Ban User/i })).not.toBeInTheDocument();
+  });
+
+  it('hides bulk actions in age-review context', () => {
+    renderWithProvider(
+      <UserActions pubkey={'a'.repeat(64)} context="age-review" />
+    );
+    expect(screen.getByRole('button', { name: /Ban User/i })).toBeInTheDocument();
+    expect(screen.queryByText(/Age Restrict All/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Delete All Content/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/UserActions.tsx
+++ b/src/components/UserActions.tsx
@@ -119,7 +119,7 @@ export function UserActions({
       ) : (
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button variant="destructive" onClick={() => banUserMutation.mutate()} disabled={anyPending}>
+            <Button variant="outline" className="border-red-500 text-red-600 hover:bg-red-50" onClick={() => banUserMutation.mutate()} disabled={anyPending}>
               <UserX className="h-4 w-4 mr-1" />
               {banUserMutation.isPending ? 'Banning...' : 'Ban User'}
             </Button>

--- a/src/components/UserActions.tsx
+++ b/src/components/UserActions.tsx
@@ -149,7 +149,7 @@ export function UserActions({
               </Button>
             }
             title="Delete All Content"
-            summary="This will permanently delete all media files from this user. This cannot be undone."
+            summary="This will permanently delete all events and media from this user. This cannot be undone."
             onConfirm={async () => { await bulkDeleteMutation.mutateAsync(); }}
             isPending={bulkDeleteMutation.isPending}
           />

--- a/src/components/UserActions.tsx
+++ b/src/components/UserActions.tsx
@@ -150,7 +150,7 @@ export function UserActions({
             }
             title="Delete All Content"
             summary="This will permanently delete all media files from this user. This cannot be undone."
-            onConfirm={() => bulkDeleteMutation.mutateAsync()}
+            onConfirm={async () => { await bulkDeleteMutation.mutateAsync(); }}
             isPending={bulkDeleteMutation.isPending}
           />
         </>

--- a/src/components/UserActions.tsx
+++ b/src/components/UserActions.tsx
@@ -1,0 +1,160 @@
+import { useMutation } from '@tanstack/react-query';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useToast } from '@/hooks/useToast';
+import { useAdminApi } from '@/hooks/useAdminApi';
+import { DeleteConfirmDialog } from './DeleteConfirmDialog';
+import { UserX, UserCheck, ShieldAlert, Trash2 } from 'lucide-react';
+
+interface UserActionsProps {
+  pubkey: string;
+  context?: 'report' | 'age-review' | 'users';
+  isBanned?: boolean;
+  onActionComplete?: () => void;
+}
+
+export function UserActions({
+  pubkey,
+  context = 'users',
+  isBanned = false,
+  onActionComplete,
+}: UserActionsProps) {
+  const { toast } = useToast();
+  const api = useAdminApi();
+  const showBulkActions = context !== 'age-review';
+
+  const banUserMutation = useMutation({
+    mutationFn: async () => {
+      await api.banPubkey(pubkey, 'Banned by moderator');
+      await api.logDecision({
+        targetType: 'pubkey',
+        targetId: pubkey,
+        action: 'ban_user',
+        reason: 'Banned by moderator',
+      });
+    },
+    onSuccess: () => {
+      toast({ title: 'User banned from relay' });
+      onActionComplete?.();
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to ban user', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const unbanUserMutation = useMutation({
+    mutationFn: async () => {
+      await api.unbanPubkey(pubkey);
+      await api.logDecision({
+        targetType: 'pubkey',
+        targetId: pubkey,
+        action: 'unban_user',
+        reason: 'Unbanned by moderator',
+      });
+    },
+    onSuccess: () => {
+      toast({ title: 'User unbanned' });
+      onActionComplete?.();
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to unban user', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const bulkAgeRestrictMutation = useMutation({
+    mutationFn: async () => {
+      const result = await api.bulkModerate(pubkey, 'age-restrict-all', 'Bulk age-restricted by moderator');
+      await api.logDecision({
+        targetType: 'pubkey',
+        targetId: pubkey,
+        action: 'bulk_age_restrict',
+        reason: `Bulk age-restricted: ${result.mediaProcessed} media file(s)`,
+      });
+      return result;
+    },
+    onSuccess: (result) => {
+      toast({ title: `Age-restricted ${result.mediaProcessed} media file(s) across ${result.eventsProcessed} events` });
+      onActionComplete?.();
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to bulk age-restrict', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const bulkDeleteMutation = useMutation({
+    mutationFn: async () => {
+      const result = await api.bulkModerate(pubkey, 'delete-all', 'Bulk deleted by moderator');
+      await api.logDecision({
+        targetType: 'pubkey',
+        targetId: pubkey,
+        action: 'bulk_delete',
+        reason: `Bulk deleted: ${result.mediaProcessed} media file(s)`,
+      });
+      return result;
+    },
+    onSuccess: (result) => {
+      toast({ title: `Deleted ${result.mediaProcessed} media file(s) across ${result.eventsProcessed} events` });
+      onActionComplete?.();
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to bulk delete', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const anyPending = banUserMutation.isPending || unbanUserMutation.isPending ||
+    bulkAgeRestrictMutation.isPending || bulkDeleteMutation.isPending;
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {isBanned ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="outline" onClick={() => unbanUserMutation.mutate()} disabled={anyPending}>
+              <UserCheck className="h-4 w-4 mr-1" />
+              {unbanUserMutation.isPending ? 'Unbanning...' : 'Unban User'}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent><p>Unban this user. They will be able to post again.</p></TooltipContent>
+        </Tooltip>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="destructive" onClick={() => banUserMutation.mutate()} disabled={anyPending}>
+              <UserX className="h-4 w-4 mr-1" />
+              {banUserMutation.isPending ? 'Banning...' : 'Ban User'}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent><p>Ban this user from the relay. Can be reversed.</p></TooltipContent>
+        </Tooltip>
+      )}
+
+      {showBulkActions && (
+        <>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button variant="outline" className="border-orange-500 text-orange-600 hover:bg-orange-50"
+                onClick={() => bulkAgeRestrictMutation.mutate()} disabled={anyPending}>
+                <ShieldAlert className="h-4 w-4 mr-1" />
+                {bulkAgeRestrictMutation.isPending ? 'Restricting...' : 'Age Restrict All'}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent><p>Age-restrict all media from this user. Can be reversed.</p></TooltipContent>
+          </Tooltip>
+
+          <DeleteConfirmDialog
+            trigger={
+              <Button variant="destructive" disabled={anyPending}>
+                <Trash2 className="h-4 w-4 mr-1" />
+                Delete All Content
+              </Button>
+            }
+            title="Delete All Content"
+            summary="This will permanently delete all media files from this user. This cannot be undone."
+            onConfirm={() => bulkDeleteMutation.mutateAsync()}
+            isPending={bulkDeleteMutation.isPending}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -18,6 +18,7 @@ import { UserX, UserCheck, Plus, Users, Trash2, User, X } from "lucide-react";
 import { BannedUserCard } from "@/components/BannedUserCard";
 import { nip19 } from "nostr-tools";
 import { useAdminApi } from "@/hooks/useAdminApi";
+import { UserActions } from "@/components/UserActions";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { UserDisplayName } from "@/components/UserIdentifier";
 import { CopyableId } from "@/components/CopyableId";
@@ -342,6 +343,12 @@ export function UserManagement({ selectedPubkey }: UserManagementProps) {
                 </Button>
               )}
             </div>
+            <UserActions
+              pubkey={selectedPubkey}
+              context="users"
+              isBanned={bannedUsers?.some((u: BannedUser) => u.pubkey === selectedPubkey) ?? false}
+              onActionComplete={invalidateUserQueries}
+            />
           </CardContent>
         </Card>
       )}

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -331,18 +331,11 @@ export function UserManagement({ selectedPubkey }: UserManagementProps) {
                 <span className="text-muted-foreground">No restrictions</span>
               )}
             </div>
-            <div className="flex gap-2">
-              {!bannedUsers?.some((u: BannedUser) => u.pubkey === selectedPubkey) && (
-                <Button variant="destructive" size="sm" onClick={() => banUserMutation.mutate({ pubkey: selectedPubkey })} disabled={banUserMutation.isPending}>
-                  <UserX className="h-4 w-4 mr-1" />Ban
-                </Button>
-              )}
-              {!allowedUsers?.some((u: AllowedUser) => u.pubkey === selectedPubkey) && (
-                <Button variant="outline" size="sm" onClick={() => allowUserMutation.mutate({ pubkey: selectedPubkey })} disabled={allowUserMutation.isPending}>
-                  <UserCheck className="h-4 w-4 mr-1" />Allow
-                </Button>
-              )}
-            </div>
+            {!allowedUsers?.some((u: AllowedUser) => u.pubkey === selectedPubkey) && (
+              <Button variant="outline" size="sm" onClick={() => allowUserMutation.mutate({ pubkey: selectedPubkey })} disabled={allowUserMutation.isPending}>
+                <UserCheck className="h-4 w-4 mr-1" />Allow
+              </Button>
+            )}
             <UserActions
               pubkey={selectedPubkey}
               context="users"

--- a/src/hooks/useAdminApi.ts
+++ b/src/hooks/useAdminApi.ts
@@ -120,6 +120,22 @@ export function useAdminApi() {
     updateAgeReviewCase: (caseId: string, updates: Record<string, unknown>) =>
       adminApi.updateAgeReviewCase(apiUrl, caseId, updates),
 
+    // Bulk moderation
+    bulkModerate: (pubkey: string, action: adminApi.BulkAction, reason?: string) =>
+      adminApi.bulkModerate(apiUrl, pubkey, action, reason),
+
+    // Delete operations
+    deleteMedia: (sha256: string, reason?: string) =>
+      adminApi.deleteMedia(apiUrl, sha256, reason),
+    publishDeletionRequest: (eventId: string, reason?: string) =>
+      adminApi.publishDeletionRequest(apiUrl, eventId, reason),
+
+    // Age review config
+    getAgeReviewConfig: () =>
+      adminApi.getAgeReviewConfig(apiUrl),
+    updateAgeReviewConfig: (config: Partial<adminApi.AgeReviewConfig>) =>
+      adminApi.updateAgeReviewConfig(apiUrl, config),
+
   }), [apiUrl, relayUrl]);
 
   return boundApi;

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -284,7 +284,7 @@ export async function markAsReviewed(
 }
 
 // Media moderation request actions
-export type ModerationAction = 'SAFE' | 'REVIEW' | 'AGE_RESTRICTED' | 'PERMANENT_BAN';
+export type ModerationAction = 'SAFE' | 'REVIEW' | 'AGE_RESTRICTED' | 'PERMANENT_BAN' | 'DELETE';
 // Media moderation status values returned by /api/check-result/:sha256
 export type MediaStatusAction = ModerationAction | 'QUARANTINE';
 
@@ -951,4 +951,58 @@ export async function updateAgeReviewCase(
   updates: Record<string, unknown>,
 ): Promise<AgeReviewCaseResponse> {
   return apiRequest<AgeReviewCaseResponse>(apiUrl, `/api/age-review/cases/${caseId}`, 'PATCH', updates);
+}
+
+// Bulk moderation
+export type BulkAction = 'age-restrict-all' | 'un-age-restrict-all' | 'delete-all';
+
+export interface BulkModerateResult {
+  success: boolean;
+  eventsProcessed: number;
+  mediaProcessed: number;
+  failures: string[];
+}
+
+export async function bulkModerate(
+  apiUrl: string,
+  pubkey: string,
+  action: BulkAction,
+  reason?: string,
+): Promise<BulkModerateResult> {
+  return apiRequest<BulkModerateResult>(apiUrl, '/api/bulk-moderate', 'POST', { pubkey, action, reason });
+}
+
+// Delete media (convenience wrapper)
+export async function deleteMedia(apiUrl: string, sha256: string, reason?: string): Promise<ApiResponse> {
+  return moderateMedia(apiUrl, sha256, 'DELETE', reason || 'Deleted by moderator');
+}
+
+// Publish NIP-09 kind 5 deletion request via worker
+export async function publishDeletionRequest(apiUrl: string, eventId: string, reason?: string): Promise<ApiResponse> {
+  return apiRequest<ApiResponse>(apiUrl, '/api/publish-deletion', 'POST', { eventId, reason });
+}
+
+// Age review config
+export interface AgeReviewConfig {
+  auto_delete_on_deny: boolean;
+}
+
+export async function getAgeReviewConfig(apiUrl: string): Promise<AgeReviewConfig> {
+  return apiRequest<AgeReviewConfig>(apiUrl, '/api/age-review/config', 'GET');
+}
+
+export async function updateAgeReviewConfig(
+  apiUrl: string,
+  config: Partial<AgeReviewConfig>,
+): Promise<AgeReviewConfig> {
+  // Worker route accepts PUT
+  const response = await fetch(`${apiUrl}/api/age-review/config`, {
+    method: 'PUT',
+    headers: getApiHeaders(),
+    body: JSON.stringify(config),
+  });
+  if (!response.ok) {
+    throw new ApiError(`HTTP ${response.status}: ${response.statusText}`, response.status, response.statusText);
+  }
+  return response.json() as Promise<AgeReviewConfig>;
 }

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -3,6 +3,12 @@
 // ABOUTME: All functions accept apiUrl as first parameter to support environment switching
 
 import type { NostrEvent } from "@nostrify/nostrify";
+import {
+  VALID_BULK_ACTIONS,
+  type BulkAction,
+  type BulkModerateResult,
+} from "../../shared/bulk-moderation";
+import { extractMediaHashes as extractSharedMediaHashes } from "../../shared/media-hashes";
 
 // Build headers with CF Access service token for cross-origin API requests.
 // The service token authenticates the frontend to CF Access policies on api-relay-* domains.
@@ -544,50 +550,7 @@ export async function verifyModerationAction(
 
 // Extract sha256 hashes from media URLs in content or tags
 export function extractMediaHashes(content: string, tags: string[][]): string[] {
-  const hashes: Set<string> = new Set();
-
-  // Common Blossom/media URL patterns with sha256
-  // e.g., https://cdn.example.com/abc123def456.mp4
-  // e.g., https://blossom.example.com/sha256/abc123def456
-  const sha256Pattern = /\b([a-f0-9]{64})\b/gi;
-  const addHashesFromText = (value: string) => {
-    let match;
-    sha256Pattern.lastIndex = 0;
-    while ((match = sha256Pattern.exec(value)) !== null) {
-      hashes.add(match[1].toLowerCase());
-    }
-  };
-
-  // Check content for hashes
-  addHashesFromText(content);
-
-  // Check imeta tags and url tags
-  for (const tag of tags) {
-    if (tag[0] === 'imeta') {
-      const mime = tag.find((part) => part.toLowerCase().startsWith('m '))?.split(/\s+/)[1];
-      if (mime?.toLowerCase().startsWith('video/')) {
-        for (const part of tag.slice(1)) {
-          const [key, ...values] = part.split(/\s+/);
-          if (key === 'url' || key === 'x') {
-            addHashesFromText(values.join(' '));
-          }
-        }
-      } else {
-        addHashesFromText(tag.join(' '));
-      }
-      continue;
-    }
-
-    if (tag[0] === 'url' || tag[0] === 'x') {
-      addHashesFromText(tag.join(' '));
-    }
-    // Direct x tag with hash
-    if (tag[0] === 'x' && tag[1] && /^[a-f0-9]{64}$/i.test(tag[1])) {
-      hashes.add(tag[1].toLowerCase());
-    }
-  }
-
-  return Array.from(hashes);
+  return extractSharedMediaHashes(content, tags);
 }
 
 // Scene classification from VLM
@@ -954,14 +917,7 @@ export async function updateAgeReviewCase(
 }
 
 // Bulk moderation
-export type BulkAction = 'age-restrict-all' | 'un-age-restrict-all' | 'delete-all';
-
-export interface BulkModerateResult {
-  success: boolean;
-  eventsProcessed: number;
-  mediaProcessed: number;
-  failures: string[];
-}
+export { VALID_BULK_ACTIONS, type BulkAction, type BulkModerateResult };
 
 export async function bulkModerate(
   apiUrl: string,
@@ -969,7 +925,12 @@ export async function bulkModerate(
   action: BulkAction,
   reason?: string,
 ): Promise<BulkModerateResult> {
-  return apiRequest<BulkModerateResult>(apiUrl, '/api/bulk-moderate', 'POST', { pubkey, action, reason });
+  const result = await apiRequest<BulkModerateResult>(apiUrl, '/api/bulk-moderate', 'POST', { pubkey, action, reason });
+  if (!result.success) {
+    const summary = result.failures.slice(0, 3).join('; ');
+    throw new ApiError(summary ? `Bulk moderation failed: ${summary}` : 'Bulk moderation failed');
+  }
+  return result;
 }
 
 // Delete media (convenience wrapper)

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -74,7 +74,7 @@ class ApiError extends Error {
 async function apiRequest<T>(
   apiUrl: string,
   endpoint: string,
-  method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
   body?: object
 ): Promise<T> {
   if (!apiUrl) {
@@ -995,14 +995,5 @@ export async function updateAgeReviewConfig(
   apiUrl: string,
   config: Partial<AgeReviewConfig>,
 ): Promise<AgeReviewConfig> {
-  // Worker route accepts PUT
-  const response = await fetch(`${apiUrl}/api/age-review/config`, {
-    method: 'PUT',
-    headers: getApiHeaders(),
-    body: JSON.stringify(config),
-  });
-  if (!response.ok) {
-    throw new ApiError(`HTTP ${response.status}: ${response.statusText}`, response.status, response.statusText);
-  }
-  return response.json() as Promise<AgeReviewConfig>;
+  return apiRequest<AgeReviewConfig>(apiUrl, '/api/age-review/config', 'PUT', config);
 }

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -8,6 +8,8 @@ import {
   handleAgeReviewReplyWebhook,
   checkAgeReviewDeadlines,
   syncAgeReviewTicketResolution,
+  getAgeReviewConfig,
+  updateAgeReviewConfig,
 } from './age-review';
 import type { AgeReviewCase } from '../../shared/age-review';
 
@@ -1043,5 +1045,44 @@ describe('handleAgeReviewReplyWebhook', () => {
     });
     const res = await handleAgeReviewReplyWebhook(req, { DB: db as unknown as D1Database }, corsHeaders);
     expect(res.status).toBe(400);
+  });
+});
+
+// -- Age review config --------------------------------------------------------
+
+describe('getAgeReviewConfig', () => {
+  it('returns default config when no rows exist', async () => {
+    const db = {
+      prepare: vi.fn().mockReturnValue({
+        first: vi.fn().mockResolvedValue(null),
+      }),
+    };
+    const config = await getAgeReviewConfig(db as unknown as D1Database);
+    expect(config.auto_delete_on_deny).toBe(true);
+  });
+
+  it('reads stored config value', async () => {
+    const db = {
+      prepare: vi.fn().mockReturnValue({
+        first: vi.fn().mockResolvedValue({ value: 'false' }),
+      }),
+    };
+    const config = await getAgeReviewConfig(db as unknown as D1Database);
+    expect(config.auto_delete_on_deny).toBe(false);
+  });
+});
+
+describe('updateAgeReviewConfig', () => {
+  it('writes config and returns updated value', async () => {
+    const db = {
+      prepare: vi.fn().mockImplementation((sql: string) => {
+        if (sql.includes('INSERT')) {
+          return { bind: vi.fn().mockReturnValue({ run: vi.fn().mockResolvedValue({}) }) };
+        }
+        return { first: vi.fn().mockResolvedValue({ value: 'false' }) };
+      }),
+    };
+    const config = await updateAgeReviewConfig(db as unknown as D1Database, { auto_delete_on_deny: false });
+    expect(config.auto_delete_on_deny).toBe(false);
   });
 });

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -10,6 +10,7 @@ import {
   defaultResolutionForBand,
 } from '../../shared/age-review';
 import { handleBulkModerate, type BulkModerateEnv } from './bulk-moderate';
+import type { BulkAction, BulkModerateResult } from '../../shared/bulk-moderation';
 
 interface AgeReviewEnv extends BulkModerateEnv {
   SLACK_WEBHOOK_URL?: string;
@@ -830,7 +831,7 @@ async function sendSlackAlert(
 
 async function triggerBulkModerate(
   pubkey: string,
-  action: string,
+  action: BulkAction,
   reason: string,
   env: AgeReviewEnv,
 ): Promise<void> {
@@ -839,9 +840,10 @@ async function triggerBulkModerate(
     body: JSON.stringify({ pubkey, action, reason }),
   });
   const response = await handleBulkModerate(request, env, {});
-  if (!response.ok) {
-    const body = await response.json() as { error?: string };
-    throw new Error(body.error || `Bulk moderate returned ${response.status}`);
+  const body = await response.json() as BulkModerateResult & { error?: string };
+  if (!response.ok || !body.success) {
+    const summary = body.failures?.slice(0, 3).join('; ');
+    throw new Error(summary || body.error || `Bulk moderate returned ${response.status}`);
   }
 }
 

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -9,6 +9,7 @@ import {
   DEADLINE_DAYS,
   defaultResolutionForBand,
 } from '../../shared/age-review';
+import { handleBulkModerate } from './bulk-moderate';
 
 interface AgeReviewEnv {
   DB?: D1Database;
@@ -223,7 +224,29 @@ export async function handleUpdateAgeReviewCase(
     }
   }
 
-  return json({ success: true, case: updated }, 200, corsHeaders);
+  // Non-critical: fire bulk content actions on state transitions
+  let bulkActionTriggered: string | undefined;
+  if (body.state && typeof body.state === 'string') {
+    try {
+      if ((body.state as string).startsWith('restricted_')) {
+        await triggerBulkModerate(existing.pubkey, 'age-restrict-all', 'Age review restriction', env);
+        bulkActionTriggered = 'age-restrict-all';
+      } else if (body.state === 'cleared') {
+        await triggerBulkModerate(existing.pubkey, 'un-age-restrict-all', 'Age review cleared', env);
+        bulkActionTriggered = 'un-age-restrict-all';
+      } else if (body.state === 'denied_closed') {
+        const config = await getAgeReviewConfig(env.DB!);
+        if (config.auto_delete_on_deny) {
+          await triggerBulkModerate(existing.pubkey, 'delete-all', 'Age review denied', env);
+          bulkActionTriggered = 'delete-all';
+        }
+      }
+    } catch (error) {
+      console.error(`[age-review] Bulk action failed for case ${caseId}:`, error);
+    }
+  }
+
+  return json({ success: true, case: updated, bulkActionTriggered }, 200, corsHeaders);
 }
 
 // ---------------------------------------------------------------------------
@@ -752,6 +775,16 @@ export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> 
     } catch (error) {
       console.error(`[age-review] Failed to sync Zendesk for auto-closed case ${row.id}:`, error);
     }
+
+    try {
+      const config = await getAgeReviewConfig(env.DB!);
+      if (config.auto_delete_on_deny) {
+        await triggerBulkModerate(row.pubkey, 'delete-all', 'Age review expired -- auto-deleted', env);
+        console.log(`[age-review] Auto-deleted content for expired case ${row.id}`);
+      }
+    } catch (error) {
+      console.error(`[age-review] Auto-delete failed for expired case ${row.id}:`, error);
+    }
   }
 
   if (expired.results.length > 0 && env.SLACK_WEBHOOK_URL) {
@@ -789,6 +822,59 @@ async function sendSlackAlert(
     console.error('[age-review] Failed to send Slack alert:', error);
     return false;
   }
+}
+
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// Bulk action trigger (internal call to handleBulkModerate)
+// ---------------------------------------------------------------------------
+
+async function triggerBulkModerate(
+  pubkey: string,
+  action: string,
+  reason: string,
+  env: AgeReviewEnv,
+): Promise<void> {
+  const request = new Request('https://internal/api/bulk-moderate', {
+    method: 'POST',
+    body: JSON.stringify({ pubkey, action, reason }),
+  });
+  const response = await handleBulkModerate(request, env as any, {});
+  if (!response.ok) {
+    const body = await response.json() as { error?: string };
+    throw new Error(body.error || `Bulk moderate returned ${response.status}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Age review configuration (D1)
+// ---------------------------------------------------------------------------
+
+interface AgeReviewConfig {
+  auto_delete_on_deny: boolean;
+}
+
+const DEFAULT_CONFIG: AgeReviewConfig = { auto_delete_on_deny: true };
+
+export async function getAgeReviewConfig(db: D1Database): Promise<AgeReviewConfig> {
+  const row = await db.prepare(
+    "SELECT value FROM age_review_config WHERE key = 'auto_delete_on_deny'"
+  ).first<{ value: string }>();
+  return {
+    auto_delete_on_deny: row ? row.value === 'true' : DEFAULT_CONFIG.auto_delete_on_deny,
+  };
+}
+
+export async function updateAgeReviewConfig(
+  db: D1Database,
+  config: Partial<AgeReviewConfig>,
+): Promise<AgeReviewConfig> {
+  if (config.auto_delete_on_deny !== undefined) {
+    await db.prepare(
+      "INSERT INTO age_review_config (key, value) VALUES ('auto_delete_on_deny', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+    ).bind(String(config.auto_delete_on_deny)).run();
+  }
+  return getAgeReviewConfig(db);
 }
 
 // ---------------------------------------------------------------------------

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -9,7 +9,7 @@ import {
   DEADLINE_DAYS,
   defaultResolutionForBand,
 } from '../../shared/age-review';
-import { handleBulkModerate } from './bulk-moderate';
+import { handleBulkModerate, type BulkModerateEnv } from './bulk-moderate';
 
 interface AgeReviewEnv {
   DB?: D1Database;
@@ -839,7 +839,7 @@ async function triggerBulkModerate(
     method: 'POST',
     body: JSON.stringify({ pubkey, action, reason }),
   });
-  const response = await handleBulkModerate(request, env as any, {});
+  const response = await handleBulkModerate(request, env as unknown as BulkModerateEnv, {});
   if (!response.ok) {
     const body = await response.json() as { error?: string };
     throw new Error(body.error || `Bulk moderate returned ${response.status}`);

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -11,8 +11,7 @@ import {
 } from '../../shared/age-review';
 import { handleBulkModerate, type BulkModerateEnv } from './bulk-moderate';
 
-interface AgeReviewEnv {
-  DB?: D1Database;
+interface AgeReviewEnv extends BulkModerateEnv {
   SLACK_WEBHOOK_URL?: string;
   ZENDESK_SUBDOMAIN?: string;
   ZENDESK_API_TOKEN?: string;
@@ -839,7 +838,7 @@ async function triggerBulkModerate(
     method: 'POST',
     body: JSON.stringify({ pubkey, action, reason }),
   });
-  const response = await handleBulkModerate(request, env as unknown as BulkModerateEnv, {});
+  const response = await handleBulkModerate(request, env, {});
   if (!response.ok) {
     const body = await response.json() as { error?: string };
     throw new Error(body.error || `Bulk moderate returned ${response.status}`);

--- a/worker/src/bulk-moderate.test.ts
+++ b/worker/src/bulk-moderate.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+import { handleBulkModerate, extractMediaHashes } from './bulk-moderate';
+
+describe('handleBulkModerate', () => {
+  const mockEnv = {
+    NOSTR_NSEC: 'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5',
+    RELAY_URL: 'wss://relay.test',
+    DB: {
+      prepare: vi.fn().mockReturnValue({
+        bind: vi.fn().mockReturnValue({
+          run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+        }),
+      }),
+    },
+  };
+
+  it('rejects invalid action', async () => {
+    const request = new Request('https://test/api/bulk-moderate', {
+      method: 'POST',
+      body: JSON.stringify({ pubkey: 'a'.repeat(64), action: 'invalid' }),
+    });
+    const response = await handleBulkModerate(request, mockEnv as any, {});
+    expect(response.status).toBe(400);
+    const body = await response.json() as { error: string };
+    expect(body.error).toMatch(/Invalid action/);
+  });
+
+  it('requires 64-char hex pubkey', async () => {
+    const request = new Request('https://test/api/bulk-moderate', {
+      method: 'POST',
+      body: JSON.stringify({ pubkey: 'short', action: 'age-restrict-all' }),
+    });
+    const response = await handleBulkModerate(request, mockEnv as any, {});
+    expect(response.status).toBe(400);
+    const body = await response.json() as { error: string };
+    expect(body.error).toMatch(/pubkey/);
+  });
+
+  it('rejects missing pubkey', async () => {
+    const request = new Request('https://test/api/bulk-moderate', {
+      method: 'POST',
+      body: JSON.stringify({ action: 'delete-all' }),
+    });
+    const response = await handleBulkModerate(request, mockEnv as any, {});
+    expect(response.status).toBe(400);
+  });
+
+  it('accepts all three valid actions', async () => {
+    for (const action of ['age-restrict-all', 'un-age-restrict-all', 'delete-all']) {
+      const request = new Request('https://test/api/bulk-moderate', {
+        method: 'POST',
+        body: JSON.stringify({ pubkey: 'a'.repeat(64), action }),
+      });
+      const response = await handleBulkModerate(request, mockEnv as any, {});
+      expect(response.status).toBe(200);
+    }
+  });
+});
+
+describe('extractMediaHashes', () => {
+  it('extracts sha256 from imeta tags on video events', () => {
+    const events = [
+      {
+        id: 'e1',
+        kind: 34235,
+        tags: [
+          ['imeta', 'url https://example.com/video.mp4', 'sha256 abcd1234'],
+          ['imeta', 'url https://example.com/thumb.jpg', 'sha256 efgh5678'],
+        ],
+      },
+    ];
+    const hashes = extractMediaHashes(events);
+    expect(hashes).toContain('abcd1234');
+    expect(hashes).toContain('efgh5678');
+    expect(hashes).toHaveLength(2);
+  });
+
+  it('extracts from x tags on video events', () => {
+    const events = [
+      { id: 'e1', kind: 34236, tags: [['x', 'hash1234']] },
+    ];
+    expect(extractMediaHashes(events)).toEqual(['hash1234']);
+  });
+
+  it('ignores non-video event kinds', () => {
+    const events = [
+      { id: 'e1', kind: 1, tags: [['imeta', 'sha256 should-be-ignored']] },
+      { id: 'e2', kind: 34235, tags: [['imeta', 'sha256 should-be-included']] },
+    ];
+    const hashes = extractMediaHashes(events);
+    expect(hashes).toEqual(['should-be-included']);
+  });
+
+  it('deduplicates hashes', () => {
+    const events = [
+      { id: 'e1', kind: 34235, tags: [['x', 'same-hash']] },
+      { id: 'e2', kind: 34236, tags: [['x', 'same-hash']] },
+    ];
+    expect(extractMediaHashes(events)).toEqual(['same-hash']);
+  });
+
+  it('returns empty array when no video events', () => {
+    const events = [
+      { id: 'e1', kind: 1, tags: [] },
+      { id: 'e2', kind: 30023, tags: [['x', 'hash']] },
+    ];
+    expect(extractMediaHashes(events)).toEqual([]);
+  });
+});

--- a/worker/src/bulk-moderate.test.ts
+++ b/worker/src/bulk-moderate.test.ts
@@ -1,25 +1,75 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { handleBulkModerate, extractMediaHashes, type BulkModerateEnv } from './bulk-moderate';
 
-describe('handleBulkModerate', () => {
-  const mockEnv = {
-    NOSTR_NSEC: 'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5',
-    RELAY_URL: 'wss://relay.test',
-    DB: {
-      prepare: vi.fn().mockReturnValue({
-        bind: vi.fn().mockReturnValue({
-          run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
-        }),
+vi.mock('./nip86', () => ({
+  getAdminPubkey: vi.fn().mockResolvedValue('moderator-pubkey'),
+  banEvent: vi.fn().mockResolvedValue({ success: true }),
+  publishKind5Deletion: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+vi.mock('./zendesk-sync', () => ({
+  syncZendeskAfterAction: vi.fn().mockResolvedValue(undefined),
+}));
+
+const hashA = 'a'.repeat(64);
+const hashB = 'b'.repeat(64);
+
+function mockRelay(events: Array<{ id: string; kind: number; content?: string; tags: string[][] }>) {
+  vi.spyOn(globalThis, 'WebSocket').mockImplementation((() => {
+    const listeners = new Map<string, Array<(value?: unknown) => void>>();
+    let subId = 'bulk-test';
+
+    queueMicrotask(() => {
+      listeners.get('open')?.forEach((handler) => handler());
+      for (const event of events) {
+        listeners.get('message')?.forEach((handler) => handler({
+          data: JSON.stringify(['EVENT', subId, event]),
+        }));
+      }
+      listeners.get('message')?.forEach((handler) => handler({
+        data: JSON.stringify(['EOSE', subId]),
+      }));
+    });
+
+    return {
+      addEventListener: (event: string, handler: (value?: unknown) => void) => {
+        listeners.set(event, [...(listeners.get(event) || []), handler]);
+      },
+      send: vi.fn((payload: string) => {
+        const data = JSON.parse(payload);
+        subId = data[1];
       }),
-    },
-  };
+      close: vi.fn(),
+    };
+  }) as unknown as typeof WebSocket);
+}
+
+describe('handleBulkModerate', () => {
+  let mockEnv: BulkModerateEnv;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockEnv = {
+      NOSTR_NSEC: 'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5',
+      RELAY_URL: 'wss://relay.test',
+      MODERATION_API: {
+        fetch: vi.fn().mockResolvedValue(new Response(null, { status: 200 })),
+      } as unknown as Fetcher,
+      DB: {
+        prepare: vi.fn().mockReturnValue({
+          bind: vi.fn().mockReturnThis(),
+        }),
+        batch: vi.fn().mockResolvedValue([]),
+      } as unknown as D1Database,
+    };
+  });
 
   it('rejects invalid action', async () => {
     const request = new Request('https://test/api/bulk-moderate', {
       method: 'POST',
       body: JSON.stringify({ pubkey: 'a'.repeat(64), action: 'invalid' }),
     });
-    const response = await handleBulkModerate(request, mockEnv as unknown as BulkModerateEnv, {});
+    const response = await handleBulkModerate(request, mockEnv, {});
     expect(response.status).toBe(400);
     const body = await response.json() as { error: string };
     expect(body.error).toMatch(/Invalid action/);
@@ -30,7 +80,7 @@ describe('handleBulkModerate', () => {
       method: 'POST',
       body: JSON.stringify({ pubkey: 'short', action: 'age-restrict-all' }),
     });
-    const response = await handleBulkModerate(request, mockEnv as unknown as BulkModerateEnv, {});
+    const response = await handleBulkModerate(request, mockEnv, {});
     expect(response.status).toBe(400);
     const body = await response.json() as { error: string };
     expect(body.error).toMatch(/pubkey/);
@@ -41,19 +91,38 @@ describe('handleBulkModerate', () => {
       method: 'POST',
       body: JSON.stringify({ action: 'delete-all' }),
     });
-    const response = await handleBulkModerate(request, mockEnv as unknown as BulkModerateEnv, {});
+    const response = await handleBulkModerate(request, mockEnv, {});
     expect(response.status).toBe(400);
   });
 
   it('accepts all three valid actions', async () => {
-    for (const action of ['age-restrict-all', 'un-age-restrict-all', 'delete-all']) {
+    mockRelay([]);
+
+    for (const action of ['age-restrict-all', 'un-age-restrict-all', 'delete-all'] as const) {
       const request = new Request('https://test/api/bulk-moderate', {
         method: 'POST',
         body: JSON.stringify({ pubkey: 'a'.repeat(64), action }),
       });
-      const response = await handleBulkModerate(request, mockEnv as unknown as BulkModerateEnv, {});
+      const response = await handleBulkModerate(request, mockEnv, {});
       expect(response.status).toBe(200);
     }
+  });
+
+  it('marks bulk delete as failed when relay deletion returns success false', async () => {
+    const { banEvent } = await import('./nip86');
+    vi.mocked(banEvent).mockResolvedValueOnce({ success: false, error: 'relay refused' });
+    mockRelay([{ id: 'e'.repeat(64), kind: 1, content: '', tags: [] }]);
+
+    const request = new Request('https://test/api/bulk-moderate', {
+      method: 'POST',
+      body: JSON.stringify({ pubkey: 'a'.repeat(64), action: 'delete-all' }),
+    });
+    const response = await handleBulkModerate(request, mockEnv, {});
+    const body = await response.json() as { success: boolean; failures: string[]; eventsProcessed: number };
+
+    expect(body.success).toBe(false);
+    expect(body.eventsProcessed).toBe(0);
+    expect(body.failures[0]).toContain('relay refused');
   });
 });
 
@@ -63,57 +132,64 @@ describe('extractMediaHashes', () => {
       {
         id: 'e1',
         kind: 34235,
+        content: '',
         tags: [
-          ['imeta', 'url https://example.com/video.mp4', 'sha256 abcd1234'],
-          ['imeta', 'url https://example.com/thumb.jpg', 'sha256 efgh5678'],
+          ['imeta', `url https://example.com/${hashA}.mp4`, 'm video/mp4', `x ${hashA}`],
+          ['imeta', `url https://example.com/${hashB}.jpg`, 'm image/jpeg', `x ${hashB}`],
         ],
       },
     ];
     const hashes = extractMediaHashes(events);
-    expect(hashes).toContain('abcd1234');
-    expect(hashes).toContain('efgh5678');
+    expect(hashes).toContain(hashA);
+    expect(hashes).toContain(hashB);
     expect(hashes).toHaveLength(2);
   });
 
-  it('extracts from x tags on video events', () => {
+  it('extracts from x tags', () => {
     const events = [
-      { id: 'e1', kind: 34236, tags: [['x', 'hash1234']] },
+      { id: 'e1', kind: 34236, content: '', tags: [['x', hashA]] },
     ];
-    expect(extractMediaHashes(events)).toEqual(['hash1234']);
+    expect(extractMediaHashes(events)).toEqual([hashA]);
   });
 
-  it('ignores non-video event kinds', () => {
+  it('extracts from content URLs and url tags', () => {
     const events = [
-      { id: 'e1', kind: 1, tags: [['imeta', 'sha256 should-be-ignored']] },
-      { id: 'e2', kind: 34235, tags: [['imeta', 'sha256 should-be-included']] },
+      { id: 'e1', kind: 1, content: `https://cdn.test/${hashA}.jpg`, tags: [] },
+      { id: 'e2', kind: 30023, content: '', tags: [['url', `https://cdn.test/${hashB}.png`]] },
     ];
-    const hashes = extractMediaHashes(events);
-    expect(hashes).toEqual(['should-be-included']);
+    expect(extractMediaHashes(events)).toEqual([hashA, hashB]);
   });
 
   it('deduplicates hashes', () => {
     const events = [
-      { id: 'e1', kind: 34235, tags: [['x', 'same-hash']] },
-      { id: 'e2', kind: 34236, tags: [['x', 'same-hash']] },
+      { id: 'e1', kind: 34235, content: '', tags: [['x', hashA]] },
+      { id: 'e2', kind: 34236, content: '', tags: [['x', hashA]] },
     ];
-    expect(extractMediaHashes(events)).toEqual(['same-hash']);
+    expect(extractMediaHashes(events)).toEqual([hashA]);
   });
 
-  it('extracts from short-form video kinds 21 and 22', () => {
+  it('ignores thumbnail image hashes embedded in video imeta tags', () => {
     const events = [
-      { id: 'e1', kind: 21, tags: [['x', 'short-hash-1']] },
-      { id: 'e2', kind: 22, tags: [['imeta', 'sha256 short-hash-2']] },
+      {
+        id: 'e1',
+        kind: 34235,
+        content: '',
+        tags: [[
+          'imeta',
+          `url https://media.divine.video/${hashA}`,
+          'm video/mp4',
+          `image https://media.divine.video/${hashB}`,
+          `x ${hashA}`,
+        ]],
+      },
     ];
-    const hashes = extractMediaHashes(events);
-    expect(hashes).toContain('short-hash-1');
-    expect(hashes).toContain('short-hash-2');
-    expect(hashes).toHaveLength(2);
+    expect(extractMediaHashes(events)).toEqual([hashA]);
   });
 
-  it('returns empty array when no video events', () => {
+  it('returns empty array when there are no valid hashes', () => {
     const events = [
-      { id: 'e1', kind: 1, tags: [] },
-      { id: 'e2', kind: 30023, tags: [['x', 'hash']] },
+      { id: 'e1', kind: 1, content: '', tags: [] },
+      { id: 'e2', kind: 30023, content: '', tags: [['x', 'not-a-hash']] },
     ];
     expect(extractMediaHashes(events)).toEqual([]);
   });

--- a/worker/src/bulk-moderate.test.ts
+++ b/worker/src/bulk-moderate.test.ts
@@ -99,6 +99,17 @@ describe('extractMediaHashes', () => {
     expect(extractMediaHashes(events)).toEqual(['same-hash']);
   });
 
+  it('extracts from short-form video kinds 21 and 22', () => {
+    const events = [
+      { id: 'e1', kind: 21, tags: [['x', 'short-hash-1']] },
+      { id: 'e2', kind: 22, tags: [['imeta', 'sha256 short-hash-2']] },
+    ];
+    const hashes = extractMediaHashes(events);
+    expect(hashes).toContain('short-hash-1');
+    expect(hashes).toContain('short-hash-2');
+    expect(hashes).toHaveLength(2);
+  });
+
   it('returns empty array when no video events', () => {
     const events = [
       { id: 'e1', kind: 1, tags: [] },

--- a/worker/src/bulk-moderate.test.ts
+++ b/worker/src/bulk-moderate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { handleBulkModerate, extractMediaHashes } from './bulk-moderate';
+import { handleBulkModerate, extractMediaHashes, type BulkModerateEnv } from './bulk-moderate';
 
 describe('handleBulkModerate', () => {
   const mockEnv = {
@@ -19,7 +19,7 @@ describe('handleBulkModerate', () => {
       method: 'POST',
       body: JSON.stringify({ pubkey: 'a'.repeat(64), action: 'invalid' }),
     });
-    const response = await handleBulkModerate(request, mockEnv as any, {});
+    const response = await handleBulkModerate(request, mockEnv as unknown as BulkModerateEnv, {});
     expect(response.status).toBe(400);
     const body = await response.json() as { error: string };
     expect(body.error).toMatch(/Invalid action/);
@@ -30,7 +30,7 @@ describe('handleBulkModerate', () => {
       method: 'POST',
       body: JSON.stringify({ pubkey: 'short', action: 'age-restrict-all' }),
     });
-    const response = await handleBulkModerate(request, mockEnv as any, {});
+    const response = await handleBulkModerate(request, mockEnv as unknown as BulkModerateEnv, {});
     expect(response.status).toBe(400);
     const body = await response.json() as { error: string };
     expect(body.error).toMatch(/pubkey/);
@@ -41,7 +41,7 @@ describe('handleBulkModerate', () => {
       method: 'POST',
       body: JSON.stringify({ action: 'delete-all' }),
     });
-    const response = await handleBulkModerate(request, mockEnv as any, {});
+    const response = await handleBulkModerate(request, mockEnv as unknown as BulkModerateEnv, {});
     expect(response.status).toBe(400);
   });
 
@@ -51,7 +51,7 @@ describe('handleBulkModerate', () => {
         method: 'POST',
         body: JSON.stringify({ pubkey: 'a'.repeat(64), action }),
       });
-      const response = await handleBulkModerate(request, mockEnv as any, {});
+      const response = await handleBulkModerate(request, mockEnv as unknown as BulkModerateEnv, {});
       expect(response.status).toBe(200);
     }
   });

--- a/worker/src/bulk-moderate.ts
+++ b/worker/src/bulk-moderate.ts
@@ -1,0 +1,198 @@
+import { banEvent, publishKind5Deletion, type Nip86Env } from './nip86';
+
+type BulkAction = 'age-restrict-all' | 'un-age-restrict-all' | 'delete-all';
+const VALID_BULK_ACTIONS: BulkAction[] = ['age-restrict-all', 'un-age-restrict-all', 'delete-all'];
+const VIDEO_KINDS = [34235, 34236];
+
+export interface BulkModerateEnv extends Nip86Env {
+  DB?: D1Database;
+  MODERATION_API?: Fetcher;
+  MODERATION_ADMIN_URL?: string;
+  SERVICE_API_TOKEN?: string | { get(): Promise<string> };
+}
+
+interface BulkResult {
+  success: boolean;
+  eventsProcessed: number;
+  mediaProcessed: number;
+  failures: string[];
+}
+
+function json(data: unknown, status: number, corsHeaders: Record<string, string>): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...corsHeaders },
+  });
+}
+
+export async function handleBulkModerate(
+  request: Request,
+  env: BulkModerateEnv,
+  corsHeaders: Record<string, string>,
+): Promise<Response> {
+  const body = await request.json() as { pubkey?: string; action?: string; reason?: string };
+
+  if (!body.pubkey || !/^[0-9a-f]{64}$/.test(body.pubkey)) {
+    return json({ error: 'Valid 64-char hex pubkey required' }, 400, corsHeaders);
+  }
+  if (!body.action || !VALID_BULK_ACTIONS.includes(body.action as BulkAction)) {
+    return json({ error: `Invalid action. Must be one of: ${VALID_BULK_ACTIONS.join(', ')}` }, 400, corsHeaders);
+  }
+
+  const action = body.action as BulkAction;
+  const reason = body.reason || `Bulk ${action} by moderator`;
+
+  const events = await queryRelayEvents(body.pubkey, env);
+  const mediaHashes = extractMediaHashes(events);
+
+  const result: BulkResult = { success: true, eventsProcessed: 0, mediaProcessed: 0, failures: [] };
+
+  if (action === 'delete-all') {
+    for (const event of events) {
+      try {
+        await banEvent(event.id, reason, env);
+        await publishKind5Deletion(event.id, reason, env);
+        result.eventsProcessed++;
+        if (env.DB) {
+          await env.DB.prepare(
+            `INSERT INTO moderation_decisions (target_type, target_id, action, reason, created_at) VALUES (?, ?, ?, ?, datetime('now'))`
+          ).bind('event', event.id, 'delete_event', reason).run();
+        }
+      } catch (error) {
+        result.failures.push(`event:${event.id}:${error}`);
+      }
+    }
+    for (const sha256 of mediaHashes) {
+      try {
+        await callModerateMedia(sha256, 'DELETE', reason, env);
+        result.mediaProcessed++;
+      } catch (error) {
+        result.failures.push(`media:${sha256}:${error}`);
+      }
+    }
+  } else {
+    const mediaAction = action === 'age-restrict-all' ? 'AGE_RESTRICTED' : 'SAFE';
+    for (const sha256 of mediaHashes) {
+      try {
+        await callModerateMedia(sha256, mediaAction, reason, env);
+        result.mediaProcessed++;
+      } catch (error) {
+        result.failures.push(`media:${sha256}:${error}`);
+      }
+    }
+  }
+
+  result.success = result.failures.length === 0;
+  return json(result, 200, corsHeaders);
+}
+
+export async function queryRelayEvents(
+  pubkey: string,
+  env: Pick<BulkModerateEnv, 'RELAY_URL'>,
+): Promise<Array<{ id: string; kind: number; tags: string[][] }>> {
+  return new Promise((resolve) => {
+    try {
+      const ws = new WebSocket(env.RELAY_URL);
+      let resolved = false;
+      const events: Array<{ id: string; kind: number; tags: string[][] }> = [];
+      const subId = `bulk-${Date.now()}`;
+
+      const timeout = setTimeout(() => {
+        if (!resolved) {
+          resolved = true;
+          ws.close();
+          resolve(events);
+        }
+      }, 10000);
+
+      ws.addEventListener('open', () => {
+        ws.send(JSON.stringify(['REQ', subId, { authors: [pubkey], limit: 5000 }]));
+      });
+
+      ws.addEventListener('message', (msg) => {
+        try {
+          const data = JSON.parse(msg.data as string);
+          if (data[0] === 'EVENT' && data[1] === subId) {
+            const event = data[2] as { id: string; kind: number; tags: string[][] };
+            events.push({ id: event.id, kind: event.kind, tags: event.tags });
+          } else if (data[0] === 'EOSE' && data[1] === subId) {
+            clearTimeout(timeout);
+            resolved = true;
+            ws.close();
+            resolve(events);
+          }
+        } catch {
+          // Ignore parse errors
+        }
+      });
+
+      ws.addEventListener('error', () => {
+        if (!resolved) {
+          clearTimeout(timeout);
+          resolved = true;
+          resolve(events);
+        }
+      });
+
+      ws.addEventListener('close', () => {
+        if (!resolved) {
+          clearTimeout(timeout);
+          resolved = true;
+          resolve(events);
+        }
+      });
+    } catch {
+      resolve([]);
+    }
+  });
+}
+
+export function extractMediaHashes(events: Array<{ id: string; kind: number; tags: string[][] }>): string[] {
+  const hashes = new Set<string>();
+  for (const event of events) {
+    if (!VIDEO_KINDS.includes(event.kind)) continue;
+    for (const tag of event.tags) {
+      if (tag[0] === 'imeta') {
+        for (let i = 1; i < tag.length; i++) {
+          if (tag[i].startsWith('sha256 ')) {
+            hashes.add(tag[i].split(' ')[1]);
+          }
+        }
+      }
+      if (tag[0] === 'x') hashes.add(tag[1]);
+    }
+  }
+  return Array.from(hashes);
+}
+
+async function callModerateMedia(
+  sha256: string,
+  action: string,
+  reason: string,
+  env: BulkModerateEnv,
+): Promise<void> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+
+  if (env.SERVICE_API_TOKEN) {
+    const token = typeof env.SERVICE_API_TOKEN === 'string'
+      ? env.SERVICE_API_TOKEN
+      : await env.SERVICE_API_TOKEN.get();
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const body = JSON.stringify({ sha256, action, reason, source: 'relay-manager-bulk' });
+
+  if (env.MODERATION_API) {
+    const response = await env.MODERATION_API.fetch('https://internal/api/v1/moderate', {
+      method: 'POST', headers, body,
+    });
+    if (!response.ok) throw new Error(`Moderation service returned ${response.status}`);
+  } else if (env.MODERATION_ADMIN_URL) {
+    const response = await fetch(`${env.MODERATION_ADMIN_URL}/api/v1/moderate`, {
+      method: 'POST', headers, body,
+    });
+    if (!response.ok) throw new Error(`Moderation service returned ${response.status}`);
+  } else {
+    throw new Error('No moderation service configured');
+  }
+}

--- a/worker/src/bulk-moderate.ts
+++ b/worker/src/bulk-moderate.ts
@@ -1,21 +1,25 @@
-import { banEvent, publishKind5Deletion, type Nip86Env } from './nip86';
+import { getAdminPubkey, banEvent, publishKind5Deletion, type Nip86Env } from './nip86';
+import { syncZendeskAfterAction, type ZendeskSyncEnv } from './zendesk-sync';
+import { VALID_BULK_ACTIONS, type BulkAction, type BulkModerateResult } from '../../shared/bulk-moderation';
+import { extractMediaHashes as extractSharedMediaHashes } from '../../shared/media-hashes';
 
-type BulkAction = 'age-restrict-all' | 'un-age-restrict-all' | 'delete-all';
-const VALID_BULK_ACTIONS: BulkAction[] = ['age-restrict-all', 'un-age-restrict-all', 'delete-all'];
-const VIDEO_KINDS = [34235, 34236, 21, 22];
+const BULK_ACTION_CONCURRENCY = 5;
+const RELAY_QUERY_LIMIT = 500;
+const RELAY_QUERY_FETCH_LIMIT = RELAY_QUERY_LIMIT + 1;
+const RELAY_QUERY_TIMEOUT_MS = 10000;
 
-export interface BulkModerateEnv extends Nip86Env {
+export interface BulkModerateEnv extends Nip86Env, ZendeskSyncEnv {
   DB?: D1Database;
   MODERATION_API?: Fetcher;
   MODERATION_ADMIN_URL?: string;
   SERVICE_API_TOKEN?: string | { get(): Promise<string> };
 }
 
-interface BulkResult {
-  success: boolean;
-  eventsProcessed: number;
-  mediaProcessed: number;
-  failures: string[];
+interface RelayEventSummary {
+  id: string;
+  kind: number;
+  content: string;
+  tags: string[][];
 }
 
 function json(data: unknown, status: number, corsHeaders: Record<string, string>): Response {
@@ -44,42 +48,66 @@ export async function handleBulkModerate(
 
   const events = await queryRelayEvents(body.pubkey, env);
   const mediaHashes = extractMediaHashes(events);
-
-  const result: BulkResult = { success: true, eventsProcessed: 0, mediaProcessed: 0, failures: [] };
+  const moderatorPubkey = await getAdminPubkey(env);
+  const result: BulkModerateResult = { success: true, eventsProcessed: 0, mediaProcessed: 0, failures: [] };
 
   if (action === 'delete-all') {
-    for (const event of events) {
+    const successfulEventIds: string[] = [];
+
+    await runWithConcurrency(events, BULK_ACTION_CONCURRENCY, async (event) => {
       try {
-        await banEvent(event.id, reason, env);
-        await publishKind5Deletion(event.id, reason, env);
-        result.eventsProcessed++;
-        if (env.DB) {
-          await env.DB.prepare(
-            `INSERT INTO moderation_decisions (target_type, target_id, action, reason, created_at) VALUES (?, ?, ?, ?, datetime('now'))`
-          ).bind('event', event.id, 'delete_event', reason).run();
+        const banResult = await banEvent(event.id, reason, env);
+        if (!banResult.success) {
+          throw new Error(banResult.error || 'banevent failed');
         }
+
+        const deleteResult = await publishKind5Deletion(event.id, reason, env);
+        if (!deleteResult.success) {
+          throw new Error(deleteResult.error || 'kind 5 deletion failed');
+        }
+
+        result.eventsProcessed++;
+        successfulEventIds.push(event.id);
       } catch (error) {
-        result.failures.push(`event:${event.id}:${error}`);
+        result.failures.push(`event:${event.id}:${formatError(error)}`);
       }
+    });
+
+    if (env.DB && successfulEventIds.length > 0) {
+      await env.DB.batch(
+        successfulEventIds.map((eventId) => env.DB!.prepare(
+          `INSERT INTO moderation_decisions (target_type, target_id, action, reason, moderator_pubkey, created_at) VALUES (?, ?, ?, ?, ?, datetime('now'))`
+        ).bind('event', eventId, 'delete_event', reason, moderatorPubkey))
+      );
     }
-    for (const sha256 of mediaHashes) {
+
+    await runWithConcurrency(successfulEventIds, BULK_ACTION_CONCURRENCY, async (eventId) => {
+      await syncZendeskAfterAction(env, 'delete_event', 'event', eventId, moderatorPubkey);
+    });
+
+    if (successfulEventIds.length > 0) {
+      await syncZendeskAfterAction(env, 'delete_event', 'pubkey', body.pubkey, moderatorPubkey);
+    }
+
+    await runWithConcurrency(mediaHashes, BULK_ACTION_CONCURRENCY, async (sha256) => {
       try {
         await callModerateMedia(sha256, 'DELETE', reason, env);
         result.mediaProcessed++;
       } catch (error) {
-        result.failures.push(`media:${sha256}:${error}`);
+        result.failures.push(`media:${sha256}:${formatError(error)}`);
       }
-    }
+    });
   } else {
+    result.eventsProcessed = events.length;
     const mediaAction = action === 'age-restrict-all' ? 'AGE_RESTRICTED' : 'SAFE';
-    for (const sha256 of mediaHashes) {
+    await runWithConcurrency(mediaHashes, BULK_ACTION_CONCURRENCY, async (sha256) => {
       try {
         await callModerateMedia(sha256, mediaAction, reason, env);
         result.mediaProcessed++;
       } catch (error) {
-        result.failures.push(`media:${sha256}:${error}`);
+        result.failures.push(`media:${sha256}:${formatError(error)}`);
       }
-    }
+    });
   }
 
   result.success = result.failures.length === 0;
@@ -89,80 +117,82 @@ export async function handleBulkModerate(
 export async function queryRelayEvents(
   pubkey: string,
   env: Pick<BulkModerateEnv, 'RELAY_URL'>,
-): Promise<Array<{ id: string; kind: number; tags: string[][] }>> {
-  return new Promise((resolve) => {
+): Promise<RelayEventSummary[]> {
+  return new Promise((resolve, reject) => {
     try {
       const ws = new WebSocket(env.RELAY_URL);
       let resolved = false;
-      const events: Array<{ id: string; kind: number; tags: string[][] }> = [];
+      const events: RelayEventSummary[] = [];
       const subId = `bulk-${Date.now()}`;
 
+      const finish = (fn: (value?: unknown) => void, value?: unknown) => {
+        if (resolved) return;
+        resolved = true;
+        clearTimeout(timeout);
+        ws.close();
+        fn(value);
+      };
+
       const timeout = setTimeout(() => {
-        if (!resolved) {
-          resolved = true;
-          ws.close();
-          resolve(events);
-        }
-      }, 10000);
+        finish(reject, new Error('Relay query timed out before EOSE'));
+      }, RELAY_QUERY_TIMEOUT_MS);
 
       ws.addEventListener('open', () => {
-        ws.send(JSON.stringify(['REQ', subId, { authors: [pubkey], limit: 5000 }]));
+        ws.send(JSON.stringify(['REQ', subId, { authors: [pubkey], limit: RELAY_QUERY_FETCH_LIMIT }]));
       });
 
       ws.addEventListener('message', (msg) => {
         try {
           const data = JSON.parse(msg.data as string);
           if (data[0] === 'EVENT' && data[1] === subId) {
-            const event = data[2] as { id: string; kind: number; tags: string[][] };
-            events.push({ id: event.id, kind: event.kind, tags: event.tags });
+            const event = data[2] as { id: string; kind: number; content?: string; tags: string[][] };
+            events.push({ id: event.id, kind: event.kind, content: event.content || '', tags: event.tags });
           } else if (data[0] === 'EOSE' && data[1] === subId) {
-            clearTimeout(timeout);
-            resolved = true;
-            ws.close();
-            resolve(events);
+            if (events.length > RELAY_QUERY_LIMIT) {
+              finish(reject, new Error(`Bulk moderation matched more than ${RELAY_QUERY_LIMIT} events; narrow the scope or add pagination`));
+              return;
+            }
+            finish(resolve, events);
           }
         } catch {
-          // Ignore parse errors
+          // Ignore malformed relay frames and continue collecting.
         }
       });
 
       ws.addEventListener('error', () => {
-        if (!resolved) {
-          clearTimeout(timeout);
-          resolved = true;
-          resolve(events);
-        }
+        finish(reject, new Error('Relay query failed'));
       });
 
       ws.addEventListener('close', () => {
-        if (!resolved) {
-          clearTimeout(timeout);
-          resolved = true;
-          resolve(events);
-        }
+        finish(reject, new Error('Relay query closed before EOSE'));
       });
-    } catch {
-      resolve([]);
+    } catch (error) {
+      reject(error);
     }
   });
 }
 
-export function extractMediaHashes(events: Array<{ id: string; kind: number; tags: string[][] }>): string[] {
+export function extractMediaHashes(events: RelayEventSummary[]): string[] {
   const hashes = new Set<string>();
   for (const event of events) {
-    if (!VIDEO_KINDS.includes(event.kind)) continue;
-    for (const tag of event.tags) {
-      if (tag[0] === 'imeta') {
-        for (let i = 1; i < tag.length; i++) {
-          if (tag[i].startsWith('sha256 ')) {
-            hashes.add(tag[i].split(' ')[1]);
-          }
-        }
-      }
-      if (tag[0] === 'x') hashes.add(tag[1]);
-    }
+    const eventHashes = extractSharedMediaHashes(event.content, event.tags);
+    eventHashes.forEach((hash) => hashes.add(hash));
   }
   return Array.from(hashes);
+}
+
+async function runWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  for (let i = 0; i < items.length; i += concurrency) {
+    await Promise.all(items.slice(i, i + concurrency).map(worker));
+  }
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 async function callModerateMedia(

--- a/worker/src/bulk-moderate.ts
+++ b/worker/src/bulk-moderate.ts
@@ -2,7 +2,7 @@ import { banEvent, publishKind5Deletion, type Nip86Env } from './nip86';
 
 type BulkAction = 'age-restrict-all' | 'un-age-restrict-all' | 'delete-all';
 const VALID_BULK_ACTIONS: BulkAction[] = ['age-restrict-all', 'un-age-restrict-all', 'delete-all'];
-const VIDEO_KINDS = [34235, 34236];
+const VIDEO_KINDS = [34235, 34236, 21, 22];
 
 export interface BulkModerateEnv extends Nip86Env {
   DB?: D1Database;

--- a/worker/src/db.ts
+++ b/worker/src/db.ts
@@ -95,4 +95,10 @@ export async function ensureSchema(db: D1Database): Promise<void> {
     // Index already exists
   }
 
+  await db.prepare(`
+    CREATE TABLE IF NOT EXISTS age_review_config (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    )
+  `).run();
 }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -22,7 +22,10 @@ import {
   handleParentContact,
   handleAgeReviewReplyWebhook,
   checkAgeReviewDeadlines,
+  getAgeReviewConfig,
+  updateAgeReviewConfig,
 } from './age-review';
+import { handleBulkModerate } from './bulk-moderate';
 
 let schemaReady = false;
 async function ensureSchemaOnce(db: D1Database): Promise<void> {
@@ -429,6 +432,27 @@ export default {
           return jsonResponse({ success: false, error: result.error }, 502, corsHeaders);
         }
         return jsonResponse({ success: true, events: result.events }, 200, corsHeaders);
+      }
+
+      // Bulk moderation (server-side iteration for batch operations)
+      if (path === '/api/bulk-moderate' && request.method === 'POST') {
+        if (env.DB) await ensureSchemaOnce(env.DB);
+        return handleBulkModerate(request, env, corsHeaders);
+      }
+
+      // Age review config
+      if (path === '/api/age-review/config' && request.method === 'GET') {
+        if (!env.DB) return jsonResponse({ error: 'Database not configured' }, 500, corsHeaders);
+        await ensureSchemaOnce(env.DB);
+        const config = await getAgeReviewConfig(env.DB);
+        return jsonResponse(config, 200, corsHeaders);
+      }
+      if (path === '/api/age-review/config' && request.method === 'PUT') {
+        if (!env.DB) return jsonResponse({ error: 'Database not configured' }, 500, corsHeaders);
+        await ensureSchemaOnce(env.DB);
+        const configBody = await request.json() as Record<string, unknown>;
+        const config = await updateAgeReviewConfig(env.DB, configBody);
+        return jsonResponse(config, 200, corsHeaders);
       }
 
       // Age review case management

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1245,7 +1245,7 @@ async function handleModerateMedia(
   try {
     const body = await request.json() as {
       sha256: string;
-      action: 'SAFE' | 'REVIEW' | 'AGE_RESTRICTED' | 'PERMANENT_BAN';
+      action: 'SAFE' | 'REVIEW' | 'AGE_RESTRICTED' | 'PERMANENT_BAN' | 'DELETE';
       reason?: string;
     };
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -442,17 +442,23 @@ export default {
 
       // Age review config
       if (path === '/api/age-review/config' && request.method === 'GET') {
-        if (!env.DB) return jsonResponse({ error: 'Database not configured' }, 500, corsHeaders);
+        if (!env.DB) return jsonResponse({ success: false, error: 'Database not configured' }, 500, corsHeaders);
         await ensureSchemaOnce(env.DB);
         const config = await getAgeReviewConfig(env.DB);
-        return jsonResponse(config, 200, corsHeaders);
+        return new Response(JSON.stringify(config), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json', ...corsHeaders },
+        });
       }
       if (path === '/api/age-review/config' && request.method === 'PUT') {
-        if (!env.DB) return jsonResponse({ error: 'Database not configured' }, 500, corsHeaders);
+        if (!env.DB) return jsonResponse({ success: false, error: 'Database not configured' }, 500, corsHeaders);
         await ensureSchemaOnce(env.DB);
         const configBody = await request.json() as Record<string, unknown>;
         const config = await updateAgeReviewConfig(env.DB, configBody);
-        return jsonResponse(config, 200, corsHeaders);
+        return new Response(JSON.stringify(config), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json', ...corsHeaders },
+        });
       }
 
       // Age review case management

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -27,6 +27,7 @@ import {
   updateAgeReviewConfig,
 } from './age-review';
 import { handleBulkModerate } from './bulk-moderate';
+import { ensureZendeskTable, addZendeskInternalNote, syncZendeskAfterAction } from './zendesk-sync';
 
 let schemaReady = false;
 async function ensureSchemaOnce(db: D1Database): Promise<void> {
@@ -989,42 +990,6 @@ async function markHumanReviewed(db: D1Database, targetType: string, targetId: s
   }
 }
 
-// Ensure zendesk_tickets table exists for tracking Zendesk ↔ Nostr mappings
-async function ensureZendeskTable(db: D1Database): Promise<void> {
-  await db.prepare(`
-    CREATE TABLE IF NOT EXISTS zendesk_tickets (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      ticket_id INTEGER NOT NULL UNIQUE,
-      event_id TEXT,
-      author_pubkey TEXT,
-      violation_type TEXT,
-      status TEXT DEFAULT 'open',
-      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-      resolved_at TEXT,
-      resolution_action TEXT,
-      resolution_moderator TEXT
-    )
-  `).run();
-
-  try {
-    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_zendesk_event ON zendesk_tickets(event_id)`).run();
-  } catch {
-    // Index might already exist
-  }
-
-  try {
-    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_zendesk_pubkey ON zendesk_tickets(author_pubkey)`).run();
-  } catch {
-    // Index might already exist
-  }
-
-  try {
-    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_zendesk_status ON zendesk_tickets(status)`).run();
-  } catch {
-    // Index might already exist
-  }
-}
-
 async function handleLogDecision(
   request: Request,
   env: Env,
@@ -1755,65 +1720,6 @@ async function updateZendeskTicket(
 }
 
 // Add internal note to Zendesk ticket (simpler than updateZendeskTicket - just adds comment, optionally solves)
-async function addZendeskInternalNote(
-  ticketId: number,
-  note: string,
-  env: Env,
-  solve: boolean = false
-): Promise<void> {
-  if (!env.ZENDESK_SUBDOMAIN || !env.ZENDESK_API_TOKEN || !env.ZENDESK_EMAIL) {
-    console.warn('[addZendeskInternalNote] Missing Zendesk credentials, skipping');
-    return;
-  }
-
-  try {
-    const auth = btoa(`${env.ZENDESK_EMAIL}/token:${env.ZENDESK_API_TOKEN}`);
-    const url = `https://${env.ZENDESK_SUBDOMAIN}.zendesk.com/api/v2/tickets/${ticketId}`;
-
-    const payload: { ticket: { comment: { body: string; public: boolean }; status?: string; assignee_email?: string; custom_fields?: Array<{ id: number; value: string }> } } = {
-      ticket: {
-        comment: {
-          body: note,
-          public: false,
-        },
-      },
-    };
-
-    if (solve) {
-      payload.ticket.status = 'solved';
-      // Zendesk requires an assignee to solve a ticket (system rule, not enforced via API error).
-      // Without this, the comment is added but the status change is silently ignored.
-      payload.ticket.assignee_email = env.ZENDESK_EMAIL;
-      // Category and Issue are required fields. These values are set unconditionally. Safe
-      // because auto-categorize triggers fire at ticket creation, and this solve call runs
-      // later only for report types where triggers didn't set specific values (e.g., "other"
-      // reports with the previously misconfigured trigger).
-      if (env.ZENDESK_FIELD_CATEGORY && env.ZENDESK_FIELD_ISSUE) {
-        payload.ticket.custom_fields = [
-          { id: parseInt(env.ZENDESK_FIELD_CATEGORY, 10), value: 'trust___safety' },
-          { id: parseInt(env.ZENDESK_FIELD_ISSUE, 10), value: 'other_content_report' },
-        ];
-      }
-    }
-
-    const response = await fetch(url, {
-      method: 'PUT',
-      headers: {
-        'Authorization': `Basic ${auth}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(payload),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      console.error(`[addZendeskInternalNote] Failed: ${response.status} - ${errorText}`);
-    }
-  } catch (error) {
-    console.error('[addZendeskInternalNote] Error:', error);
-  }
-}
-
 // Proxy handler for blocked media preview (Blossom admin bypass)
 // Moderators need to see media that Blossom blocks (Banned/Restricted status returns 404 on CDN).
 // This endpoint authenticates against Blossom's admin bypass and streams the content through.
@@ -2681,85 +2587,6 @@ async function handleMobileJwt(
 }
 
 // Sync Zendesk ticket after moderation action in relay-manager
-async function syncZendeskAfterAction(
-  env: Env,
-  action: string,
-  targetType: 'event' | 'pubkey' | 'media',
-  targetId: string,
-  moderator: string
-): Promise<void> {
-  console.log('[syncZendeskAfterAction] Called with:', { action, targetType, targetId, moderator });
-
-  if (!env.DB) {
-    console.log('[syncZendeskAfterAction] No DB configured, skipping');
-    return;
-  }
-
-  try {
-    await ensureZendeskTable(env.DB);
-
-    // Find linked open ticket
-    let linked: { ticket_id: number } | null = null;
-
-    if (targetType === 'event') {
-      console.log('[syncZendeskAfterAction] Querying for event_id:', targetId);
-      linked = await env.DB.prepare(
-        `SELECT ticket_id FROM zendesk_tickets WHERE event_id = ? AND status = 'open'`
-      ).bind(targetId).first();
-    } else if (targetType === 'pubkey') {
-      console.log('[syncZendeskAfterAction] Querying for author_pubkey:', targetId);
-      linked = await env.DB.prepare(
-        `SELECT ticket_id FROM zendesk_tickets WHERE author_pubkey = ? AND status = 'open'`
-      ).bind(targetId).first();
-    }
-
-    console.log('[syncZendeskAfterAction] Query result:', linked);
-
-    if (!linked?.ticket_id) {
-      console.log('[syncZendeskAfterAction] No linked open ticket found, skipping');
-      return;
-    }
-
-    // Determine if this is a resolution action (should solve ticket)
-    // Note: ban_user is Zendesk webhook naming, ban_pubkey is UI naming - same effect
-    const resolutionActions = ['reviewed', 'dismissed', 'no-action', 'false-positive', 'delete_event', 'ban_pubkey', 'ban_user', 'auto_hide_confirmed', 'auto_hide_restored'];
-    const isResolution = resolutionActions.includes(action);
-
-    // Build note
-    const actionDisplay = action.replace(/_/g, ' ').replace(/([A-Z])/g, ' $1').trim();
-    const timestamp = new Date().toISOString();
-
-    const note = [
-      '📋 **Moderation Action Taken**',
-      '',
-      `**Action:** ${actionDisplay}`,
-      `**Target:** \`${targetId}\``,
-      `**Moderator:** ${moderator}`,
-      `**Time:** ${timestamp}`,
-    ].join('\n');
-
-    // Add note (and solve if resolution action)
-    await addZendeskInternalNote(linked.ticket_id, note, env, isResolution);
-
-    // Update our tracking if resolved
-    if (isResolution) {
-      await env.DB.prepare(`
-        UPDATE zendesk_tickets
-        SET status = 'resolved',
-            resolved_at = CURRENT_TIMESTAMP,
-            resolution_action = ?,
-            resolution_moderator = ?
-        WHERE ticket_id = ?
-      `).bind(action, moderator, linked.ticket_id).run();
-    }
-
-    console.log(`[syncZendeskAfterAction] Updated ticket #${linked.ticket_id} with action: ${action}`);
-  } catch (error) {
-    console.error('[syncZendeskAfterAction] Error:', error);
-    // Don't throw - Zendesk sync failure shouldn't break moderation
-  }
-}
-
 // Get context for Zendesk sidebar app
 async function handleZendeskContext(
   request: Request,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -9,6 +9,7 @@ import {
   banEvent,
   banPubkey,
   unbanPubkey,
+  publishKind5Deletion,
   type SecretStoreSecret,
 } from './nip86';
 import { ensureSchema } from './db';
@@ -368,6 +369,18 @@ export default {
 
       if (path === '/api/moderate-media' && request.method === 'POST') {
         return handleModerateMedia(request, env, corsHeaders);
+      }
+
+      if (path === '/api/publish-deletion' && request.method === 'POST') {
+        const body = await request.json() as { eventId?: string; reason?: string };
+        if (!body.eventId) {
+          return jsonResponse({ success: false, error: 'Missing eventId' }, 400, corsHeaders);
+        }
+        const result = await publishKind5Deletion(body.eventId, body.reason || 'Deleted by moderator', env);
+        if (!result.success) {
+          return jsonResponse({ success: false, error: result.error || 'Failed to publish deletion' }, 500, corsHeaders);
+        }
+        return jsonResponse({ success: true }, 200, corsHeaders);
       }
 
       if (path === '/api/decisions' && request.method === 'POST') {

--- a/worker/src/nip86.test.ts
+++ b/worker/src/nip86.test.ts
@@ -11,6 +11,7 @@ import {
   allowEvent,
   banPubkey,
   unbanPubkey,
+  publishKind5Deletion,
   type Nip86Env,
 } from './nip86';
 
@@ -212,5 +213,54 @@ describe('convenience methods', () => {
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
     expect(body.method).toBe('unbanpubkey');
     expect(body.params).toEqual(['pubkey123']);
+  });
+});
+
+describe('publishKind5Deletion', () => {
+  it('constructs a valid NIP-09 kind 5 event and posts to relay', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    const env: Nip86Env = {
+      NOSTR_NSEC: TEST_NSEC,
+      RELAY_URL: 'wss://relay.test.com',
+    };
+
+    const result = await publishKind5Deletion('target-event-id-hex', 'Content violates policy', env, mockFetch);
+
+    expect(result.success).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('https://relay.test.com');
+    const body = JSON.parse(opts.body);
+    expect(body[0]).toBe('EVENT');
+    expect(body[1].kind).toBe(5);
+    expect(body[1].tags).toContainEqual(['e', 'target-event-id-hex']);
+    expect(body[1].content).toBe('Content violates policy');
+    expect(body[1].sig).toBeDefined();
+  });
+
+  it('returns error when relay responds with non-OK status', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    const env: Nip86Env = {
+      NOSTR_NSEC: TEST_NSEC,
+      RELAY_URL: 'wss://relay.test.com',
+    };
+
+    const result = await publishKind5Deletion('event-id', 'reason', env, mockFetch);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('500');
+  });
+
+  it('returns error on fetch failure', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
+    const env: Nip86Env = {
+      NOSTR_NSEC: TEST_NSEC,
+      RELAY_URL: 'wss://relay.test.com',
+    };
+
+    const result = await publishKind5Deletion('event-id', 'reason', env, mockFetch);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Network error');
   });
 });

--- a/worker/src/nip86.ts
+++ b/worker/src/nip86.ts
@@ -191,3 +191,42 @@ export async function unbanPubkey(
 ): Promise<Nip86RpcResult> {
   return callNip86Rpc('unbanpubkey', [pubkey], env);
 }
+
+/**
+ * Publish a NIP-09 kind 5 deletion request to the relay.
+ * Published from the admin key -- Funnelcake honors admin deletions.
+ * Other relays may ignore kind 5 from non-authors.
+ */
+export async function publishKind5Deletion(
+  targetEventId: string,
+  reason: string,
+  env: Nip86Env,
+  fetchFn: typeof fetch = fetch,
+): Promise<{ success: boolean; error?: string }> {
+  const secretKey = await getSecretKey(env);
+  const relayHttpUrl = env.RELAY_URL.replace('wss://', 'https://').replace('ws://', 'http://');
+
+  const event = finalizeEvent(
+    {
+      kind: 5,
+      content: reason,
+      tags: [['e', targetEventId]],
+      created_at: Math.floor(Date.now() / 1000),
+    },
+    secretKey,
+  );
+
+  try {
+    const response = await fetchFn(relayHttpUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(['EVENT', event]),
+    });
+    if (!response.ok) {
+      return { success: false, error: `Relay returned ${response.status}` };
+    }
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: String(error) };
+  }
+}

--- a/worker/src/zendesk-sync.ts
+++ b/worker/src/zendesk-sync.ts
@@ -1,0 +1,195 @@
+import type { SecretStoreSecret } from './nip86';
+
+export interface ZendeskSyncEnv {
+  DB?: D1Database;
+  ZENDESK_SUBDOMAIN?: string;
+  ZENDESK_API_TOKEN?: string;
+  ZENDESK_EMAIL?: string;
+  ZENDESK_FIELD_CATEGORY?: string;
+  ZENDESK_FIELD_ISSUE?: string;
+  NOSTR_NSEC: string | SecretStoreSecret;
+  RELAY_URL: string;
+}
+
+function buildResolutionCustomFields(env: ZendeskSyncEnv): Array<{ id: number; value: string }> | undefined {
+  if (!env.ZENDESK_FIELD_CATEGORY || !env.ZENDESK_FIELD_ISSUE) {
+    return undefined;
+  }
+
+  return [
+    { id: Number.parseInt(env.ZENDESK_FIELD_CATEGORY, 10), value: 'trust___safety' },
+    { id: Number.parseInt(env.ZENDESK_FIELD_ISSUE, 10), value: 'other_content_report' },
+  ];
+}
+
+export async function ensureZendeskTable(db: D1Database): Promise<void> {
+  await db.prepare(`
+    CREATE TABLE IF NOT EXISTS zendesk_tickets (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      ticket_id INTEGER NOT NULL UNIQUE,
+      event_id TEXT,
+      author_pubkey TEXT,
+      violation_type TEXT,
+      status TEXT DEFAULT 'open',
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      resolved_at TEXT,
+      resolution_action TEXT,
+      resolution_moderator TEXT
+    )
+  `).run();
+
+  try {
+    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_zendesk_event ON zendesk_tickets(event_id)`).run();
+  } catch {
+    // Index might already exist
+  }
+
+  try {
+    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_zendesk_pubkey ON zendesk_tickets(author_pubkey)`).run();
+  } catch {
+    // Index might already exist
+  }
+
+  try {
+    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_zendesk_status ON zendesk_tickets(status)`).run();
+  } catch {
+    // Index might already exist
+  }
+}
+
+export async function addZendeskInternalNote(
+  ticketId: number,
+  note: string,
+  env: ZendeskSyncEnv,
+  solve: boolean = false
+): Promise<void> {
+  if (!env.ZENDESK_SUBDOMAIN || !env.ZENDESK_API_TOKEN || !env.ZENDESK_EMAIL) {
+    console.warn('[addZendeskInternalNote] Missing Zendesk credentials, skipping');
+    return;
+  }
+
+  try {
+    const auth = btoa(`${env.ZENDESK_EMAIL}/token:${env.ZENDESK_API_TOKEN}`);
+    const url = `https://${env.ZENDESK_SUBDOMAIN}.zendesk.com/api/v2/tickets/${ticketId}`;
+
+    const payload: {
+      ticket: {
+        comment: { body: string; public: boolean };
+        status?: string;
+        assignee_email?: string;
+        custom_fields?: Array<{ id: number; value: string }>;
+      };
+    } = {
+      ticket: {
+        comment: {
+          body: note,
+          public: false,
+        },
+      },
+    };
+
+    if (solve) {
+      payload.ticket.status = 'solved';
+      payload.ticket.assignee_email = env.ZENDESK_EMAIL;
+      payload.ticket.custom_fields = buildResolutionCustomFields(env);
+    }
+
+    const response = await fetch(url, {
+      method: 'PUT',
+      headers: {
+        'Authorization': `Basic ${auth}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error(`[addZendeskInternalNote] Failed: ${response.status} - ${errorText}`);
+    }
+  } catch (error) {
+    console.error('[addZendeskInternalNote] Error:', error);
+  }
+}
+
+export async function syncZendeskAfterAction(
+  env: ZendeskSyncEnv,
+  action: string,
+  targetType: 'event' | 'pubkey' | 'media',
+  targetId: string,
+  moderator: string
+): Promise<void> {
+  console.log('[syncZendeskAfterAction] Called with:', { action, targetType, targetId, moderator });
+
+  if (!env.DB) {
+    console.log('[syncZendeskAfterAction] No DB configured, skipping');
+    return;
+  }
+
+  try {
+    await ensureZendeskTable(env.DB);
+
+    let linked: { ticket_id: number } | null = null;
+
+    if (targetType === 'event') {
+      console.log('[syncZendeskAfterAction] Querying for event_id:', targetId);
+      linked = await env.DB.prepare(
+        `SELECT ticket_id FROM zendesk_tickets WHERE event_id = ? AND status = 'open'`
+      ).bind(targetId).first();
+    } else if (targetType === 'pubkey') {
+      console.log('[syncZendeskAfterAction] Querying for author_pubkey:', targetId);
+      linked = await env.DB.prepare(
+        `SELECT ticket_id FROM zendesk_tickets WHERE author_pubkey = ? AND status = 'open'`
+      ).bind(targetId).first();
+    }
+
+    console.log('[syncZendeskAfterAction] Query result:', linked);
+
+    if (!linked?.ticket_id) {
+      console.log('[syncZendeskAfterAction] No linked open ticket found, skipping');
+      return;
+    }
+
+    const resolutionActions = [
+      'reviewed',
+      'dismissed',
+      'no-action',
+      'false-positive',
+      'delete_event',
+      'ban_pubkey',
+      'ban_user',
+      'auto_hide_confirmed',
+      'auto_hide_restored',
+    ];
+    const isResolution = resolutionActions.includes(action);
+
+    const actionDisplay = action.replace(/_/g, ' ').replace(/([A-Z])/g, ' $1').trim();
+    const timestamp = new Date().toISOString();
+
+    const note = [
+      '📋 **Moderation Action Taken**',
+      '',
+      `**Action:** ${actionDisplay}`,
+      `**Target:** \`${targetId}\``,
+      `**Moderator:** ${moderator}`,
+      `**Time:** ${timestamp}`,
+    ].join('\n');
+
+    await addZendeskInternalNote(linked.ticket_id, note, env, isResolution);
+
+    if (isResolution) {
+      await env.DB.prepare(`
+        UPDATE zendesk_tickets
+        SET status = 'resolved',
+            resolved_at = CURRENT_TIMESTAMP,
+            resolution_action = ?,
+            resolution_moderator = ?
+        WHERE ticket_id = ?
+      `).bind(action, moderator, linked.ticket_id).run();
+    }
+
+    console.log(`[syncZendeskAfterAction] Updated ticket #${linked.ticket_id} with action: ${action}`);
+  } catch (error) {
+    console.error('[syncZendeskAfterAction] Error:', error);
+  }
+}


### PR DESCRIPTION
## Summary

Implementing the under-16 age review enforcement layer (support-trust-safety#138) exposed that moderation actions were inconsistent across surfaces and the line between reversible actions (ban, block, restrict) and permanent ones (delete) was blurred -- deletion was only available as a sub-option of "Block & Delete" rather than a deliberate, standalone choice. This PR realigns moderation actions and makes the reversible/permanent distinction explicit, particularly for content take-downs and age review case resolution.

The action buttons in ReportDetail had grown to ~2200 lines of inline mutations, confirmation dialogs, and verification logic. Rather than bolt more onto that, we extracted composable `EventActions` and `UserActions` components that are now shared across Reports, Events, Users, and Age Review -- same actions, same confirmation flows, same visual distinction between reversible (outline) and irreversible (red, two-click) operations everywhere.

**What's new:**
- DELETE as a first-class media action (Blossom) and NIP-09 kind 5 event deletion (Funnelcake)
- Bulk content operations via `/api/bulk-moderate` (age-restrict all, delete all for a pubkey)
- Age review deny/expire can auto-delete all user content (configurable toggle in Settings)
- Manual delete fallback in age review when auto-delete is disabled
- `DeleteConfirmDialog` requiring typed confirmation for all irreversible actions
- Composable `EventActions` and `UserActions` replacing ~1100 lines of inline action code in ReportDetail

Relates to divinevideo/support-trust-safety#138

## Prerequisite

divinevideo/divine-moderation-service#147 (one-line change adding `DELETE` to `validActions`) must deploy before Blossom media deletion works. Everything else (NIP-09 deletion, bulk operations, UI) works independently.

## New files

| File | Purpose |
|------|---------|
| `src/components/EventActions.tsx` | Composable event-level actions (ban/restore, media block/restrict/delete) |
| `src/components/UserActions.tsx` | Composable user-level actions (ban/unban, bulk age-restrict, bulk delete) |
| `src/components/DeleteConfirmDialog.tsx` | Two-click confirmation dialog for destructive actions |
| `worker/src/bulk-moderate.ts` | Server-side bulk moderation (fetches user events, applies action to all media) |

## Verification

**Local (dev server, no worker):**
- [x] All tabs render without crashes (Reports, Age Review, Events, Users, Settings)
- [x] AgeReviewSettings toggle renders in Settings with description text
- [x] Age Review tab renders case list with Active/Closed/All filters

**Automated:**
- [x] 97 tests pass, 0 failures
- [x] eslint clean
- [x] tsc --noEmit clean

**Needs staging deploy:**
- [ ] ReportDetail action buttons (EventActions/UserActions) with a real report
- [ ] EventModeration banned events list with EventActions
- [ ] UserManagement selected user with UserActions
- [ ] AgeReviewDetail deny flow with auto-delete confirmation
- [ ] DeleteConfirmDialog two-click flow
- [ ] Bulk operations hitting the worker