### PR TITLE
fix(moderate): route ban/unban through NIP-86 and correct method names

### DIFF
--- a/src/components/EventActions.tsx
+++ b/src/components/EventActions.tsx
@@ -6,10 +6,17 @@ import { useAdminApi } from '@/hooks/useAdminApi';
 import { DeleteConfirmDialog } from './DeleteConfirmDialog';
 import { ShieldX, Undo2, Video, ShieldAlert, Unlock, Trash2 } from 'lucide-react';
 
+export interface MediaHashStatus {
+  hash: string;
+  isBlocked: boolean;
+  isRestricted: boolean;
+}
+
 interface EventActionsProps {
   eventId: string;
   pubkey: string;
   mediaHashes?: string[];
+  mediaHashStatuses?: MediaHashStatus[];
   isEventBanned?: boolean;
   hasBlockedMedia?: boolean;
   hasRestrictedMedia?: boolean;
@@ -20,6 +27,7 @@ export function EventActions({
   eventId,
   pubkey,
   mediaHashes = [],
+  mediaHashStatuses = [],
   isEventBanned = false,
   hasBlockedMedia = false,
   hasRestrictedMedia = false,
@@ -131,14 +139,16 @@ export function EventActions({
 
   const unblockMediaMutation = useMutation({
     mutationFn: async () => {
-      for (const hash of mediaHashes) {
+      const blockedHashes = mediaHashStatuses.filter(s => s.isBlocked).map(s => s.hash);
+      if (blockedHashes.length === 0) return;
+      for (const hash of blockedHashes) {
         await api.moderateMedia(hash, 'SAFE', 'Unblocked by moderator');
       }
       await api.logDecision({
         targetType: 'event',
         targetId: eventId,
         action: 'unblock_media',
-        reason: `Unblocked/unrestricted ${mediaHashes.length} media file(s)`,
+        reason: `Unblocked ${blockedHashes.length} media file(s)`,
       });
     },
     onSuccess: () => {
@@ -147,6 +157,29 @@ export function EventActions({
     },
     onError: (error: Error) => {
       toast({ title: 'Failed to unblock media', description: error.message, variant: 'destructive' });
+    },
+  });
+
+  const removeRestrictionMutation = useMutation({
+    mutationFn: async () => {
+      const restrictedHashes = mediaHashStatuses.filter(s => s.isRestricted).map(s => s.hash);
+      if (restrictedHashes.length === 0) return;
+      for (const hash of restrictedHashes) {
+        await api.moderateMedia(hash, 'SAFE', 'Restriction removed by moderator');
+      }
+      await api.logDecision({
+        targetType: 'event',
+        targetId: eventId,
+        action: 'remove_restriction',
+        reason: `Removed restriction from ${restrictedHashes.length} media file(s)`,
+      });
+    },
+    onSuccess: () => {
+      toast({ title: 'Restriction removed' });
+      onActionComplete?.();
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Failed to remove restriction', description: error.message, variant: 'destructive' });
     },
   });
 
@@ -217,7 +250,8 @@ export function EventActions({
 
   const anyPending = banEventMutation.isPending || restoreEventMutation.isPending ||
     deleteEventMutation.isPending || blockMediaMutation.isPending || ageRestrictMutation.isPending ||
-    unblockMediaMutation.isPending || deleteMediaMutation.isPending || deleteEventAndMediaMutation.isPending;
+    unblockMediaMutation.isPending || removeRestrictionMutation.isPending ||
+    deleteMediaMutation.isPending || deleteEventAndMediaMutation.isPending;
 
   return (
     <div className="flex flex-wrap gap-2">
@@ -281,9 +315,9 @@ export function EventActions({
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button variant="outline" className="border-green-500 text-green-600 hover:bg-green-50"
-                  onClick={() => unblockMediaMutation.mutate()} disabled={anyPending}>
+                  onClick={() => removeRestrictionMutation.mutate()} disabled={anyPending}>
                   <Unlock className="h-4 w-4 mr-1" />
-                  {unblockMediaMutation.isPending ? 'Removing...' : 'Remove Restriction'}
+                  {removeRestrictionMutation.isPending ? 'Removing...' : 'Remove Restriction'}
                 </Button>
               </TooltipTrigger>
               <TooltipContent><p>Remove age restriction. Media will be publicly accessible.</p></TooltipContent>

--- a/src/components/EventActions.tsx
+++ b/src/components/EventActions.tsx
@@ -50,7 +50,7 @@ export function EventActions({
 
   const restoreEventMutation = useMutation({
     mutationFn: async () => {
-      await api.callRelayRpc('allowevent', [eventId]);
+      await api.callRelayRpc('unbanevent', [eventId]);
       await api.logDecision({
         targetType: 'event',
         targetId: eventId,

--- a/src/components/EventDetail.tsx
+++ b/src/components/EventDetail.tsx
@@ -566,7 +566,7 @@ export function EventDetail({ event, onSelectEvent, onSelectPubkey, onViewReport
 
   const restoreMutation = useMutation({
     mutationFn: async ({ eventId }: { eventId: string }) => {
-      await callRelayRpc('allowevent', [eventId]);
+      await callRelayRpc('unbanevent', [eventId]);
       await logDecision({
         targetType: 'event',
         targetId: eventId,

--- a/src/components/EventModeration.tsx
+++ b/src/components/EventModeration.tsx
@@ -54,7 +54,7 @@ export function EventModeration() {
   // Mutation for allowing events
   const allowEventMutation = useMutation({
     mutationFn: ({ eventId, reason }: { eventId: string; reason?: string }) =>
-      callRelayRpc('allowevent', [eventId, reason]),
+      callRelayRpc('unbanevent', [eventId, reason]),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['events-needing-moderation'] });
       toast({ title: "Event approved successfully" });

--- a/src/components/EventsList.tsx
+++ b/src/components/EventsList.tsx
@@ -628,7 +628,7 @@ export function EventsList({ relayUrl }: EventsListProps) {
   // Mutation for event moderation
   const moderateEventMutation = useMutation({
     mutationFn: async ({ eventId, action, reason }: { eventId: string; action: 'allow' | 'ban'; reason?: string }) => {
-      const method = action === 'allow' ? 'allowevent' : 'banevent';
+      const method = action === 'allow' ? 'unbanevent' : 'banevent';
       await callRelayRpc(method, [eventId, reason]);
       return { eventId, action };
     },

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -298,7 +298,7 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
   // Restore auto-hidden content (reverse the auto-hide)
   const restoreAutoHideMutation = useMutation({
     mutationFn: async ({ eventId }: { eventId: string }) => {
-      await callRelayRpc('allowevent', [eventId]);
+      await callRelayRpc('unbanevent', [eventId]);
       await logDecision({
         targetType: 'event',
         targetId: eventId,
@@ -797,7 +797,7 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
                   description: "The event has been removed from the relay.",
                   action: (
                     <ToastAction altText="Undo delete" onClick={async () => {
-                      await callRelayRpc('allowevent', [eventId]);
+                      await callRelayRpc('unbanevent', [eventId]);
                       handleActionComplete();
                       toast({ title: "Event restored" });
                     }}>

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -792,6 +792,13 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
             onDeleteEvent={async (eventId) => {
               try {
                 await deleteEvent(eventId, 'Deleted from report review');
+                await logDecision({
+                  targetType: 'event',
+                  targetId: eventId,
+                  action: 'delete_event',
+                  reason: 'Deleted from report review',
+                  reportId: report?.id,
+                });
                 toast({
                   title: "Event deleted",
                   description: "The event has been removed from the relay.",
@@ -1056,6 +1063,7 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
                 eventId={context.target.value}
                 pubkey={context.reportedUser.pubkey || ''}
                 mediaHashes={mediaHashes}
+                mediaHashStatuses={mediaStatus.results}
                 isEventBanned={isEventDeleted ?? undefined}
                 hasBlockedMedia={mediaStatus.hasBlockedMedia}
                 hasRestrictedMedia={mediaStatus.hasRestrictedMedia}

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -122,7 +122,7 @@ export function UserManagement({ selectedPubkey }: UserManagementProps) {
   // Mutation for allowing users
   const allowUserMutation = useMutation({
     mutationFn: async ({ pubkey, reason }: { pubkey: string; reason?: string }) => {
-      await callRelayRpc('allowpubkey', [pubkey, reason]);
+      await callRelayRpc('unbanpubkey', [pubkey, reason]);
       // Log to D1 for audit trail
       await logDecision({
         targetType: 'pubkey',

--- a/worker/src/bulk-moderate.test.ts
+++ b/worker/src/bulk-moderate.test.ts
@@ -15,7 +15,7 @@ const hashA = 'a'.repeat(64);
 const hashB = 'b'.repeat(64);
 
 function mockRelay(events: Array<{ id: string; kind: number; content?: string; tags: string[][] }>) {
-  vi.spyOn(globalThis, 'WebSocket').mockImplementation((() => {
+  vi.spyOn(globalThis, 'WebSocket').mockImplementation((function () {
     const listeners = new Map<string, Array<(value?: unknown) => void>>();
     let subId = 'bulk-test';
 
@@ -41,7 +41,7 @@ function mockRelay(events: Array<{ id: string; kind: number; content?: string; t
       }),
       close: vi.fn(),
     };
-  }) as unknown as typeof WebSocket);
+  } as unknown as typeof WebSocket));
 }
 
 describe('handleBulkModerate', () => {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -756,28 +756,71 @@ async function handleModerate(
       }
     }
 
-    case 'ban_pubkey':
+    case 'ban_pubkey': {
       if (!body.pubkey) {
         return jsonResponse({ success: false, error: 'Missing pubkey for ban_pubkey' }, 400, corsHeaders);
       }
-      // NIP-86 relay management event
-      kind = 10000;
-      content = JSON.stringify({
-        method: 'banpubkey',
-        params: [body.pubkey, body.reason || ''],
-      });
-      break;
+      try {
+        const rpcRequest = new Request(request.url.replace(/\/api\/moderate$/, '/api/relay-rpc'), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            method: 'banpubkey',
+            params: [body.pubkey, body.reason || ''],
+          }),
+        });
+        const rpcResponse = await handleRelayRpc(rpcRequest, env, corsHeaders, ctx);
+        const rpcResult = await rpcResponse.json() as { success: boolean; error?: string };
+        if (!rpcResult.success) {
+          return jsonResponse({ success: false, error: rpcResult.error || 'banpubkey RPC failed' }, 500, corsHeaders);
+        }
+        if (env.DB) {
+          await markHumanReviewed(env.DB, 'pubkey', body.pubkey);
+        }
+        try {
+          await syncZendeskAfterAction(env, body.action, 'pubkey', body.pubkey, getPublicKey(secretKey));
+        } catch (err) {
+          console.error('[handleModerate] Zendesk sync error:', err);
+        }
+        const dmPromise = notifyModerationService(env, body.pubkey, 'ACCOUNT_SUSPENDED', body.reason || 'Account suspended by moderator')
+          .catch(err => console.error('[handleModerate] DM notification error:', err));
+        if (ctx) ctx.waitUntil(dmPromise);
+        return jsonResponse({ success: true, pubkey: body.pubkey }, 200, corsHeaders);
+      } catch (error) {
+        console.error('[handleModerate] ban_pubkey error:', error);
+        return jsonResponse({ success: false, error: error instanceof Error ? error.message : 'Unknown error' }, 500, corsHeaders);
+      }
+    }
 
-    case 'allow_pubkey':
+    case 'allow_pubkey': {
       if (!body.pubkey) {
         return jsonResponse({ success: false, error: 'Missing pubkey for allow_pubkey' }, 400, corsHeaders);
       }
-      kind = 10000;
-      content = JSON.stringify({
-        method: 'allowpubkey',
-        params: [body.pubkey],
-      });
-      break;
+      try {
+        const rpcRequest = new Request(request.url.replace(/\/api\/moderate$/, '/api/relay-rpc'), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            method: 'unbanpubkey',
+            params: [body.pubkey],
+          }),
+        });
+        const rpcResponse = await handleRelayRpc(rpcRequest, env, corsHeaders);
+        const rpcResult = await rpcResponse.json() as { success: boolean; error?: string };
+        if (!rpcResult.success) {
+          return jsonResponse({ success: false, error: rpcResult.error || 'unbanpubkey RPC failed' }, 500, corsHeaders);
+        }
+        try {
+          await syncZendeskAfterAction(env, body.action, 'pubkey', body.pubkey, getPublicKey(secretKey));
+        } catch (err) {
+          console.error('[handleModerate] Zendesk sync error:', err);
+        }
+        return jsonResponse({ success: true, pubkey: body.pubkey }, 200, corsHeaders);
+      } catch (error) {
+        console.error('[handleModerate] allow_pubkey error:', error);
+        return jsonResponse({ success: false, error: error instanceof Error ? error.message : 'Unknown error' }, 500, corsHeaders);
+      }
+    }
 
     default:
       return jsonResponse({ success: false, error: `Unknown action: ${body.action}` }, 400, corsHeaders);
@@ -2729,7 +2772,7 @@ async function handleZendeskAction(
       case 'allow_user':
         if (body.pubkey) {
           const httpUrl = getManagementUrl(env);
-          const payload = JSON.stringify({ method: 'allowpubkey', params: [body.pubkey] });
+          const payload = JSON.stringify({ method: 'unbanpubkey', params: [body.pubkey] });
           const payloadHash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(payload));
           const payloadHashHex = Array.from(new Uint8Array(payloadHash)).map(b => b.toString(16).padStart(2, '0')).join('');
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -694,11 +694,6 @@ async function handleModerate(
 
   const secretKey = await getSecretKey(env);
 
-  // Build NIP-86 moderation event (kind 10000 + action-specific kinds)
-  let kind: number;
-  let content: string;
-  const tags: string[][] = [];
-
   switch (body.action) {
     case 'delete_event': {
       // Use banevent RPC directly instead of publishing kind 5 events.
@@ -782,9 +777,6 @@ async function handleModerate(
         } catch (err) {
           console.error('[handleModerate] Zendesk sync error:', err);
         }
-        const dmPromise = notifyModerationService(env, body.pubkey, 'ACCOUNT_SUSPENDED', body.reason || 'Account suspended by moderator')
-          .catch(err => console.error('[handleModerate] DM notification error:', err));
-        if (ctx) ctx.waitUntil(dmPromise);
         return jsonResponse({ success: true, pubkey: body.pubkey }, 200, corsHeaders);
       } catch (error) {
         console.error('[handleModerate] ban_pubkey error:', error);
@@ -810,6 +802,9 @@ async function handleModerate(
         if (!rpcResult.success) {
           return jsonResponse({ success: false, error: rpcResult.error || 'unbanpubkey RPC failed' }, 500, corsHeaders);
         }
+        if (env.DB) {
+          await markHumanReviewed(env.DB, 'pubkey', body.pubkey);
+        }
         try {
           await syncZendeskAfterAction(env, body.action, 'pubkey', body.pubkey, getPublicKey(secretKey));
         } catch (err) {
@@ -825,50 +820,6 @@ async function handleModerate(
     default:
       return jsonResponse({ success: false, error: `Unknown action: ${body.action}` }, 400, corsHeaders);
   }
-
-  const event = finalizeEvent(
-    {
-      kind,
-      content,
-      tags,
-      created_at: Math.floor(Date.now() / 1000),
-    },
-    secretKey
-  );
-
-  // Publish to relay
-  const publishResult = await publishToRelay(event, env.RELAY_URL);
-
-  if (!publishResult.success) {
-    return jsonResponse({ success: false, error: publishResult.error }, 500, corsHeaders);
-  }
-
-  if (env.DB && body.pubkey) {
-    await markHumanReviewed(env.DB, 'pubkey', body.pubkey);
-  }
-
-  // Sync linked Zendesk tickets for both event and pubkey targets if present
-  // (delete_event has its own early-return sync above)
-  const moderator = getPublicKey(secretKey);
-  try {
-    if (body.eventId) {
-      await syncZendeskAfterAction(env, body.action, 'event', body.eventId, moderator);
-    }
-    if (body.pubkey) {
-      await syncZendeskAfterAction(env, body.action, 'pubkey', body.pubkey, moderator);
-    }
-  } catch (err) {
-    console.error('[handleModerate] Zendesk sync error:', err);
-  }
-
-  // DM the banned user (non-critical, off response path)
-  if (body.action === 'ban_pubkey' && body.pubkey) {
-    const dmPromise = notifyModerationService(env, body.pubkey, 'ACCOUNT_SUSPENDED', body.reason || 'Account suspended by moderator')
-      .catch(err => console.error('[handleModerate] DM notification error:', err));
-    if (ctx) ctx.waitUntil(dmPromise);
-  }
-
-  return jsonResponse({ success: true, event }, 200, corsHeaders);
 }
 
 async function handleRelayRpc(

--- a/worker/src/nip86.test.ts
+++ b/worker/src/nip86.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Tests for NIP-86 RPC utilities
 // ABOUTME: Uses vitest with mocked fetch for relay calls
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   getSecretKey,
   getAdminPubkey,
@@ -217,50 +217,108 @@ describe('convenience methods', () => {
 });
 
 describe('publishKind5Deletion', () => {
-  it('constructs a valid NIP-09 kind 5 event and posts to relay', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
-    const env: Nip86Env = {
-      NOSTR_NSEC: TEST_NSEC,
-      RELAY_URL: 'wss://relay.test.com',
-    };
+  let wsListeners: Record<string, ((...args: unknown[]) => void)[]>;
+  let wsSend: ReturnType<typeof vi.fn>;
+  let wsClose: ReturnType<typeof vi.fn>;
+  let originalWebSocket: typeof globalThis.WebSocket;
+  let autoOpen: boolean;
 
-    const result = await publishKind5Deletion('target-event-id-hex', 'Content violates policy', env, mockFetch);
+  beforeEach(() => {
+    vi.useFakeTimers();
+    wsListeners = {};
+    wsSend = vi.fn();
+    wsClose = vi.fn();
+    autoOpen = true;
+    originalWebSocket = globalThis.WebSocket;
 
+    const outerListeners = wsListeners;
+    const outerAutoOpen = () => autoOpen;
+    class MockWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+      send = wsSend;
+      close = wsClose;
+      addEventListener(event: string, cb: (...args: unknown[]) => void) {
+        (outerListeners[event] ??= []).push(cb);
+      }
+      constructor(_url: string) {
+        if (outerAutoOpen()) {
+          queueMicrotask(() => {
+            for (const cb of outerListeners['open'] ?? []) cb();
+          });
+        }
+      }
+    }
+    vi.stubGlobal('WebSocket', MockWebSocket);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    globalThis.WebSocket = originalWebSocket;
+  });
+
+  function fireWsEvent(event: string, ...args: unknown[]) {
+    for (const cb of wsListeners[event] ?? []) cb(...args);
+  }
+
+  it('publishes a kind 5 event via WebSocket and waits for OK', async () => {
+    const env: Nip86Env = { NOSTR_NSEC: TEST_NSEC, RELAY_URL: 'wss://relay.test.com' };
+
+    const promise = publishKind5Deletion('target-event-id-hex', 'Content violates policy', env);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(wsSend).toHaveBeenCalledTimes(1);
+    const sent = JSON.parse(wsSend.mock.calls[0][0]);
+    expect(sent[0]).toBe('EVENT');
+    expect(sent[1].kind).toBe(5);
+    expect(sent[1].tags).toContainEqual(['e', 'target-event-id-hex']);
+    expect(sent[1].content).toBe('Content violates policy');
+    expect(sent[1].sig).toBeDefined();
+
+    fireWsEvent('message', { data: JSON.stringify(['OK', sent[1].id, true, '']) });
+
+    const result = await promise;
     expect(result.success).toBe(true);
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    const [url, opts] = mockFetch.mock.calls[0];
-    expect(url).toBe('https://relay.test.com');
-    const body = JSON.parse(opts.body);
-    expect(body[0]).toBe('EVENT');
-    expect(body[1].kind).toBe(5);
-    expect(body[1].tags).toContainEqual(['e', 'target-event-id-hex']);
-    expect(body[1].content).toBe('Content violates policy');
-    expect(body[1].sig).toBeDefined();
+    expect(wsClose).toHaveBeenCalled();
   });
 
-  it('returns error when relay responds with non-OK status', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
-    const env: Nip86Env = {
-      NOSTR_NSEC: TEST_NSEC,
-      RELAY_URL: 'wss://relay.test.com',
-    };
+  it('returns error when relay rejects the event', async () => {
+    const env: Nip86Env = { NOSTR_NSEC: TEST_NSEC, RELAY_URL: 'wss://relay.test.com' };
 
-    const result = await publishKind5Deletion('event-id', 'reason', env, mockFetch);
+    const promise = publishKind5Deletion('event-id', 'reason', env);
+    await vi.advanceTimersByTimeAsync(0);
 
+    const sent = JSON.parse(wsSend.mock.calls[0][0]);
+    fireWsEvent('message', { data: JSON.stringify(['OK', sent[1].id, false, 'blocked: not authorized']) });
+
+    const result = await promise;
     expect(result.success).toBe(false);
-    expect(result.error).toContain('500');
+    expect(result.error).toContain('not authorized');
   });
 
-  it('returns error on fetch failure', async () => {
-    const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
-    const env: Nip86Env = {
-      NOSTR_NSEC: TEST_NSEC,
-      RELAY_URL: 'wss://relay.test.com',
-    };
+  it('returns error on WebSocket connection failure', async () => {
+    autoOpen = false;
+    const env: Nip86Env = { NOSTR_NSEC: TEST_NSEC, RELAY_URL: 'wss://relay.test.com' };
 
-    const result = await publishKind5Deletion('event-id', 'reason', env, mockFetch);
+    const promise = publishKind5Deletion('event-id', 'reason', env);
+    await vi.advanceTimersByTimeAsync(0);
+    fireWsEvent('error');
 
+    const result = await promise;
     expect(result.success).toBe(false);
-    expect(result.error).toContain('Network error');
+    expect(result.error).toContain('WebSocket');
+  });
+
+  it('times out if relay never responds', async () => {
+    const env: Nip86Env = { NOSTR_NSEC: TEST_NSEC, RELAY_URL: 'wss://relay.test.com' };
+
+    const promise = publishKind5Deletion('event-id', 'reason', env);
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    const result = await promise;
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('timeout');
   });
 });

--- a/worker/src/nip86.test.ts
+++ b/worker/src/nip86.test.ts
@@ -188,12 +188,12 @@ describe('convenience methods', () => {
     expect(body.params).toEqual(['event123', 'spam']);
   });
 
-  it('allowEvent should call allowevent RPC', async () => {
+  it('allowEvent should call unbanevent RPC', async () => {
     const result = await allowEvent('event123', mockEnv);
     expect(result.success).toBe(true);
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
-    expect(body.method).toBe('allowevent');
+    expect(body.method).toBe('unbanevent');
     expect(body.params).toEqual(['event123']);
   });
 

--- a/worker/src/nip86.ts
+++ b/worker/src/nip86.ts
@@ -192,8 +192,10 @@ export async function unbanPubkey(
   return callNip86Rpc('unbanpubkey', [pubkey], env);
 }
 
+const KIND5_PUBLISH_TIMEOUT_MS = 10_000;
+
 /**
- * Publish a NIP-09 kind 5 deletion request to the relay.
+ * Publish a NIP-09 kind 5 deletion request to the relay via WebSocket.
  * Published from the admin key -- Funnelcake honors admin deletions.
  * Other relays may ignore kind 5 from non-authors.
  */
@@ -201,10 +203,8 @@ export async function publishKind5Deletion(
   targetEventId: string,
   reason: string,
   env: Nip86Env,
-  fetchFn: typeof fetch = fetch,
 ): Promise<{ success: boolean; error?: string }> {
   const secretKey = await getSecretKey(env);
-  const relayHttpUrl = env.RELAY_URL.replace('wss://', 'https://').replace('ws://', 'http://');
 
   const event = finalizeEvent(
     {
@@ -216,17 +216,41 @@ export async function publishKind5Deletion(
     secretKey,
   );
 
-  try {
-    const response = await fetchFn(relayHttpUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(['EVENT', event]),
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: { success: boolean; error?: string }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      try { ws.close(); } catch { /* ignore */ }
+      resolve(result);
+    };
+
+    const timeout = setTimeout(() => {
+      finish({ success: false, error: 'Relay did not respond to EVENT within timeout' });
+    }, KIND5_PUBLISH_TIMEOUT_MS);
+
+    const ws = new WebSocket(env.RELAY_URL);
+
+    ws.addEventListener('open', () => {
+      ws.send(JSON.stringify(['EVENT', event]));
     });
-    if (!response.ok) {
-      return { success: false, error: `Relay returned ${response.status}` };
-    }
-    return { success: true };
-  } catch (error) {
-    return { success: false, error: String(error) };
-  }
+
+    ws.addEventListener('message', (msg) => {
+      try {
+        const data = JSON.parse(msg.data as string);
+        if (data[0] === 'OK' && data[1] === event.id) {
+          if (data[2] === true) {
+            finish({ success: true });
+          } else {
+            finish({ success: false, error: data[3] || 'Relay rejected kind 5 event' });
+          }
+        }
+      } catch { /* ignore malformed frames */ }
+    });
+
+    ws.addEventListener('error', () => {
+      finish({ success: false, error: 'WebSocket connection to relay failed' });
+    });
+  });
 }

--- a/worker/src/nip86.ts
+++ b/worker/src/nip86.ts
@@ -168,7 +168,7 @@ export async function allowEvent(
   eventId: string,
   env: Nip86Env
 ): Promise<Nip86RpcResult> {
-  return callNip86Rpc('allowevent', [eventId], env);
+  return callNip86Rpc('unbanevent', [eventId], env);
 }
 
 /**


### PR DESCRIPTION
## Summary

- **ban_pubkey** published a kind 10000 event via WebSocket -- the relay accepted it but never processed it as a management command. Bans from the admin UI silently failed. Refactored to route through `handleRelayRpc` (NIP-86 HTTP POST with NIP-98 auth).
- **allow_pubkey** sent `allowpubkey` to the relay. Funnelcake accepts this silently but has no implementation. Changed to `unbanpubkey`.
- **allowevent** -> `unbanevent` across all frontend components and `nip86.ts`. Same issue -- Funnelcake's methods are `unban*`, not `allow*`.
- Removed duplicate DM notification from `ban_pubkey` (handleRelayRpc already sends one).
- Restored `markHumanReviewed` on `allow_pubkey` (dropped during refactor).
- Removed ~40 lines of dead code (unreachable `finalizeEvent`/`publishToRelay` block).
- Fixed pre-existing `bulk-moderate.test.ts` failure from vitest 4.x breaking change.

Combined effect: ban/unban user and restore event buttons in the admin UI were completely non-functional. Both now work.

Fixes divinevideo/support-trust-safety#147
See also divinevideo/divine-funnelcake#450 (Funnelcake should reject unknown methods)

## Review feedback addressed

- **Restore media actions filtered by per-hash status** -- Unblock only sends `SAFE` to blocked hashes; Remove Restriction only clears restricted hashes. `EventActions` now receives `mediaHashStatuses` with per-hash blocked/restricted flags instead of operating on all hashes blindly.
- **Profile-card delete audit row** -- `onDeleteEvent` in `ReportDetail` now calls `logDecision` with `targetType: 'event'`, action, reason, and `reportId` after `deleteEvent` succeeds.
- **Kind 5 deletion via WebSocket** -- `publishKind5Deletion` now opens a WebSocket to `RELAY_URL`, sends `["EVENT", ...]`, and waits for the relay's `["OK", ...]` response with a 10s timeout. Replaces the HTTP POST that standard relays don't accept for event ingestion.

## Files changed

| File | Change |
|------|--------|
| `worker/src/index.ts` | `ban_pubkey`: WebSocket -> `handleRelayRpc`. `allow_pubkey`: `allowpubkey` -> `unbanpubkey`. Dead code removed. |
| `worker/src/nip86.ts` | `allowEvent()`: `allowevent` -> `unbanevent`. `publishKind5Deletion`: HTTP POST -> WebSocket with OK wait. |
| `worker/src/nip86.test.ts` | Assertions updated. Kind 5 tests rewritten for WebSocket mock (OK, reject, error, timeout). |
| `worker/src/bulk-moderate.test.ts` | Arrow function -> function expression for vitest 4.x |
| `src/components/EventActions.tsx` | `allowevent` -> `unbanevent`. Restore mutations filter by per-hash status. Separate `removeRestrictionMutation`. |
| `src/components/EventModeration.tsx` | `allowevent` -> `unbanevent` |
| `src/components/ReportDetail.tsx` | `allowevent` -> `unbanevent`. Profile-card delete now logs audit decision with reportId. Passes `mediaHashStatuses` to EventActions. |
| `src/components/EventsList.tsx` | `allowevent` -> `unbanevent` |
| `src/components/EventDetail.tsx` | `allowevent` -> `unbanevent` |
| `src/components/UserManagement.tsx` | `allowpubkey` -> `unbanpubkey` |

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `cd worker && npx vitest run` passes (184 tests)
- [x] `grep -rn "allowevent\|allowpubkey" src/` returns zero hits
- [ ] Deploy to staging, verify ban/unban and restore flows
- [ ] Verify kind-5 deletion publishes and relay returns OK
- [ ] Verify audit log row appears for profile-card deletes