### PR TITLE
feat: add suspend/unsuspend user actions and clarify ban destructiveness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 *.local
 .env
+.dev.vars
 
 # Editor directories and files
 .idea

--- a/src/components/BannedUserCard.tsx
+++ b/src/components/BannedUserCard.tsx
@@ -22,9 +22,10 @@ interface BannedUserCardProps {
   pubkey: string;
   reason?: string;
   onUnban?: () => void;
+  actionButton?: React.ReactNode;
 }
 
-export function BannedUserCard({ pubkey: rawPubkey, reason, onUnban }: BannedUserCardProps) {
+export function BannedUserCard({ pubkey: rawPubkey, reason, onUnban, actionButton }: BannedUserCardProps) {
   const { nostr } = useNostr();
   const [isOpen, setIsOpen] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -185,11 +186,11 @@ export function BannedUserCard({ pubkey: rawPubkey, reason, onUnban }: BannedUse
                   />
                 </Button>
               </CollapsibleTrigger>
-              {onUnban && (
+              {actionButton ?? (onUnban && (
                 <Button variant="outline" size="sm" onClick={onUnban}>
                   <Trash2 className="h-4 w-4" />
                 </Button>
-              )}
+              ))}
             </div>
           </div>
         </div>

--- a/src/components/ConfirmDialog.test.tsx
+++ b/src/components/ConfirmDialog.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ConfirmDialog } from './ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+  it('shows summary on first click and executes on confirm', async () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        trigger={<button>Action</button>}
+        title="Confirm Action"
+        summary="Are you sure you want to proceed?"
+        onConfirm={onConfirm}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Action'));
+    expect(screen.getByText(/Are you sure/)).toBeInTheDocument();
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /Confirm/i }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('does not call onConfirm when cancelled', () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        trigger={<button>Action</button>}
+        title="Confirm"
+        summary="Summary"
+        onConfirm={onConfirm}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Action'));
+    fireEvent.click(screen.getByRole('button', { name: /Cancel/i }));
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('shows custom confirm and pending labels', () => {
+    render(
+      <ConfirmDialog
+        trigger={<button>Action</button>}
+        title="Ban User"
+        summary="This is destructive."
+        onConfirm={() => {}}
+        confirmLabel="Ban User"
+        pendingLabel="Banning..."
+        isPending={true}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Action'));
+    expect(screen.getByRole('button', { name: /Banning.../i })).toBeDisabled();
+  });
+
+  it('does not throw unhandled rejection when onConfirm fails', async () => {
+    const onConfirm = vi.fn().mockRejectedValue(new Error('RPC failed'));
+    render(
+      <ConfirmDialog
+        trigger={<button>Action</button>}
+        title="Confirm"
+        summary="Summary"
+        onConfirm={onConfirm}
+        confirmLabel="Do It"
+      />
+    );
+
+    fireEvent.click(screen.getByText('Action'));
+    fireEvent.click(screen.getByRole('button', { name: /Do It/i }));
+    await vi.waitFor(() => expect(onConfirm).toHaveBeenCalledOnce());
+  });
+});

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,64 @@
+import { useState, type ReactNode } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+
+interface ConfirmDialogProps {
+  trigger: ReactNode;
+  title: string;
+  summary: string;
+  onConfirm: () => void | Promise<void>;
+  confirmLabel?: string;
+  pendingLabel?: string;
+  isPending?: boolean;
+}
+
+export function ConfirmDialog({
+  trigger,
+  title,
+  summary,
+  onConfirm,
+  confirmLabel = 'Confirm',
+  pendingLabel = 'Processing...',
+  isPending = false,
+}: ConfirmDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{summary}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={async (e) => {
+              e.preventDefault();
+              try {
+                await onConfirm();
+                setOpen(false);
+              } catch {
+                // Dialog stays open so the user can retry.
+              }
+            }}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            disabled={isPending}
+          >
+            {isPending ? pendingLabel : confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/DeleteConfirmDialog.tsx
+++ b/src/components/DeleteConfirmDialog.tsx
@@ -1,57 +1,12 @@
-import { useState, type ReactNode } from 'react';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
+import { type ComponentProps } from 'react';
+import { ConfirmDialog } from './ConfirmDialog';
 
-interface DeleteConfirmDialogProps {
-  trigger: ReactNode;
-  title: string;
-  summary: string;
-  onConfirm: () => void | Promise<void>;
-  confirmLabel?: string;
-  isPending?: boolean;
-}
-
-export function DeleteConfirmDialog({
-  trigger,
-  title,
-  summary,
-  onConfirm,
-  confirmLabel = 'Confirm Delete',
-  isPending = false,
-}: DeleteConfirmDialogProps) {
-  const [open, setOpen] = useState(false);
-
+export function DeleteConfirmDialog(props: ComponentProps<typeof ConfirmDialog>) {
   return (
-    <AlertDialog open={open} onOpenChange={setOpen}>
-      <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>{title}</AlertDialogTitle>
-          <AlertDialogDescription>{summary}</AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={async () => {
-              await onConfirm();
-              setOpen(false);
-            }}
-            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            disabled={isPending}
-          >
-            {isPending ? 'Deleting...' : confirmLabel}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    <ConfirmDialog
+      confirmLabel="Confirm Delete"
+      pendingLabel="Deleting..."
+      {...props}
+    />
   );
 }

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -331,6 +331,7 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
     queryClient.invalidateQueries({ queryKey: ['banned-events'] });
     queryClient.invalidateQueries({ queryKey: ['banned-users'] });
     queryClient.invalidateQueries({ queryKey: ['banned-pubkeys'] });
+    queryClient.invalidateQueries({ queryKey: ['suspended-pubkeys'] });
     queryClient.invalidateQueries({ queryKey: ['decisions'] });
     queryClient.invalidateQueries({ queryKey: ['media-status'] });
     queryClient.invalidateQueries({ queryKey: ['user-stats', context.reportedUser.pubkey] });
@@ -1077,6 +1078,7 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
                 pubkey={context.reportedUser.pubkey}
                 context="report"
                 isBanned={isUserBanned ?? undefined}
+                isSuspended={moderationStatus.isUserSuspended ?? undefined}
                 onActionComplete={handleActionComplete}
               />
             )}

--- a/src/components/UserActions.test.tsx
+++ b/src/components/UserActions.test.tsx
@@ -9,6 +9,8 @@ vi.mock('@/hooks/useAdminApi', () => ({
     bulkModerate: vi.fn().mockResolvedValue({ success: true, eventsProcessed: 3, mediaProcessed: 2, failures: [] }),
     banPubkey: vi.fn().mockResolvedValue({ success: true }),
     unbanPubkey: vi.fn().mockResolvedValue({ success: true }),
+    suspendPubkey: vi.fn().mockResolvedValue({ success: true }),
+    unsuspendPubkey: vi.fn().mockResolvedValue({ success: true }),
     logDecision: vi.fn().mockResolvedValue(undefined),
   }),
 }));
@@ -27,13 +29,23 @@ function renderWithProvider(ui: React.ReactElement) {
 }
 
 describe('UserActions', () => {
-  it('renders ban, bulk age-restrict, and bulk delete', () => {
+  it('renders suspend, ban, bulk age-restrict, and bulk delete for active user', () => {
     renderWithProvider(
       <UserActions pubkey={'a'.repeat(64)} />
     );
+    expect(screen.getByRole('button', { name: /Suspend User/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Ban User/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Age Restrict All/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Delete All Content/i })).toBeInTheDocument();
+  });
+
+  it('renders unsuspend and ban when user is suspended', () => {
+    renderWithProvider(
+      <UserActions pubkey={'a'.repeat(64)} isSuspended={true} />
+    );
+    expect(screen.getByRole('button', { name: /Unsuspend User/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Ban User/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Suspend User/i })).not.toBeInTheDocument();
   });
 
   it('renders unban when user is banned', () => {
@@ -42,12 +54,14 @@ describe('UserActions', () => {
     );
     expect(screen.getByRole('button', { name: /Unban User/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /^Ban User/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Suspend User/i })).not.toBeInTheDocument();
   });
 
   it('hides bulk actions in age-review context', () => {
     renderWithProvider(
       <UserActions pubkey={'a'.repeat(64)} context="age-review" />
     );
+    expect(screen.getByRole('button', { name: /Suspend User/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Ban User/i })).toBeInTheDocument();
     expect(screen.queryByText(/Age Restrict All/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Delete All Content/i)).not.toBeInTheDocument();

--- a/src/components/UserActions.tsx
+++ b/src/components/UserActions.tsx
@@ -3,13 +3,14 @@ import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useToast } from '@/hooks/useToast';
 import { useAdminApi } from '@/hooks/useAdminApi';
-import { DeleteConfirmDialog } from './DeleteConfirmDialog';
-import { UserX, UserCheck, ShieldAlert, Trash2 } from 'lucide-react';
+import { ConfirmDialog } from './ConfirmDialog';
+import { UserX, UserCheck, ShieldAlert, Trash2, Pause, Play } from 'lucide-react';
 
 interface UserActionsProps {
   pubkey: string;
   context?: 'report' | 'age-review' | 'users';
   isBanned?: boolean;
+  isSuspended?: boolean;
   onActionComplete?: () => void;
 }
 
@@ -17,11 +18,50 @@ export function UserActions({
   pubkey,
   context = 'users',
   isBanned = false,
+  isSuspended = false,
   onActionComplete,
 }: UserActionsProps) {
   const { toast } = useToast();
   const api = useAdminApi();
   const showBulkActions = context !== 'age-review';
+
+  const suspendUserMutation = useMutation({
+    mutationFn: async () => {
+      await api.suspendPubkey(pubkey, 'Suspended by moderator');
+      await api.logDecision({
+        targetType: 'pubkey',
+        targetId: pubkey,
+        action: 'suspend_user',
+        reason: 'Suspended by moderator',
+      });
+    },
+    onSuccess: () => {
+      toast({ title: 'User suspended' });
+      onActionComplete?.();
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to suspend user', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const unsuspendUserMutation = useMutation({
+    mutationFn: async () => {
+      await api.unsuspendPubkey(pubkey);
+      await api.logDecision({
+        targetType: 'pubkey',
+        targetId: pubkey,
+        action: 'unsuspend_user',
+        reason: 'Unsuspended by moderator',
+      });
+    },
+    onSuccess: () => {
+      toast({ title: 'User unsuspended' });
+      onActionComplete?.();
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to unsuspend user', description: error.message, variant: 'destructive' });
+    },
+  });
 
   const banUserMutation = useMutation({
     mutationFn: async () => {
@@ -101,7 +141,8 @@ export function UserActions({
     },
   });
 
-  const anyPending = banUserMutation.isPending || unbanUserMutation.isPending ||
+  const anyPending = suspendUserMutation.isPending || unsuspendUserMutation.isPending ||
+    banUserMutation.isPending || unbanUserMutation.isPending ||
     bulkAgeRestrictMutation.isPending || bulkDeleteMutation.isPending;
 
   return (
@@ -114,18 +155,49 @@ export function UserActions({
               {unbanUserMutation.isPending ? 'Unbanning...' : 'Unban User'}
             </Button>
           </TooltipTrigger>
-          <TooltipContent><p>Unban this user. They will be able to post again.</p></TooltipContent>
+          <TooltipContent><p>Unban this user. They can post new content, but previously purged content is not restored.</p></TooltipContent>
         </Tooltip>
       ) : (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="outline" className="border-red-500 text-red-600 hover:bg-red-50" onClick={() => banUserMutation.mutate()} disabled={anyPending}>
-              <UserX className="h-4 w-4 mr-1" />
-              {banUserMutation.isPending ? 'Banning...' : 'Ban User'}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent><p>Ban this user from the relay. Can be reversed.</p></TooltipContent>
-        </Tooltip>
+        <>
+          {isSuspended ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="outline" className="border-green-500 text-green-600 hover:bg-green-50"
+                  onClick={() => unsuspendUserMutation.mutate()} disabled={anyPending}>
+                  <Play className="h-4 w-4 mr-1" />
+                  {unsuspendUserMutation.isPending ? 'Unsuspending...' : 'Unsuspend User'}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent><p>Unsuspend this user. Their content will be visible again.</p></TooltipContent>
+            </Tooltip>
+          ) : (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="outline" className="border-amber-500 text-amber-600 hover:bg-amber-50"
+                  onClick={() => suspendUserMutation.mutate()} disabled={anyPending}>
+                  <Pause className="h-4 w-4 mr-1" />
+                  {suspendUserMutation.isPending ? 'Suspending...' : 'Suspend User'}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent><p>Suspend this user. Hides their content without deleting it. Can be reversed.</p></TooltipContent>
+            </Tooltip>
+          )}
+
+          <ConfirmDialog
+            trigger={
+              <Button variant="destructive" disabled={anyPending}>
+                <UserX className="h-4 w-4 mr-1" />
+                Ban User
+              </Button>
+            }
+            title="Ban User"
+            summary="Permanently ban this user and purge all their content from the relay. This destroys events across 16+ tables and cannot be fully reversed — unbanning allows new posts but does not restore purged content."
+            confirmLabel="Ban User"
+            pendingLabel="Banning..."
+            onConfirm={async () => { await banUserMutation.mutateAsync(); }}
+            isPending={banUserMutation.isPending}
+          />
+        </>
       )}
 
       {showBulkActions && (
@@ -141,7 +213,7 @@ export function UserActions({
             <TooltipContent><p>Age-restrict all media from this user. Can be reversed.</p></TooltipContent>
           </Tooltip>
 
-          <DeleteConfirmDialog
+          <ConfirmDialog
             trigger={
               <Button variant="destructive" disabled={anyPending}>
                 <Trash2 className="h-4 w-4 mr-1" />
@@ -150,6 +222,8 @@ export function UserActions({
             }
             title="Delete All Content"
             summary="This will permanently delete all events and media from this user. This cannot be undone."
+            confirmLabel="Confirm Delete"
+            pendingLabel="Deleting..."
             onConfirm={async () => { await bulkDeleteMutation.mutateAsync(); }}
             isPending={bulkDeleteMutation.isPending}
           />

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -1,4 +1,4 @@
-// ABOUTME: User management interface for banning and allowing users on the relay
+// ABOUTME: User management interface for banning, suspending, and allowing users on the relay
 // ABOUTME: Includes verification to confirm NIP-86 actions succeeded and D1 audit logging
 
 import { useState } from "react";
@@ -14,7 +14,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { useToast } from "@/hooks/useToast";
-import { UserX, UserCheck, Plus, Users, Trash2, User, X } from "lucide-react";
+import { UserX, UserCheck, Plus, Users, Trash2, User, X, Pause, Play } from "lucide-react";
 import { BannedUserCard } from "@/components/BannedUserCard";
 import { nip19 } from "nostr-tools";
 import { useAdminApi } from "@/hooks/useAdminApi";
@@ -42,7 +42,7 @@ export function UserManagement({ selectedPubkey }: UserManagementProps) {
   const { toast } = useToast();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { callRelayRpc, verifyPubkeyBanned, verifyPubkeyUnbanned, unbanPubkey, logDecision } = useAdminApi();
+  const { callRelayRpc, verifyPubkeyBanned, verifyPubkeyUnbanned, unbanPubkey, unsuspendPubkey, logDecision } = useAdminApi();
   const { user } = useCurrentUser();
   const [newPubkey, setNewPubkey] = useState("");
   const [newReason, setNewReason] = useState("");
@@ -59,6 +59,8 @@ export function UserManagement({ selectedPubkey }: UserManagementProps) {
     queryClient.invalidateQueries({ queryKey: ['banned-users'] });
     queryClient.invalidateQueries({ queryKey: ['banned-pubkeys'] });
     queryClient.invalidateQueries({ queryKey: ['allowed-users'] });
+    queryClient.invalidateQueries({ queryKey: ['suspended-users'] });
+    queryClient.invalidateQueries({ queryKey: ['suspended-pubkeys'] });
   };
 
   // Query for banned users
@@ -71,6 +73,12 @@ export function UserManagement({ selectedPubkey }: UserManagementProps) {
   const { data: allowedUsers, isLoading: loadingAllowed, error: allowedError } = useQuery({
     queryKey: ['allowed-users'],
     queryFn: () => callRelayRpc<BannedPubkeyEntry[]>('listallowedpubkeys'),
+  });
+
+  // Query for suspended users
+  const { data: suspendedUsers, isLoading: loadingSuspended, error: suspendedError } = useQuery({
+    queryKey: ['suspended-users'],
+    queryFn: () => callRelayRpc<BannedPubkeyEntry[]>('listsuspendedpubkeys'),
   });
 
   // Mutation for banning users
@@ -211,11 +219,37 @@ export function UserManagement({ selectedPubkey }: UserManagementProps) {
     },
   });
 
-  const handleRemoveUser = async (pubkey: string, type: 'ban' | 'allow') => {
+  const unsuspendUserMutation = useMutation({
+    mutationFn: async ({ pubkey }: { pubkey: string }) => {
+      await unsuspendPubkey(pubkey);
+      await logDecision({
+        targetType: 'pubkey',
+        targetId: pubkey,
+        action: 'unsuspend_user',
+        reason: 'Unsuspended via User Management',
+        moderatorPubkey: user?.pubkey,
+      });
+      return pubkey;
+    },
+    onSuccess: () => {
+      invalidateUserQueries();
+      toast({ title: "User unsuspended successfully" });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Failed to unsuspend user",
+        description: error.message,
+        variant: "destructive"
+      });
+    },
+  });
+
+  const handleRemoveUser = async (pubkey: string, type: 'ban' | 'allow' | 'suspend') => {
     if (type === 'ban') {
       unbanUserMutation.mutate({ pubkey });
+    } else if (type === 'suspend') {
+      unsuspendUserMutation.mutate({ pubkey });
     } else {
-      // NIP-86 doesn't define a method to remove from allow list
       toast({
         title: "Not yet supported",
         description: "Removing from allow list requires an RPC method which is not defined in NIP-86",
@@ -229,7 +263,7 @@ export function UserManagement({ selectedPubkey }: UserManagementProps) {
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-2xl font-bold">User Management</h2>
-          <p className="text-muted-foreground">Manage banned and allowed users on your relay</p>
+          <p className="text-muted-foreground">Manage banned, suspended, and allowed users on your relay</p>
         </div>
         <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
           <DialogTrigger asChild>
@@ -325,6 +359,8 @@ export function UserManagement({ selectedPubkey }: UserManagementProps) {
             <div className="flex items-center gap-2 text-sm">
               {bannedUsers?.some((u: BannedUser) => u.pubkey === selectedPubkey) ? (
                 <span className="flex items-center gap-1 text-red-600"><UserX className="h-4 w-4" />Banned</span>
+              ) : suspendedUsers?.some((u: BannedPubkeyEntry) => u.pubkey === selectedPubkey) ? (
+                <span className="flex items-center gap-1 text-amber-600"><Pause className="h-4 w-4" />Suspended</span>
               ) : allowedUsers?.some((u: AllowedUser) => u.pubkey === selectedPubkey) ? (
                 <span className="flex items-center gap-1 text-green-600"><UserCheck className="h-4 w-4" />Allowed</span>
               ) : (
@@ -340,6 +376,7 @@ export function UserManagement({ selectedPubkey }: UserManagementProps) {
               pubkey={selectedPubkey}
               context="users"
               isBanned={bannedUsers?.some((u: BannedUser) => u.pubkey === selectedPubkey) ?? false}
+              isSuspended={suspendedUsers?.some((u: BannedPubkeyEntry) => u.pubkey === selectedPubkey) ?? false}
               onActionComplete={invalidateUserQueries}
             />
           </CardContent>
@@ -351,6 +388,10 @@ export function UserManagement({ selectedPubkey }: UserManagementProps) {
           <TabsTrigger value="banned" className="flex items-center space-x-2">
             <UserX className="h-4 w-4" />
             <span>Banned Users</span>
+          </TabsTrigger>
+          <TabsTrigger value="suspended" className="flex items-center space-x-2">
+            <Pause className="h-4 w-4" />
+            <span>Suspended Users</span>
           </TabsTrigger>
           <TabsTrigger value="allowed" className="flex items-center space-x-2">
             <UserCheck className="h-4 w-4" />
@@ -401,6 +442,67 @@ export function UserManagement({ selectedPubkey }: UserManagementProps) {
                       pubkey={user.pubkey}
                       reason={user.reason}
                       onUnban={() => handleRemoveUser(user.pubkey, 'ban')}
+                    />
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="suspended">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center space-x-2">
+                <Pause className="h-5 w-5" />
+                <span>Suspended Users</span>
+              </CardTitle>
+              <CardDescription>
+                Users whose content is hidden but not deleted. Suspension can be reversed.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {loadingSuspended ? (
+                <div className="space-y-3">
+                  {[...Array(3)].map((_, i) => (
+                    <div key={i} className="flex items-center justify-between p-3 border rounded-lg">
+                      <div className="space-y-2">
+                        <Skeleton className="h-4 w-64" />
+                        <Skeleton className="h-3 w-48" />
+                      </div>
+                      <Skeleton className="h-8 w-20" />
+                    </div>
+                  ))}
+                </div>
+              ) : suspendedError ? (
+                <Alert>
+                  <AlertDescription>
+                    Failed to load suspended users: {suspendedError.message}
+                  </AlertDescription>
+                </Alert>
+              ) : !suspendedUsers || suspendedUsers.length === 0 ? (
+                <div className="text-center py-8 text-muted-foreground">
+                  <Users className="h-12 w-12 mx-auto mb-4 opacity-50" />
+                  <p>No suspended users</p>
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {suspendedUsers.map((user: BannedPubkeyEntry, index: number) => (
+                    <BannedUserCard
+                      key={index}
+                      pubkey={user.pubkey}
+                      reason={user.reason}
+                      actionButton={
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="border-green-500 text-green-600 hover:bg-green-50"
+                          onClick={() => handleRemoveUser(user.pubkey, 'suspend')}
+                        >
+                          <Play className="h-4 w-4 mr-1" />
+                          Unsuspend
+                        </Button>
+                      }
                     />
                   ))}
                 </div>

--- a/src/hooks/useAdminApi.ts
+++ b/src/hooks/useAdminApi.ts
@@ -51,6 +51,12 @@ export function useAdminApi() {
       adminApi.listBannedPubkeys(apiUrl),
     listBannedEvents: () =>
       adminApi.listBannedEvents(apiUrl),
+    suspendPubkey: (pubkey: string, reason?: string) =>
+      adminApi.suspendPubkey(apiUrl, pubkey, reason),
+    unsuspendPubkey: (pubkey: string) =>
+      adminApi.unsuspendPubkey(apiUrl, pubkey),
+    listSuspendedPubkeys: () =>
+      adminApi.listSuspendedPubkeys(apiUrl),
 
     // Server-side relay queries (replaces browser WebSocket for freshness)
     fetchReports: () =>

--- a/src/hooks/useModerationStatus.ts
+++ b/src/hooks/useModerationStatus.ts
@@ -8,6 +8,8 @@ import { useAdminApi } from "@/hooks/useAdminApi";
 interface ModerationStatus {
   /** User's pubkey is in the relay's ban list */
   isUserBanned: boolean | null;
+  /** User's pubkey is in the relay's suspended list */
+  isUserSuspended: boolean | null;
   /** Event ID is in the relay's ban list */
   isEventBanned: boolean | null;
   /** Event is not queryable from the relay (deleted, banned, or never existed) */
@@ -28,7 +30,7 @@ export function useModerationStatus(
   /** Set true when the event could not be found via normal relay queries or banned event lookup */
   eventNotFound?: boolean,
 ): ModerationStatus {
-  const { listBannedPubkeys, listBannedEvents, verifyEventDeleted, verifyPubkeyBanned } = useAdminApi();
+  const { listBannedPubkeys, listBannedEvents, listSuspendedPubkeys, verifyEventDeleted, verifyPubkeyBanned } = useAdminApi();
   const [wsResult, setWsResult] = useState<{
     userBanned: boolean | null;
     eventGone: boolean | null;
@@ -66,14 +68,30 @@ export function useModerationStatus(
     staleTime: 30 * 1000,
   });
 
-  // Derive ban list status
+  const suspendedPubkeys = useQuery({
+    queryKey: ['suspended-pubkeys'],
+    queryFn: async () => {
+      try {
+        return await listSuspendedPubkeys();
+      } catch (error) {
+        console.warn('NIP-86 listsuspendedpubkeys failed:', error);
+        return [];
+      }
+    },
+    staleTime: 30 * 1000,
+  });
+
+  // Derive ban/suspend list status
   const isUserBannedFromList = pubkey
     ? bannedPubkeys.data?.some(entry => entry.pubkey === pubkey) ?? null
+    : null;
+  const isUserSuspendedFromList = pubkey
+    ? suspendedPubkeys.data?.some(entry => entry.pubkey === pubkey) ?? null
     : null;
   const isEventBannedFromList = eventId
     ? bannedEvents.data?.some(e => e.id === eventId) ?? null
     : null;
-  const banListsLoading = bannedPubkeys.isLoading || bannedEvents.isLoading;
+  const banListsLoading = bannedPubkeys.isLoading || bannedEvents.isLoading || suspendedPubkeys.isLoading;
 
   // WebSocket + fresh ban list verification
   const runCheck = useCallback(async () => {
@@ -99,14 +117,15 @@ export function useModerationStatus(
         isChecking: false,
       });
 
-      // Also refresh ban lists so badges stay in sync
+      // Also refresh ban/suspend lists so badges stay in sync
       bannedPubkeys.refetch();
       bannedEvents.refetch();
+      suspendedPubkeys.refetch();
     } catch (error) {
       console.error('Moderation status check failed:', error);
       setWsResult(prev => ({ ...prev, isChecking: false }));
     }
-  }, [pubkey, eventId, verifyPubkeyBanned, verifyEventDeleted, bannedPubkeys, bannedEvents]);
+  }, [pubkey, eventId, verifyPubkeyBanned, verifyEventDeleted, bannedPubkeys, bannedEvents, suspendedPubkeys]);
 
   // Auto-check: for events when not found, for users always (just a ban list refresh)
   useEffect(() => {
@@ -134,6 +153,7 @@ export function useModerationStatus(
   return {
     // User ban: WebSocket check result takes precedence over ban list
     isUserBanned: wsResult.userBanned ?? isUserBannedFromList,
+    isUserSuspended: isUserSuspendedFromList,
     // Event in ban list (separate from "gone" — banned events can be retrieved via admin API)
     isEventBanned: isEventBannedFromList,
     // Event gone from relay (WebSocket verified, or known from ban list)

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -222,6 +222,24 @@ export async function listBannedEvents(apiUrl: string): Promise<Array<{ id: stri
   return callRelayRpc<Array<{ id: string; reason?: string }>>(apiUrl, 'listbannedevents');
 }
 
+export async function suspendPubkey(apiUrl: string, pubkey: string, reason?: string): Promise<void> {
+  await callRelayRpc(apiUrl, 'suspendpubkey', [pubkey, reason || 'Suspended via admin']);
+}
+
+export async function unsuspendPubkey(apiUrl: string, pubkey: string): Promise<void> {
+  await callRelayRpc(apiUrl, 'unsuspendpubkey', [pubkey]);
+}
+
+export async function listSuspendedPubkeys(apiUrl: string): Promise<BannedPubkeyEntry[]> {
+  const result = await callRelayRpc<string[] | BannedPubkeyEntry[]>(apiUrl, 'listsuspendedpubkeys');
+  return result.map(item => {
+    if (typeof item === 'string') {
+      return { pubkey: item };
+    }
+    return item as BannedPubkeyEntry;
+  });
+}
+
 // Fetch reports via server-side relay query (replaces browser WebSocket)
 export async function fetchReports(apiUrl: string): Promise<NostrEvent[]> {
   const data = await apiRequest<{ success: boolean; events: NostrEvent[] }>(apiUrl, '/api/reports', 'GET');

--- a/worker/src/zendesk-sync.ts
+++ b/worker/src/zendesk-sync.ts
@@ -150,6 +150,8 @@ export async function syncZendeskAfterAction(
       return;
     }
 
+    // suspend_user / unsuspend_user deliberately excluded — suspension is a
+    // holding action, not a final resolution, so tickets stay open for follow-up.
     const resolutionActions = [
       'reviewed',
       'dismissed',


### PR DESCRIPTION
## Summary

- Wire up `suspendpubkey`/`unsuspendpubkey`/`listsuspendedpubkeys` NIP-86 RPC methods (from funnelcake PR #434) as general-purpose moderation actions, available from reports, user detail, and user management views
- Add Suspend/Unsuspend buttons with amber/green styling distinct from destructive ban
- Add "Suspended Users" tab to User Management page
- Put Ban User behind a confirmation dialog that honestly describes the destructive purge cascade
- Fix misleading "Can be reversed" ban tooltip and "They will be able to post again" unban tooltip

## Motivation

Suspension was previously only available through the age review flow (PR #80). Moderators need it as a general tool — it hides content without purging, and unsuspend restores visibility. Ban triggers a purge cascade across 16+ funnelcake tables, and unban doesn't restore purged content. The UI should make this distinction clear.

## Changes

| File | What |
|------|------|
| `src/lib/adminApi.ts` | Add `suspendPubkey`, `unsuspendPubkey`, `listSuspendedPubkeys` |
| `src/hooks/useAdminApi.ts` | Wire 3 new functions |
| `src/hooks/useModerationStatus.ts` | Add `isUserSuspended` with suspended-pubkeys query |
| `src/components/ConfirmDialog.tsx` | New generic dialog extracted from DeleteConfirmDialog |
| `src/components/DeleteConfirmDialog.tsx` | Thin wrapper preserving delete-specific defaults |
| `src/components/UserActions.tsx` | Suspend/unsuspend buttons, ban behind confirmation dialog |
| `src/components/UserManagement.tsx` | Suspended Users tab, pass `isSuspended` prop |
| `src/components/ReportDetail.tsx` | Pass `isSuspended` to UserActions |

## Validation

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 99 passed, 1 skipped, 0 failed (frontend)
- [x] `npx vite build` — clean
- [ ] Deploy to staging and test suspend/unsuspend cycle
- [ ] Verify ban confirmation dialog appears with destructive language

Relates to divinevideo/support-trust-safety#146