### PR TITLE
fix(age-review): correct Keycast path and Zendesk Issue field

### DIFF
--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -326,7 +326,7 @@ describe('handleUpdateAgeReviewCase', () => {
     expect(payload.ticket.tags).toEqual(['age-review', 'age-band-age_16_plus_claimed', 'internal']);
     expect(payload.ticket.custom_fields).toEqual([
       { id: 1001, value: 'trust___safety' },
-      { id: 1002, value: 'age_review' },
+      { id: 1002, value: 'content_report_under_16' },
       { id: 1003, value: '2026-05-30' },
     ]);
 
@@ -1273,7 +1273,7 @@ describe('syncAgeReviewTicketResolution', () => {
     const payload = JSON.parse((mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string);
     expect(payload.ticket.custom_fields).toEqual([
       { id: 12345, value: 'trust___safety' },
-      { id: 67890, value: 'age_review' },
+      { id: 67890, value: 'content_report_under_16' },
     ]);
 
     vi.unstubAllGlobals();

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -488,7 +488,7 @@ function buildAgeReviewCustomFields(
   if (env.ZENDESK_FIELD_CATEGORY && env.ZENDESK_FIELD_ISSUE) {
     customFields.push(
       { id: parseInt(env.ZENDESK_FIELD_CATEGORY, 10), value: 'trust___safety' },
-      { id: parseInt(env.ZENDESK_FIELD_ISSUE, 10), value: 'age_review' },
+      { id: parseInt(env.ZENDESK_FIELD_ISSUE, 10), value: 'content_report_under_16' },
     );
   }
 
@@ -687,7 +687,7 @@ export async function syncAgeReviewTicketResolution(
   if (env.ZENDESK_FIELD_CATEGORY && env.ZENDESK_FIELD_ISSUE) {
     (payload.ticket as Record<string, unknown>).custom_fields = [
       { id: parseInt(env.ZENDESK_FIELD_CATEGORY, 10), value: 'trust___safety' },
-      { id: parseInt(env.ZENDESK_FIELD_ISSUE, 10), value: 'age_review' },
+      { id: parseInt(env.ZENDESK_FIELD_ISSUE, 10), value: 'content_report_under_16' },
     ];
   }
 

--- a/worker/src/keycast-client.test.ts
+++ b/worker/src/keycast-client.test.ts
@@ -33,7 +33,7 @@ describe('keycast-client', () => {
       expect(result).toEqual({ success: true });
       expect(fetchMock).toHaveBeenCalledOnce();
       const [url, opts] = fetchMock.mock.calls[0];
-      expect(url).toBe(`https://login.test.divine.video/admin/users/${VALID_PUBKEY}/status`);
+      expect(url).toBe(`https://login.test.divine.video/api/admin/users/${VALID_PUBKEY}/status`);
       expect(opts.method).toBe('PUT');
       expect(JSON.parse(opts.body)).toEqual({ status: 'suspended', reason: 'age_review' });
       expect(opts.headers['Authorization']).toBe('Bearer test-service-token');

--- a/worker/src/keycast-client.ts
+++ b/worker/src/keycast-client.ts
@@ -40,7 +40,7 @@ async function callKeycast(
   }
 
   try {
-    const res = await fetch(`${env.KEYCAST_URL}/admin/users/${pubkey}/status`, {
+    const res = await fetch(`${env.KEYCAST_URL}/api/admin/users/${pubkey}/status`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary

- **Keycast API path**: `/admin/users/:pubkey/status` -> `/api/admin/users/:pubkey/status`. The wrong path hit SvelteKit's catch-all and returned 405, so Keycast suspend/unsuspend calls during age review silently failed.
- **Zendesk Issue field**: `age_review` -> `content_report_under_16`. `age_review` is not a valid dropdown option in the Zendesk field configuration, causing the custom field to be silently dropped on ticket creation and 422 on ticket resolution.

Both discovered during E2E verification of the under-16 age review flow.

Relates to divinevideo/support-trust-safety#145

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `cd worker && npx vitest run` passes (183 tests, assertions updated)
- [x] Deploy to prod, restrict age review case -> `keycastUpdated: true` (was silently failing)
- [x] Clear case -> `keycastUpdated: true` (unsuspend works)
- [x] Zendesk ticket #2441 created with correct Issue field value
- [x] E2E verified with `invited.divine.video` and `u16.divine.video` test accounts