### PR TITLE
fix(nip86): use allowevent instead of unbanevent for event unbans

### DIFF
--- a/src/components/EventActions.tsx
+++ b/src/components/EventActions.tsx
@@ -39,7 +39,7 @@ export function EventActions({
 
   const banEventMutation = useMutation({
     mutationFn: async () => {
-      await api.callRelayRpc('banevent', [eventId, 'Banned by moderator']);
+      await api.banEvent(eventId, 'Banned by moderator');
       await api.logDecision({
         targetType: 'event',
         targetId: eventId,
@@ -58,7 +58,7 @@ export function EventActions({
 
   const restoreEventMutation = useMutation({
     mutationFn: async () => {
-      await api.callRelayRpc('allowevent', [eventId]);
+      await api.allowEvent(eventId);
       await api.logDecision({
         targetType: 'event',
         targetId: eventId,

--- a/src/components/EventActions.tsx
+++ b/src/components/EventActions.tsx
@@ -58,7 +58,7 @@ export function EventActions({
 
   const restoreEventMutation = useMutation({
     mutationFn: async () => {
-      await api.callRelayRpc('unbanevent', [eventId]);
+      await api.callRelayRpc('allowevent', [eventId]);
       await api.logDecision({
         targetType: 'event',
         targetId: eventId,

--- a/src/components/EventDetail.tsx
+++ b/src/components/EventDetail.tsx
@@ -566,7 +566,7 @@ export function EventDetail({ event, onSelectEvent, onSelectPubkey, onViewReport
 
   const restoreMutation = useMutation({
     mutationFn: async ({ eventId }: { eventId: string }) => {
-      await callRelayRpc('unbanevent', [eventId]);
+      await callRelayRpc('allowevent', [eventId]);
       await logDecision({
         targetType: 'event',
         targetId: eventId,

--- a/src/components/EventDetail.tsx
+++ b/src/components/EventDetail.tsx
@@ -358,7 +358,7 @@ function TagsTable({ tags }: { tags: string[][] }) {
 export function EventDetail({ event, onSelectEvent, onSelectPubkey, onViewReports }: EventDetailProps) {
   const { nostr } = useNostr();
   const { toast } = useToast();
-  const { banPubkey, deleteEvent, unbanPubkey, verifyPubkeyBanned, verifyPubkeyUnbanned, verifyEventDeleted, callRelayRpc, logDecision } = useAdminApi();
+  const { banPubkey, deleteEvent, unbanPubkey, allowEvent, verifyPubkeyBanned, verifyPubkeyUnbanned, verifyEventDeleted, logDecision } = useAdminApi();
   const queryClient = useQueryClient();
 
   const [_showRawJson, _setShowRawJson] = useState(false);
@@ -566,7 +566,7 @@ export function EventDetail({ event, onSelectEvent, onSelectPubkey, onViewReport
 
   const restoreMutation = useMutation({
     mutationFn: async ({ eventId }: { eventId: string }) => {
-      await callRelayRpc('allowevent', [eventId]);
+      await allowEvent(eventId);
       await logDecision({
         targetType: 'event',
         targetId: eventId,

--- a/src/components/EventModeration.tsx
+++ b/src/components/EventModeration.tsx
@@ -54,7 +54,7 @@ export function EventModeration() {
   // Mutation for allowing events
   const allowEventMutation = useMutation({
     mutationFn: ({ eventId, reason }: { eventId: string; reason?: string }) =>
-      callRelayRpc('unbanevent', [eventId, reason]),
+      callRelayRpc('allowevent', [eventId, reason]),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['events-needing-moderation'] });
       toast({ title: "Event approved successfully" });

--- a/src/components/EventModeration.tsx
+++ b/src/components/EventModeration.tsx
@@ -28,7 +28,7 @@ interface BannedEvent {
 export function EventModeration() {
   const { toast } = useToast();
   const queryClient = useQueryClient();
-  const { callRelayRpc, verifyEventDeleted } = useAdminApi();
+  const { callRelayRpc, banEvent, allowEvent, verifyEventDeleted } = useAdminApi();
   const [newEventId, setNewEventId] = useState("");
   const [newReason, setNewReason] = useState("");
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
@@ -53,8 +53,8 @@ export function EventModeration() {
 
   // Mutation for allowing events
   const allowEventMutation = useMutation({
-    mutationFn: ({ eventId, reason }: { eventId: string; reason?: string }) =>
-      callRelayRpc('allowevent', [eventId, reason]),
+    mutationFn: ({ eventId }: { eventId: string; reason?: string }) =>
+      allowEvent(eventId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['events-needing-moderation'] });
       toast({ title: "Event approved successfully" });
@@ -71,7 +71,7 @@ export function EventModeration() {
   // Mutation for banning events
   const banEventMutation = useMutation({
     mutationFn: async ({ eventId, reason }: { eventId: string; reason?: string }) => {
-      await callRelayRpc('banevent', [eventId, reason]);
+      await banEvent(eventId, reason);
       return eventId;
     },
     onSuccess: async (eventId) => {

--- a/src/components/EventsList.tsx
+++ b/src/components/EventsList.tsx
@@ -628,7 +628,7 @@ export function EventsList({ relayUrl }: EventsListProps) {
   // Mutation for event moderation
   const moderateEventMutation = useMutation({
     mutationFn: async ({ eventId, action, reason }: { eventId: string; action: 'allow' | 'ban'; reason?: string }) => {
-      const method = action === 'allow' ? 'unbanevent' : 'banevent';
+      const method = action === 'allow' ? 'allowevent' : 'banevent';
       await callRelayRpc(method, [eventId, reason]);
       return { eventId, action };
     },

--- a/src/components/EventsList.tsx
+++ b/src/components/EventsList.tsx
@@ -382,7 +382,7 @@ export function EventsList({ relayUrl }: EventsListProps) {
   const { nostr } = useNostr();
   const { user } = useCurrentUser();
   const { toast } = useToast();
-  const { callRelayRpc, verifyEventDeleted } = useAdminApi();
+  const { callRelayRpc, banEvent, allowEvent, verifyEventDeleted } = useAdminApi();
   const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
   const [isVerifying, setIsVerifying] = useState(false);
@@ -628,8 +628,11 @@ export function EventsList({ relayUrl }: EventsListProps) {
   // Mutation for event moderation
   const moderateEventMutation = useMutation({
     mutationFn: async ({ eventId, action, reason }: { eventId: string; action: 'allow' | 'ban'; reason?: string }) => {
-      const method = action === 'allow' ? 'allowevent' : 'banevent';
-      await callRelayRpc(method, [eventId, reason]);
+      if (action === 'allow') {
+        await allowEvent(eventId);
+      } else {
+        await banEvent(eventId, reason);
+      }
       return { eventId, action };
     },
     onSuccess: async ({ eventId, action }) => {

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -85,7 +85,7 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const {
-    deleteEvent, markAsReviewed, logDecision, deleteDecisions, callRelayRpc,
+    deleteEvent, allowEvent, markAsReviewed, logDecision, deleteDecisions,
   } = useAdminApi();
   const { config } = useAppContext();
   const navigate = useNavigate();
@@ -298,7 +298,7 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
   // Restore auto-hidden content (reverse the auto-hide)
   const restoreAutoHideMutation = useMutation({
     mutationFn: async ({ eventId }: { eventId: string }) => {
-      await callRelayRpc('allowevent', [eventId]);
+      await allowEvent(eventId);
       await logDecision({
         targetType: 'event',
         targetId: eventId,
@@ -804,7 +804,7 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
                   description: "The event has been removed from the relay.",
                   action: (
                     <ToastAction altText="Undo delete" onClick={async () => {
-                      await callRelayRpc('allowevent', [eventId]);
+                      await allowEvent(eventId);
                       handleActionComplete();
                       toast({ title: "Event restored" });
                     }}>

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -298,7 +298,7 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
   // Restore auto-hidden content (reverse the auto-hide)
   const restoreAutoHideMutation = useMutation({
     mutationFn: async ({ eventId }: { eventId: string }) => {
-      await callRelayRpc('unbanevent', [eventId]);
+      await callRelayRpc('allowevent', [eventId]);
       await logDecision({
         targetType: 'event',
         targetId: eventId,
@@ -804,7 +804,7 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
                   description: "The event has been removed from the relay.",
                   action: (
                     <ToastAction altText="Undo delete" onClick={async () => {
-                      await callRelayRpc('unbanevent', [eventId]);
+                      await callRelayRpc('allowevent', [eventId]);
                       handleActionComplete();
                       toast({ title: "Event restored" });
                     }}>

--- a/src/hooks/useAdminApi.ts
+++ b/src/hooks/useAdminApi.ts
@@ -43,6 +43,10 @@ export function useAdminApi() {
     // NIP-86 RPC
     callRelayRpc: <T = unknown>(method: string, params?: (string | number | undefined)[]) =>
       adminApi.callRelayRpc<T>(apiUrl, method, params),
+    banEvent: (eventId: string, reason?: string) =>
+      adminApi.banEvent(apiUrl, eventId, reason),
+    allowEvent: (eventId: string) =>
+      adminApi.allowEvent(apiUrl, eventId),
     banPubkey: (pubkey: string, reason?: string) =>
       adminApi.banPubkey(apiUrl, pubkey, reason),
     unbanPubkey: (pubkey: string) =>

--- a/src/lib/adminApi.test.ts
+++ b/src/lib/adminApi.test.ts
@@ -10,6 +10,8 @@ import {
   banPubkeyViaModerate,
   allowPubkey,
   callRelayRpc,
+  banEvent,
+  allowEvent,
   banPubkey,
   unbanPubkey,
   listBannedPubkeys,
@@ -380,6 +382,42 @@ describe('adminApi', () => {
         expect.stringContaining('/api/relay-rpc'),
         expect.objectContaining({
           body: JSON.stringify({ method: 'unbanpubkey', params: ['pubkey123'] }),
+        })
+      );
+    });
+  });
+
+  describe('banEvent', () => {
+    it('should call banevent RPC method with event id and reason', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, result: null }),
+      });
+
+      await banEvent(API_URL, 'event123', 'Spam');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/relay-rpc'),
+        expect.objectContaining({
+          body: JSON.stringify({ method: 'banevent', params: ['event123', 'Spam'] }),
+        })
+      );
+    });
+  });
+
+  describe('allowEvent', () => {
+    it('should call allowevent RPC method with only the event id', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, result: null }),
+      });
+
+      await allowEvent(API_URL, 'event123');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/relay-rpc'),
+        expect.objectContaining({
+          body: JSON.stringify({ method: 'allowevent', params: ['event123'] }),
         })
       );
     });

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -191,6 +191,15 @@ export async function banPubkey(apiUrl: string, pubkey: string, reason?: string)
   await callRelayRpc(apiUrl, 'banpubkey', [pubkey, reason || 'Banned via admin']);
 }
 
+export async function banEvent(apiUrl: string, eventId: string, reason?: string): Promise<void> {
+  await callRelayRpc(apiUrl, 'banevent', [eventId, reason]);
+}
+
+// Funnelcake's event unban method is intentionally named allowevent, not unbanevent.
+export async function allowEvent(apiUrl: string, eventId: string): Promise<void> {
+  await callRelayRpc(apiUrl, 'allowevent', [eventId]);
+}
+
 // Convenience function for unbanning pubkey
 // Note: 'unbanpubkey' is not in NIP-86 spec but is a necessary extension
 // This will fail on relays that don't support it until they add the method

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -1486,7 +1486,7 @@ describe('handleCreateMinorAccount', () => {
 
   it('creates account and returns success with claim_url', async () => {
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db as unknown as D1Database }, corsHeaders);
     const body = await res.json() as Record<string, unknown>;
 
     expect(res.status).toBe(200);
@@ -1498,14 +1498,14 @@ describe('handleCreateMinorAccount', () => {
 
   it('rejects missing username', async () => {
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({}), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({}), { DB: db as unknown as D1Database }, corsHeaders);
     expect(res.status).toBe(400);
     expect(mockCreateMinorAccount).not.toHaveBeenCalled();
   });
 
   it('rejects invalid username characters', async () => {
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'BAD USER!' }), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'BAD USER!' }), { DB: db as unknown as D1Database }, corsHeaders);
     expect(res.status).toBe(400);
     expect(mockCreateMinorAccount).not.toHaveBeenCalled();
   });
@@ -1514,7 +1514,7 @@ describe('handleCreateMinorAccount', () => {
     const db = makeMinorDb();
     const res = await handleCreateMinorAccount(
       makeRequest({ username: 'test', display_name: 12345 }),
-      { DB: db } as any,
+      { DB: db as unknown as D1Database },
       corsHeaders,
     );
     expect(res.status).toBe(400);
@@ -1523,7 +1523,7 @@ describe('handleCreateMinorAccount', () => {
 
   it('strips empty display_name before calling Keycast', async () => {
     const db = makeMinorDb();
-    await handleCreateMinorAccount(makeRequest({ username: 'test', display_name: '  ' }), { DB: db } as any, corsHeaders);
+    await handleCreateMinorAccount(makeRequest({ username: 'test', display_name: '  ' }), { DB: db as unknown as D1Database }, corsHeaders);
     expect(mockCreateMinorAccount).toHaveBeenCalledWith('test', undefined, expect.anything());
   });
 
@@ -1531,7 +1531,7 @@ describe('handleCreateMinorAccount', () => {
     const db = makeMinorDb();
     const res = await handleCreateMinorAccount(
       makeRequest({ username: 'test', zendesk_ticket_id: 'abc' }),
-      { DB: db } as any,
+      { DB: db as unknown as D1Database },
       corsHeaders,
     );
     expect(res.status).toBe(400);
@@ -1540,7 +1540,7 @@ describe('handleCreateMinorAccount', () => {
 
   it('returns 500 without claim_url when D1 insert fails after Keycast success', async () => {
     const db = makeMinorDb(() => Promise.reject(new Error('D1 write failed')));
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db as unknown as D1Database }, corsHeaders);
     const body = await res.json() as Record<string, unknown>;
 
     expect(res.status).toBe(500);
@@ -1553,21 +1553,21 @@ describe('handleCreateMinorAccount', () => {
   it('maps Keycast 409 to 409 status', async () => {
     mockCreateMinorAccount.mockResolvedValue({ success: false, error: '409: Username taken' });
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'taken' }), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'taken' }), { DB: db as unknown as D1Database }, corsHeaders);
     expect(res.status).toBe(409);
   });
 
   it('maps other Keycast 4xx to 400 status', async () => {
     mockCreateMinorAccount.mockResolvedValue({ success: false, error: '422: Invalid input' });
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db as unknown as D1Database }, corsHeaders);
     expect(res.status).toBe(400);
   });
 
   it('maps Keycast server errors to 502 status', async () => {
     mockCreateMinorAccount.mockResolvedValue({ success: false, error: 'Connection refused' });
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db as unknown as D1Database }, corsHeaders);
     expect(res.status).toBe(502);
   });
 });

--- a/worker/src/nip86.test.ts
+++ b/worker/src/nip86.test.ts
@@ -188,12 +188,12 @@ describe('convenience methods', () => {
     expect(body.params).toEqual(['event123', 'spam']);
   });
 
-  it('allowEvent should call unbanevent RPC', async () => {
+  it('allowEvent should call allowevent RPC', async () => {
     const result = await allowEvent('event123', mockEnv);
     expect(result.success).toBe(true);
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
-    expect(body.method).toBe('unbanevent');
+    expect(body.method).toBe('allowevent');
     expect(body.params).toEqual(['event123']);
   });
 

--- a/worker/src/nip86.ts
+++ b/worker/src/nip86.ts
@@ -168,7 +168,7 @@ export async function allowEvent(
   eventId: string,
   env: Nip86Env
 ): Promise<Nip86RpcResult> {
-  return callNip86Rpc('unbanevent', [eventId], env);
+  return callNip86Rpc('allowevent', [eventId], env);
 }
 
 /**


### PR DESCRIPTION
## Summary

- PR #88 changed event unban RPC calls from `allowevent` to `unbanevent`, but Funnelcake does not implement `unbanevent` — the method returns `{"error": "Unknown method: unbanevent"}`, silently breaking all event restore/unban actions in the UI and worker.
- Funnelcake's method naming is asymmetric: `unbanpubkey` exists and correctly removes from the banned set, but the event equivalent is `allowevent` (not `unbanevent`). `allowpubkey` is a separate operation that adds to an allowlist without unbanning.
- This fix reverts the event method name to `allowevent` in `nip86.ts` and all 5 frontend components that call the relay directly.

**Affected actions (all broken since PR #88 merge):**
- Restore auto-hidden content (ReportDetail)
- Undo delete (ReportDetail toast action)
- Restore event (EventDetail)
- Allow event (EventActions)
- Allow event (EventModeration)
- Allow event in bulk (EventsList)

## Method name reference

| Operation | Correct method | What PR #88 used | Funnelcake behavior |
|-----------|---------------|-----------------|-------------------|
| Ban event | `banevent` | `banevent` | OK |
| Unban event | `allowevent` | `unbanevent` | **"Unknown method"** error |
| Ban pubkey | `banpubkey` | `banpubkey` | OK |
| Unban pubkey | `unbanpubkey` | `unbanpubkey` | OK |

The asymmetry exists because Funnelcake implements `allowevent` (which removes from the ban cache + ClickHouse banned set) but never added `unbanevent` as an alias. For pubkeys, `unbanpubkey` exists separately from `allowpubkey` (which adds to a whitelist).

## Also included: lint fix inherited from #90

Rebasing this branch onto `main` after #90 merged pulled in 10 `@typescript-eslint/no-explicit-any` eslint errors in `worker/src/age-review.test.ts`. They slipped through #90's review and turned `main`'s CI red, which this branch then inherited. Rather than open a separate cleanup PR, the fix is folded in here: `{ DB: db } as any` becomes `{ DB: db as unknown as D1Database }`, matching the typing idiom already used throughout that test file.

This is a test-only change with no runtime effect. The compiled worker bundle is byte-identical before and after (verified by comparing `wrangler deploy --dry-run` output hashes), so it does not touch the unban fix or the deployed artifact.

Note: `main` itself stays red until this PR merges, since the fix lives on this branch rather than a standalone PR to `main`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `cd worker && npx vitest run` — 209 tests pass (nip86.test.ts updated)
- [x] eslint — clean (resolves the failures inherited from #90)
- [x] `grep -rn unbanevent src/ worker/src/` — zero hits
- [x] Deployed to staging and production; banned then unbanned an event end to end — unban succeeds via `allowevent`
