### PR TITLE
config: wire Zendesk credentials via Secrets Store bindings

### DIFF
--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -11,14 +11,16 @@ import {
   defaultResolutionForBand,
 } from '../../shared/age-review';
 import { handleBulkModerate, type BulkModerateEnv } from './bulk-moderate';
+import { resolveZendeskCreds } from './zendesk-sync';
 import type { BulkAction, BulkModerateResult } from '../../shared/bulk-moderation';
 import { suspendUser, unsuspendUser, banUser, type KeycastEnv } from './keycast-client';
+import type { SecretStoreSecret } from './nip86';
 
 interface AgeReviewEnv extends BulkModerateEnv, KeycastEnv {
   SLACK_WEBHOOK_URL?: string;
-  ZENDESK_SUBDOMAIN?: string;
-  ZENDESK_API_TOKEN?: string;
-  ZENDESK_EMAIL?: string;
+  ZENDESK_SUBDOMAIN?: string | SecretStoreSecret;
+  ZENDESK_API_TOKEN?: string | SecretStoreSecret;
+  ZENDESK_EMAIL?: string | SecretStoreSecret;
   ZENDESK_FIELD_CATEGORY?: string;
   ZENDESK_FIELD_ISSUE?: string;
   ZENDESK_FIELD_AGE_REVIEW_DEADLINE?: string;
@@ -27,6 +29,7 @@ interface AgeReviewEnv extends BulkModerateEnv, KeycastEnv {
 interface ZendeskClientConfig {
   auth: string;
   baseUrl: string;
+  email: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -451,14 +454,13 @@ const BAND_DISPLAY: Record<AgeBand, string> = {
   age_16_plus_claimed: '16+ (claimed)',
 };
 
-function getZendeskClientConfig(env: AgeReviewEnv): ZendeskClientConfig | null {
-  if (!env.ZENDESK_SUBDOMAIN || !env.ZENDESK_API_TOKEN || !env.ZENDESK_EMAIL) {
-    return null;
-  }
-
+async function getZendeskClientConfig(env: AgeReviewEnv): Promise<ZendeskClientConfig | null> {
+  const creds = await resolveZendeskCreds(env);
+  if (!creds) return null;
   return {
-    auth: btoa(`${env.ZENDESK_EMAIL}/token:${env.ZENDESK_API_TOKEN}`),
-    baseUrl: `https://${env.ZENDESK_SUBDOMAIN}.zendesk.com/api/v2`,
+    auth: btoa(`${creds.email}/token:${creds.apiToken}`),
+    baseUrl: `https://${creds.subdomain}.zendesk.com/api/v2`,
+    email: creds.email,
   };
 }
 
@@ -505,7 +507,7 @@ async function createAgeReviewTicket(
   deadlineAt: string | null,
   env: AgeReviewEnv,
 ): Promise<void> {
-  const zendesk = getZendeskClientConfig(env);
+  const zendesk = await getZendeskClientConfig(env);
   if (!zendesk) {
     console.warn('[age-review] Missing Zendesk credentials, skipping ticket creation');
     return;
@@ -554,7 +556,7 @@ async function updateTicketWithParentContact(
   ageBand: AgeBand,
   env: AgeReviewEnv,
 ): Promise<void> {
-  const zendesk = getZendeskClientConfig(env);
+  const zendesk = await getZendeskClientConfig(env);
   if (!zendesk) return;
 
   const outreachBody = buildParentOutreachBody(ageBand);
@@ -598,7 +600,7 @@ async function createAgeReviewInternalTicket(
   deadlineAt: string | null,
   env: AgeReviewEnv,
 ): Promise<number | null> {
-  const zendesk = getZendeskClientConfig(env);
+  const zendesk = await getZendeskClientConfig(env);
   if (!zendesk) {
     console.warn('[age-review] Missing Zendesk credentials, skipping internal ticket creation');
     return null;
@@ -659,7 +661,7 @@ export async function syncAgeReviewTicketResolution(
 ): Promise<void> {
   if (!env.DB) return;
 
-  const zendesk = getZendeskClientConfig(env);
+  const zendesk = await getZendeskClientConfig(env);
   if (!zendesk) return;
 
   const row = await env.DB.prepare(
@@ -679,7 +681,7 @@ export async function syncAgeReviewTicketResolution(
     ticket: {
       comment: { body: noteLines.join('\n'), public: false },
       status: 'solved',
-      assignee_email: env.ZENDESK_EMAIL,
+      assignee_email: zendesk.email,
     },
   };
 
@@ -710,6 +712,7 @@ export async function syncAgeReviewTicketResolution(
   }
 }
 
+// Caller (index.ts) must verify HMAC signature before dispatching here.
 export async function handleAgeReviewReplyWebhook(
   request: Request,
   env: AgeReviewEnv,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -28,7 +28,7 @@ import {
   updateAgeReviewConfig,
 } from './age-review';
 import { handleBulkModerate } from './bulk-moderate';
-import { ensureZendeskTable, addZendeskInternalNote, syncZendeskAfterAction } from './zendesk-sync';
+import { ensureZendeskTable, addZendeskInternalNote, syncZendeskAfterAction, resolveZendeskCreds } from './zendesk-sync';
 
 let schemaReady = false;
 async function ensureSchemaOnce(db: D1Database): Promise<void> {
@@ -53,14 +53,16 @@ interface Env extends KeycastEnv {
   // Service binding to divine-moderation-service (bypasses CF Access + no cold starts)
   MODERATION_API?: Fetcher;
   // Zendesk integration
-  ZENDESK_SUBDOMAIN?: string;
+  ZENDESK_SUBDOMAIN?: string | SecretStoreSecret;
+  // These four are per-worker secrets (not Secrets Store). If migrated to SecretStoreSecret,
+  // update the call sites — they pass these directly to crypto/TextEncoder without resolving.
   ZENDESK_JWT_SECRET?: string;
-  ZENDESK_PREAUTH_SECRET?: string;  // HMAC secret for pre-auth token generation/verification
-  ZENDESK_WEBHOOK_SECRET?: string;  // For /api/zendesk/webhook
-  ZENDESK_PARSE_REPORT_SECRET?: string;  // For /api/zendesk/parse-report
-  ZENDESK_AGE_REVIEW_WEBHOOK_SECRET?: string;  // For /api/zendesk/age-review-reply
-  ZENDESK_API_TOKEN?: string;
-  ZENDESK_EMAIL?: string;
+  ZENDESK_PREAUTH_SECRET?: string;
+  ZENDESK_WEBHOOK_SECRET?: string;
+  ZENDESK_PARSE_REPORT_SECRET?: string;
+  ZENDESK_AGE_REVIEW_WEBHOOK_SECRET?: string | SecretStoreSecret;  // For /api/zendesk/age-review-reply
+  ZENDESK_API_TOKEN?: string | SecretStoreSecret;
+  ZENDESK_EMAIL?: string | SecretStoreSecret;
   ZENDESK_FIELD_ACTION_STATUS?: string;
   ZENDESK_FIELD_ACTION_REQUESTED?: string;
   ZENDESK_FIELD_CATEGORY?: string;       // For auto-solve required fields
@@ -1671,7 +1673,8 @@ async function updateZendeskTicket(
   note: string,
   env: Env
 ): Promise<void> {
-  if (!env.ZENDESK_SUBDOMAIN || !env.ZENDESK_API_TOKEN || !env.ZENDESK_EMAIL) {
+  const creds = await resolveZendeskCreds(env);
+  if (!creds) {
     console.warn('[updateZendeskTicket] Missing Zendesk API credentials, skipping callback');
     return;
   }
@@ -1682,8 +1685,8 @@ async function updateZendeskTicket(
   }
 
   try {
-    const auth = btoa(`${env.ZENDESK_EMAIL}/token:${env.ZENDESK_API_TOKEN}`);
-    const url = `https://${env.ZENDESK_SUBDOMAIN}.zendesk.com/api/v2/tickets/${ticketId}`;
+    const auth = btoa(`${creds.email}/token:${creds.apiToken}`);
+    const url = `https://${creds.subdomain}.zendesk.com/api/v2/tickets/${ticketId}`;
 
     const customFields = [
       { id: parseInt(env.ZENDESK_FIELD_ACTION_STATUS, 10), value: success ? 'success' : 'failed' },
@@ -2035,7 +2038,8 @@ async function handleZendeskRoutes(
   // Age review: parent replied to Zendesk ticket
   if (subPath === '/age-review-reply' && request.method === 'POST') {
     const bodyText = await request.text();
-    if (!await verifyZendeskWebhook(request, bodyText, env.ZENDESK_AGE_REVIEW_WEBHOOK_SECRET)) {
+    const ageReviewWebhookSecret = await resolveSecret(env.ZENDESK_AGE_REVIEW_WEBHOOK_SECRET) ?? undefined;
+    if (!await verifyZendeskWebhook(request, bodyText, ageReviewWebhookSecret)) {
       return jsonResponse({ success: false, error: 'Invalid webhook signature' }, 401, corsHeaders);
     }
     if (env.DB) await ensureSchemaOnce(env.DB);
@@ -2224,9 +2228,11 @@ async function handleZendeskWebhook(
         }
       }
 
-      // Fire-and-forget: don't await, don't let errors break the response
-      updateZendeskTicket(body.ticket_id, actionResult.success, body.action_requested, zendeskNote, env)
-        .catch((err) => console.error('[handleZendeskWebhook] Zendesk callback error:', err));
+      try {
+        await updateZendeskTicket(body.ticket_id, actionResult.success, body.action_requested, zendeskNote, env);
+      } catch (err) {
+        console.error('[handleZendeskWebhook] Zendesk callback error:', err);
+      }
     }
 
     return new Response(JSON.stringify({

--- a/worker/src/zendesk-sync.ts
+++ b/worker/src/zendesk-sync.ts
@@ -2,13 +2,34 @@ import type { SecretStoreSecret } from './nip86';
 
 export interface ZendeskSyncEnv {
   DB?: D1Database;
-  ZENDESK_SUBDOMAIN?: string;
-  ZENDESK_API_TOKEN?: string;
-  ZENDESK_EMAIL?: string;
+  ZENDESK_SUBDOMAIN?: string | SecretStoreSecret;
+  ZENDESK_API_TOKEN?: string | SecretStoreSecret;
+  ZENDESK_EMAIL?: string | SecretStoreSecret;
   ZENDESK_FIELD_CATEGORY?: string;
   ZENDESK_FIELD_ISSUE?: string;
   NOSTR_NSEC: string | SecretStoreSecret;
   RELAY_URL: string;
+}
+
+async function resolveString(val: string | SecretStoreSecret | undefined): Promise<string | undefined> {
+  if (!val) return undefined;
+  return typeof val === 'string' ? val : await val.get();
+}
+
+export interface ResolvedZendeskCreds {
+  subdomain: string;
+  email: string;
+  apiToken: string;
+}
+
+export async function resolveZendeskCreds(env: Pick<ZendeskSyncEnv, 'ZENDESK_SUBDOMAIN' | 'ZENDESK_API_TOKEN' | 'ZENDESK_EMAIL'>): Promise<ResolvedZendeskCreds | null> {
+  const [subdomain, apiToken, email] = await Promise.all([
+    resolveString(env.ZENDESK_SUBDOMAIN),
+    resolveString(env.ZENDESK_API_TOKEN),
+    resolveString(env.ZENDESK_EMAIL),
+  ]);
+  if (!subdomain || !apiToken || !email) return null;
+  return { subdomain, email, apiToken };
 }
 
 function buildResolutionCustomFields(env: ZendeskSyncEnv): Array<{ id: number; value: string }> | undefined {
@@ -63,14 +84,15 @@ export async function addZendeskInternalNote(
   env: ZendeskSyncEnv,
   solve: boolean = false
 ): Promise<void> {
-  if (!env.ZENDESK_SUBDOMAIN || !env.ZENDESK_API_TOKEN || !env.ZENDESK_EMAIL) {
+  const creds = await resolveZendeskCreds(env);
+  if (!creds) {
     console.warn('[addZendeskInternalNote] Missing Zendesk credentials, skipping');
     return;
   }
 
   try {
-    const auth = btoa(`${env.ZENDESK_EMAIL}/token:${env.ZENDESK_API_TOKEN}`);
-    const url = `https://${env.ZENDESK_SUBDOMAIN}.zendesk.com/api/v2/tickets/${ticketId}`;
+    const auth = btoa(`${creds.email}/token:${creds.apiToken}`);
+    const url = `https://${creds.subdomain}.zendesk.com/api/v2/tickets/${ticketId}`;
 
     const payload: {
       ticket: {
@@ -90,7 +112,7 @@ export async function addZendeskInternalNote(
 
     if (solve) {
       payload.ticket.status = 'solved';
-      payload.ticket.assignee_email = env.ZENDESK_EMAIL;
+      payload.ticket.assignee_email = creds.email;
       payload.ticket.custom_fields = buildResolutionCustomFields(env);
     }
 

--- a/worker/wrangler.prod.toml
+++ b/worker/wrangler.prod.toml
@@ -45,6 +45,28 @@ binding = "KEYCAST_SERVICE_TOKEN"
 store_id = "ef490704b12a4feb91c7feb51229c364"
 secret_name = "KEYCAST_SERVICE_TOKEN"
 
+# Zendesk API credentials (shared across workers)
+[[secrets_store_secrets]]
+binding = "ZENDESK_SUBDOMAIN"
+store_id = "ef490704b12a4feb91c7feb51229c364"
+secret_name = "ZENDESK_SUBDOMAIN"
+
+[[secrets_store_secrets]]
+binding = "ZENDESK_EMAIL"
+store_id = "ef490704b12a4feb91c7feb51229c364"
+secret_name = "ZENDESK_EMAIL"
+
+[[secrets_store_secrets]]
+binding = "ZENDESK_API_TOKEN"
+store_id = "ef490704b12a4feb91c7feb51229c364"
+secret_name = "ZENDESK_API_TOKEN"
+
+# HMAC secret for verifying Zendesk age-review reply webhooks
+[[secrets_store_secrets]]
+binding = "ZENDESK_AGE_REVIEW_WEBHOOK_SECRET"
+store_id = "ef490704b12a4feb91c7feb51229c364"
+secret_name = "ZENDESK_AGE_REVIEW_WEBHOOK_SECRET"
+
 [vars]
 RELAY_URL = "wss://relay.divine.video"
 ENVIRONMENT = "production"

--- a/worker/wrangler.staging.toml
+++ b/worker/wrangler.staging.toml
@@ -45,6 +45,28 @@ binding = "KEYCAST_SERVICE_TOKEN"
 store_id = "ef490704b12a4feb91c7feb51229c364"
 secret_name = "KEYCAST_SERVICE_TOKEN"
 
+# Zendesk API credentials (shared across workers)
+[[secrets_store_secrets]]
+binding = "ZENDESK_SUBDOMAIN"
+store_id = "ef490704b12a4feb91c7feb51229c364"
+secret_name = "ZENDESK_SUBDOMAIN"
+
+[[secrets_store_secrets]]
+binding = "ZENDESK_EMAIL"
+store_id = "ef490704b12a4feb91c7feb51229c364"
+secret_name = "ZENDESK_EMAIL"
+
+[[secrets_store_secrets]]
+binding = "ZENDESK_API_TOKEN"
+store_id = "ef490704b12a4feb91c7feb51229c364"
+secret_name = "ZENDESK_API_TOKEN"
+
+# HMAC secret for verifying Zendesk age-review reply webhooks
+[[secrets_store_secrets]]
+binding = "ZENDESK_AGE_REVIEW_WEBHOOK_SECRET"
+store_id = "ef490704b12a4feb91c7feb51229c364"
+secret_name = "ZENDESK_AGE_REVIEW_WEBHOOK_SECRET"
+
 [vars]
 RELAY_URL = "wss://relay.staging.divine.video"
 ENVIRONMENT = "staging"


### PR DESCRIPTION
## Summary

Provisions Cloudflare Secrets Store bindings for Zendesk API credentials (`ZENDESK_SUBDOMAIN`, `ZENDESK_API_TOKEN`, `ZENDESK_EMAIL`, `ZENDESK_AGE_REVIEW_WEBHOOK_SECRET`) in staging and prod wrangler configs. Updates env interfaces and credential resolution to handle `SecretStoreSecret` objects.

Without these bindings, all Zendesk ticket creation and sync for age review cases silently no-ops because `getZendeskClientConfig()` returns null when the credentials are absent.

**Changes:**
- Add `secrets_store_secrets` bindings to `wrangler.staging.toml` and `wrangler.prod.toml`
- Add shared `resolveZendeskCreds` helper in `zendesk-sync.ts` handling both `string` and `SecretStoreSecret` types
- Update `age-review.ts` to delegate credential resolution to `resolveZendeskCreds`
- Fix fire-and-forget `updateZendeskTicket` call to use awaited try/catch
- Add protective comments on plain-string Zendesk secrets passed directly to crypto APIs

No behavioral change when credentials are absent -- existing no-op guards remain intact.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `cd worker && npx vitest run` passes (183 tests)
- [x] Deploy to prod, restrict age review case -- Zendesk ticket #2441 created
- [x] Clear case -- Zendesk ticket solved via `syncAgeReviewTicketResolution`
- [x] E2E verified with `invited.divine.video` test account