### PR TITLE
fix: dedup report categories, surface Keycast failures, audit partial deletes

### DIFF
--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAdminApi } from "@/hooks/useAdminApi";
+import { useToast } from "@/hooks/useToast";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { UserActions } from "@/components/UserActions";
 import { Badge } from "@/components/ui/badge";
@@ -82,10 +83,20 @@ interface Props {
   caseData: AgeReviewCase;
 }
 
+const KEYCAST_STATES: AgeReviewState[] = [
+  'restricted_pending_user_response',
+  'restricted_pending_parental_consent',
+  'restricted_pending_support_email',
+  'cleared',
+  'denied_closed',
+];
+
 export function AgeReviewDetail({ caseData: c }: Props) {
   const api = useAdminApi();
+  const { toast } = useToast();
   const queryClient = useQueryClient();
   const [resolutionNote, setResolutionNote] = useState(c.resolution_note ?? "");
+  const pendingStateRef = useRef<string | undefined>();
 
   useEffect(() => {
     setResolutionNote(c.resolution_note ?? "");
@@ -95,10 +106,20 @@ export function AgeReviewDetail({ caseData: c }: Props) {
   const daysRemaining = getDaysRemaining(c);
 
   const updateCase = useMutation({
-    mutationFn: (updates: Record<string, unknown>) =>
-      api.updateAgeReviewCase(c.id, updates),
-    onSuccess: () => {
+    mutationFn: (updates: Record<string, unknown>) => {
+      pendingStateRef.current = updates.state as string | undefined;
+      return api.updateAgeReviewCase(c.id, updates);
+    },
+    onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['age-review-cases'] });
+      const requestedState = pendingStateRef.current as AgeReviewState | undefined;
+      if (requestedState && KEYCAST_STATES.includes(requestedState) && data.keycastUpdated === false) {
+        toast({
+          title: 'Account enforcement failed',
+          description: 'Case was updated but Keycast account suspension did not apply. The user\'s account may still be active. Retry or escalate.',
+          variant: 'destructive',
+        });
+      }
     },
   });
 

--- a/src/components/EventActions.tsx
+++ b/src/components/EventActions.tsx
@@ -173,24 +173,45 @@ export function EventActions({
 
   const deleteEventAndMediaMutation = useMutation({
     mutationFn: async () => {
-      await api.deleteEvent(eventId, 'Permanently deleted by moderator', pubkey);
-      await api.publishDeletionRequest(eventId, 'Permanently deleted by moderator');
-      for (const hash of mediaHashes) {
-        await api.deleteMedia(hash, 'Permanently deleted by moderator');
+      const completed: string[] = [];
+      try {
+        await api.deleteEvent(eventId, 'Permanently deleted by moderator', pubkey);
+        completed.push('event_deleted');
+        await api.logDecision({ targetType: 'event', targetId: eventId, action: 'delete_event', reason: 'Permanently deleted (combined)' });
+
+        await api.publishDeletionRequest(eventId, 'Permanently deleted by moderator');
+        completed.push('deletion_request');
+
+        for (const hash of mediaHashes) {
+          await api.deleteMedia(hash, 'Permanently deleted by moderator');
+          completed.push(`media_${hash.slice(0, 8)}`);
+        }
+        await api.logDecision({ targetType: 'event', targetId: eventId, action: 'delete_event_and_media', reason: `Permanently deleted event + ${mediaHashes.length} media file(s)` });
+      } catch (error) {
+        if (completed.length > 0) {
+          try {
+            await api.logDecision({ targetType: 'event', targetId: eventId, action: 'delete_event_and_media_partial', reason: `Partial delete (completed: ${completed.join(', ')}). Error: ${error instanceof Error ? error.message : 'unknown'}` });
+          } catch { /* audit log itself failed — nothing more we can do */ }
+        }
+        throw Object.assign(error instanceof Error ? error : new Error('Unknown error'), { completed });
       }
-      await api.logDecision({
-        targetType: 'event',
-        targetId: eventId,
-        action: 'delete_event_and_media',
-        reason: `Permanently deleted event + ${mediaHashes.length} media file(s)`,
-      });
     },
     onSuccess: () => {
       toast({ title: 'Event and media permanently deleted' });
       onActionComplete?.();
     },
-    onError: (error: Error) => {
-      toast({ title: 'Failed to delete', description: error.message, variant: 'destructive' });
+    onError: (error: Error & { completed?: string[] }) => {
+      const completed = error.completed ?? [];
+      if (completed.length > 0) {
+        toast({
+          title: 'Partially completed',
+          description: `Event was deleted but media deletion failed: ${error.message}. Check audit log for details.`,
+          variant: 'destructive',
+        });
+        onActionComplete?.();
+      } else {
+        toast({ title: 'Failed to delete', description: error.message, variant: 'destructive' });
+      }
     },
   });
 

--- a/src/components/Reports.tsx
+++ b/src/components/Reports.tsx
@@ -43,7 +43,7 @@ import {
 import { nip19 } from "nostr-tools";
 import { ReportDetail } from "@/components/ReportDetail";
 import { useAdminApi } from "@/hooks/useAdminApi";
-import { AUTO_HIDE_ACTIONS, CATEGORY_LABELS } from "@/lib/constants";
+import { AUTO_HIDE_ACTIONS, CATEGORY_LABELS, HIGH_PRIORITY_CATEGORIES, getReportCategory } from "@/lib/constants";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import type { NostrEvent } from "@nostrify/nostrify";
@@ -59,9 +59,6 @@ const SORT_OPTIONS: { value: SortOption; label: string }[] = [
   { value: 'category', label: 'By Category' },
 ];
 
-// High-priority categories that need immediate attention (CSAM, illegal content)
-// Includes both NIP-56 standard names and Divine client variations
-const HIGH_PRIORITY_CATEGORIES = ['sexual_minors', 'csam', 'NS-csam', 'nonconsensual_sexual_content', 'terrorism_extremism', 'credible_threats'];
 const MEDIUM_PRIORITY_CATEGORIES = ['doxxing_pii', 'malware_scam', 'illegal_goods'];
 
 // Category priority for sorting
@@ -88,14 +85,6 @@ interface ConsolidatedReport {
   reporters: string[];
   latestReport: NostrEvent;
   oldestReport: NostrEvent;
-}
-
-function getReportCategory(event: NostrEvent): string {
-  const reportTag = event.tags.find(t => t[0] === 'report');
-  if (reportTag && reportTag[1]) return reportTag[1];
-  const lTag = event.tags.find(t => t[0] === 'l');
-  if (lTag && lTag[1]) return lTag[1];
-  return 'other';
 }
 
 function getReportTarget(event: NostrEvent): ReportTarget | null {

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -888,6 +888,7 @@ interface AgeReviewCasesResponse {
 interface AgeReviewCaseResponse {
   success: boolean;
   case: import('../../shared/age-review').AgeReviewCase;
+  keycastUpdated?: boolean;
 }
 
 export async function getAgeReviewCases(


### PR DESCRIPTION
## Summary

- **Dedup getReportCategory and HIGH_PRIORITY_CATEGORIES** (closes #81): the local copy in Reports.tsx was missing `NS-underageUser` and `NS-childSafety` (6 entries vs 8 in constants), so child-safety reports weren't getting priority treatment in the queue list. Now imports from `@/lib/constants`.

- **Surface failed Keycast enforcement in age review** (pre-existing): when a moderator restricts/clears/denies an age review case, the worker calls Keycast to suspend/unsuspend/ban the account and returns `keycastUpdated` in the response. The UI was ignoring this flag — showing success even when account enforcement failed silently. Now shows a destructive toast so the moderator knows to retry or escalate.

- **Audit partial deletes in combined event+media deletion** (pre-existing): the "Delete Event & Media" action ran four sequential steps with a single audit log at the end. If media deletion failed after the event was already destroyed, the error toast hid what succeeded and the audit trail was incomplete. Now logs each irreversible side effect as it completes and surfaces partial success to the moderator.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] All 99 tests pass (10 suites including EventActions and AgeReviewDetail)
- [ ] Staging: verify child-safety reports appear with priority badge in queue
- [ ] Staging: trigger age review restrict with Keycast unconfigured, verify warning toast appears
- [ ] Staging: verify combined delete surfaces partial success if media step fails