### PR TITLE
fix: use real hostname in moderation service binding fetch

### DIFF
--- a/worker/src/bulk-moderate.ts
+++ b/worker/src/bulk-moderate.ts
@@ -213,7 +213,7 @@ async function callModerateMedia(
   const body = JSON.stringify({ sha256, action, reason, source: 'relay-manager-bulk' });
 
   if (env.MODERATION_API) {
-    const response = await env.MODERATION_API.fetch('https://internal/api/v1/moderate', {
+    const response = await env.MODERATION_API.fetch('https://moderation-api.divine.video/api/v1/moderate', {
       method: 'POST', headers, body,
     });
     if (!response.ok) throw new Error(`Moderation service returned ${response.status}`);


### PR DESCRIPTION
## Summary

- The `callModerateMedia()` function in `bulk-moderate.ts` used a fake `https://internal/...` URL for the Cloudflare service binding fetch to the moderation service
- The moderation service validates the request hostname against an allowlist (`moderation-api.divine.video`, `moderation.admin.divine.video`, localhost) and rejected `internal` with a 404
- This broke **Age Restrict All** and **Delete All** media actions in the bulk moderation flow
- Fix: use the real hostname `https://moderation-api.divine.video/api/v1/moderate`

## Root cause

Service binding fetches in Cloudflare Workers pass the URL hostname through to the receiving worker — it's not stripped or ignored. The moderation service's hostname validation (`src/index.mjs:1390`) rejects any hostname not in its allowlist.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Pre-existing bulk-moderate test failures (WebSocket mock constructor) confirmed on main — not related
- [ ] Deploy staging worker, test age-restrict-all on a throwaway account
- [ ] Deploy prod worker