### PR TITLE
feat: approved minor onboarding via claim link

### DIFF
--- a/shared/age-review.ts
+++ b/shared/age-review.ts
@@ -91,6 +91,8 @@ export interface AgeReviewCase {
   resolution_note: string | null;
   last_alerted_at: string | null;
   zendesk_ticket_id: number | null;
+  created_via: string | null;
+  claim_link_url: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/src/components/AgeReview.tsx
+++ b/src/components/AgeReview.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/select";
 import { Clock, RefreshCw, Filter, AlertTriangle } from "lucide-react";
 import { AgeReviewDetail } from "@/components/AgeReviewDetail";
+import { CreateMinorAccountDialog } from "@/components/CreateMinorAccountDialog";
 import { UserIdentifier } from "@/components/UserIdentifier";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
@@ -108,14 +109,17 @@ export function AgeReview() {
               )}
             </span>
           </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => refetch()}
-            className="h-7"
-          >
-            <RefreshCw className="h-3.5 w-3.5" />
-          </Button>
+          <div className="flex items-center gap-1">
+            <CreateMinorAccountDialog />
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => refetch()}
+              className="h-7"
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+            </Button>
+          </div>
         </div>
 
         <div className="flex gap-2">

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -38,6 +38,8 @@ function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
     resolution_note: null,
     last_alerted_at: null,
     zendesk_ticket_id: null,
+    created_via: null,
+    claim_link_url: null,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
     ...overrides,

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -407,6 +407,16 @@ export function AgeReviewDetail({ caseData: c }: Props) {
             <Separator />
             <div className="space-y-1">
               <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Resolution</h4>
+              {c.created_via === 'minor_onboarding' && (
+                <Badge className="bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400 text-[10px]">
+                  Minor Onboarding
+                </Badge>
+              )}
+              {c.resolution_note.startsWith('Auto-cleared:') && (
+                <Badge className="bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400 text-[10px]">
+                  Auto-cleared
+                </Badge>
+              )}
               <p className="text-sm">{c.resolution_note}</p>
             </div>
           </>

--- a/src/components/CreateMinorAccountDialog.tsx
+++ b/src/components/CreateMinorAccountDialog.tsx
@@ -1,0 +1,162 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAdminApi } from "@/hooks/useAdminApi";
+import { useToast } from "@/hooks/useToast";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { UserPlus, Copy, Check, Loader2 } from "lucide-react";
+import { CopyableId } from "@/components/CopyableId";
+
+export function CreateMinorAccountDialog() {
+  const api = useAdminApi();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [username, setUsername] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [zendeskTicketId, setZendeskTicketId] = useState("");
+  const [claimUrlCopied, setClaimUrlCopied] = useState(false);
+
+  const createAccount = useMutation({
+    mutationFn: () => {
+      const ticketId = zendeskTicketId ? parseInt(zendeskTicketId, 10) : undefined;
+      return api.createMinorAccount(username.trim(), displayName.trim() || undefined, ticketId);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['age-review-cases'] });
+    },
+    onError: (err: Error) => {
+      toast({ title: 'Failed to create account', description: err.message, variant: 'destructive' });
+    },
+  });
+
+  const result = createAccount.data;
+
+  function handleCopyClaimUrl() {
+    if (!result?.claim_url) return;
+    navigator.clipboard.writeText(result.claim_url);
+    setClaimUrlCopied(true);
+    setTimeout(() => setClaimUrlCopied(false), 2000);
+    toast({ title: 'Claim link copied' });
+  }
+
+  function handleClose() {
+    setOpen(false);
+    setUsername("");
+    setDisplayName("");
+    setZendeskTicketId("");
+    createAccount.reset();
+    setClaimUrlCopied(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => v ? setOpen(true) : handleClose()}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" className="h-7 text-xs gap-1">
+          <UserPlus className="h-3 w-3" />
+          New Minor Account
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-sm">Create Approved Minor Account</DialogTitle>
+        </DialogHeader>
+
+        {!result?.success ? (
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium">Username *</label>
+              <Input
+                placeholder="username"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                className="h-8 text-sm"
+                disabled={createAccount.isPending}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium">Display Name</label>
+              <Input
+                placeholder="Display name (optional)"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                className="h-8 text-sm"
+                disabled={createAccount.isPending}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium">Zendesk Ticket ID</label>
+              <Input
+                placeholder="e.g. 12345 (optional)"
+                value={zendeskTicketId}
+                onChange={(e) => setZendeskTicketId(e.target.value.replace(/\D/g, ''))}
+                className="h-8 text-sm"
+                disabled={createAccount.isPending}
+              />
+            </div>
+            <Button
+              className="w-full h-8 text-xs"
+              disabled={!username.trim() || createAccount.isPending}
+              onClick={() => createAccount.mutate()}
+            >
+              {createAccount.isPending ? (
+                <><Loader2 className="h-3 w-3 mr-1 animate-spin" /> Creating...</>
+              ) : (
+                'Create Account & Generate Claim Link'
+              )}
+            </Button>
+            {createAccount.isError && (
+              <p className="text-xs text-red-600">{(createAccount.error as Error).message}</p>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="rounded-md bg-green-50 dark:bg-green-900/20 p-3 space-y-2">
+              <p className="text-xs font-medium text-green-800 dark:text-green-300">Account created</p>
+              <div className="space-y-1.5">
+                <div className="text-xs text-muted-foreground">Pubkey:</div>
+                <CopyableId value={result.pubkey ?? ''} type="hex" size="xs" truncateStart={16} truncateEnd={8} />
+              </div>
+              <div className="text-xs text-muted-foreground">
+                Expires: {result.expires_at ? new Date(result.expires_at).toLocaleDateString() : 'N/A'}
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium">Claim Link</label>
+              <div className="flex gap-1.5">
+                <Input
+                  readOnly
+                  value={result.claim_url ?? ''}
+                  className="h-8 text-xs font-mono"
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 shrink-0"
+                  onClick={handleCopyClaimUrl}
+                >
+                  {claimUrlCopied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                </Button>
+              </div>
+              <p className="text-[10px] text-muted-foreground">
+                Send this link to the parent via Zendesk reply. The minor uses it to set their email and password.
+              </p>
+            </div>
+
+            <Button variant="outline" className="w-full h-8 text-xs" onClick={handleClose}>
+              Done
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/CreateMinorAccountDialog.tsx
+++ b/src/components/CreateMinorAccountDialog.tsx
@@ -76,7 +76,8 @@ export function CreateMinorAccountDialog() {
               <Input
                 placeholder="username"
                 value={username}
-                onChange={(e) => setUsername(e.target.value)}
+                onChange={(e) => setUsername(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
+                maxLength={63}
                 className="h-8 text-sm"
                 disabled={createAccount.isPending}
               />
@@ -103,7 +104,7 @@ export function CreateMinorAccountDialog() {
             </div>
             <Button
               className="w-full h-8 text-xs"
-              disabled={!username.trim() || createAccount.isPending}
+              disabled={!username.trim() || username.length < 3 || username.startsWith('-') || username.endsWith('-') || createAccount.isPending}
               onClick={() => createAccount.mutate()}
             >
               {createAccount.isPending ? (

--- a/src/hooks/useAdminApi.ts
+++ b/src/hooks/useAdminApi.ts
@@ -141,6 +141,8 @@ export function useAdminApi() {
       adminApi.getAgeReviewConfig(apiUrl),
     updateAgeReviewConfig: (config: Partial<adminApi.AgeReviewConfig>) =>
       adminApi.updateAgeReviewConfig(apiUrl, config),
+    createMinorAccount: (username: string, displayName?: string, zendeskTicketId?: number) =>
+      adminApi.createMinorAccount(apiUrl, username, displayName, zendeskTicketId),
 
   }), [apiUrl, relayUrl]);
 

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -935,6 +935,28 @@ export async function updateAgeReviewCase(
   return apiRequest<AgeReviewCaseResponse>(apiUrl, `/api/age-review/cases/${caseId}`, 'PATCH', updates);
 }
 
+// Minor onboarding
+export interface CreateMinorAccountResponse {
+  success: boolean;
+  pubkey?: string;
+  claim_url?: string;
+  expires_at?: string;
+  case_id?: string;
+  error?: string;
+}
+
+export async function createMinorAccount(
+  apiUrl: string,
+  username: string,
+  displayName?: string,
+  zendeskTicketId?: number,
+): Promise<CreateMinorAccountResponse> {
+  const body: Record<string, unknown> = { username };
+  if (displayName != null) body.display_name = displayName;
+  if (zendeskTicketId != null) body.zendesk_ticket_id = zendeskTicketId;
+  return apiRequest<CreateMinorAccountResponse>(apiUrl, '/api/age-review/create-minor-account', 'POST', body);
+}
+
 // Bulk moderation
 export { VALID_BULK_ACTIONS, type BulkAction, type BulkModerateResult };
 

--- a/worker/migrations/0009_age_review_minor_onboarding.sql
+++ b/worker/migrations/0009_age_review_minor_onboarding.sql
@@ -1,0 +1,3 @@
+-- Track how age review cases were created and store claim links for minor onboarding
+ALTER TABLE age_review_cases ADD COLUMN created_via TEXT DEFAULT 'report';
+ALTER TABLE age_review_cases ADD COLUMN claim_link_url TEXT;

--- a/worker/src/ReportWatcher.test.ts
+++ b/worker/src/ReportWatcher.test.ts
@@ -1430,6 +1430,7 @@ describe('ReportWatcher', () => {
   describe('age review case creation', () => {
     let ageWatcher: ReportWatcher;
     let ageEnv: ReportWatcherEnv;
+    let ageState: DurableObjectState;
     let mockDbRun: ReturnType<typeof vi.fn>;
     let mockDbFirst: ReturnType<typeof vi.fn>;
     const mockGetUserStatus = getUserStatus as ReturnType<typeof vi.fn>;
@@ -1452,7 +1453,7 @@ describe('ReportWatcher', () => {
       mockGetUserStatus.mockReset();
       mockGetUserStatus.mockResolvedValue({ success: false, error: 'not configured' });
 
-      const ageState = createMockState();
+      ageState = createMockState();
       ageEnv = createMockEnv({
         AUTO_HIDE_ENABLED: 'false',
         KEYCAST_URL: 'https://login.test.divine.video',
@@ -1533,6 +1534,38 @@ describe('ReportWatcher', () => {
         );
         expect(insertCall).toBeDefined();
         expect(insertCall![0]).toContain('cleared');
+      }, { timeout: 2000 });
+    });
+
+    it('should attach message handler work to DO lifecycle via waitUntil', async () => {
+      mockGetUserStatus.mockResolvedValue({
+        success: true,
+        pubkey: 'lifecycle_pubkey',
+        status: 'active',
+        verified_minor: false,
+      });
+
+      await ageWatcher.fetch(new Request('https://do/start', { method: 'POST' }));
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const ws = getLastMockWebSocket();
+      const reportEvent: ReportEvent = {
+        id: 'lifecycle_report_1',
+        pubkey: 'reporter_pubkey',
+        kind: 1984,
+        content: 'Underage user report',
+        tags: [
+          ['p', 'lifecycle_pubkey'],
+          ['l', 'NS-underageUser', 'social.nos.ontology'],
+          ['client', 'diVine'],
+        ],
+        created_at: Math.floor(Date.now() / 1000),
+      };
+
+      ws!.simulateMessage(JSON.stringify(['EVENT', 'auto-hide-reports', reportEvent]));
+
+      await vi.waitFor(() => {
+        expect((ageState.waitUntil as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
       }, { timeout: 2000 });
     });
   });

--- a/worker/src/ReportWatcher.test.ts
+++ b/worker/src/ReportWatcher.test.ts
@@ -4,6 +4,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ReportWatcher, type ReportWatcherEnv, type ReportEvent, type ReportWatcherStatus, type AutoHideConfig } from './ReportWatcher';
 
+vi.mock('./keycast-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./keycast-client')>();
+  return {
+    ...actual,
+    getUserStatus: vi.fn().mockResolvedValue({ success: false, error: 'not configured' }),
+  };
+});
+import { getUserStatus } from './keycast-client';
+
 // Mock WebSocket instances created during tests
 let mockWebSockets: MockWebSocket[] = [];
 
@@ -1415,6 +1424,116 @@ describe('ReportWatcher', () => {
       expect(response.status).toBe(400);
       const body = await response.json() as { error: string };
       expect(body.error).toContain('trusted');
+    });
+  });
+
+  describe('age review case creation', () => {
+    let ageWatcher: ReportWatcher;
+    let ageEnv: ReportWatcherEnv;
+    let mockDbRun: ReturnType<typeof vi.fn>;
+    let mockDbFirst: ReturnType<typeof vi.fn>;
+    const mockGetUserStatus = getUserStatus as ReturnType<typeof vi.fn>;
+
+    function makeMockDb() {
+      mockDbRun = vi.fn().mockResolvedValue({ success: true });
+      mockDbFirst = vi.fn().mockResolvedValue(null);
+      const boundMock = { run: mockDbRun, first: mockDbFirst };
+      const stmtMock = {
+        run: mockDbRun,
+        first: mockDbFirst,
+        bind: vi.fn().mockReturnValue(boundMock),
+      };
+      return {
+        prepare: vi.fn().mockReturnValue(stmtMock),
+      } as unknown as D1Database;
+    }
+
+    beforeEach(async () => {
+      mockGetUserStatus.mockReset();
+      mockGetUserStatus.mockResolvedValue({ success: false, error: 'not configured' });
+
+      const ageState = createMockState();
+      ageEnv = createMockEnv({
+        AUTO_HIDE_ENABLED: 'false',
+        KEYCAST_URL: 'https://login.test.divine.video',
+        KEYCAST_SERVICE_TOKEN: 'test-token',
+      } as Partial<ReportWatcherEnv>);
+      ageEnv.DB = makeMockDb();
+      ageWatcher = new ReportWatcher(ageState, ageEnv);
+      await new Promise(resolve => setTimeout(resolve, 10));
+    });
+
+    it('should create age review case for NS-underageUser reports and await completion', async () => {
+      mockGetUserStatus.mockResolvedValue({
+        success: true,
+        pubkey: 'reported_pubkey_abc',
+        status: 'active',
+        verified_minor: false,
+      });
+
+      await ageWatcher.fetch(new Request('https://do/start', { method: 'POST' }));
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const ws = getLastMockWebSocket();
+      const reportEvent: ReportEvent = {
+        id: 'underage_report_1',
+        pubkey: 'reporter_pubkey',
+        kind: 1984,
+        content: 'Underage user report',
+        tags: [
+          ['p', 'reported_pubkey_abc'],
+          ['l', 'NS-underageUser', 'social.nos.ontology'],
+          ['client', 'diVine'],
+        ],
+        created_at: Math.floor(Date.now() / 1000),
+      };
+
+      ws!.simulateMessage(JSON.stringify(['EVENT', 'auto-hide-reports', reportEvent]));
+
+      await vi.waitFor(() => {
+        const prepareCalls = (ageEnv.DB!.prepare as ReturnType<typeof vi.fn>).mock.calls;
+        const insertCall = prepareCalls.find(
+          (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('age_review_cases') && c[0].includes('INSERT')
+        );
+        expect(insertCall).toBeDefined();
+      }, { timeout: 2000 });
+    });
+
+    it('should auto-clear age review case for verified minors', async () => {
+      mockGetUserStatus.mockResolvedValue({
+        success: true,
+        pubkey: 'verified_minor_pubkey',
+        status: 'active',
+        verified_minor: true,
+      });
+
+      await ageWatcher.fetch(new Request('https://do/start', { method: 'POST' }));
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const ws = getLastMockWebSocket();
+      const reportEvent: ReportEvent = {
+        id: 'underage_report_2',
+        pubkey: 'reporter_pubkey',
+        kind: 1984,
+        content: 'Underage user report',
+        tags: [
+          ['p', 'verified_minor_pubkey'],
+          ['l', 'NS-underageUser', 'social.nos.ontology'],
+          ['client', 'diVine'],
+        ],
+        created_at: Math.floor(Date.now() / 1000),
+      };
+
+      ws!.simulateMessage(JSON.stringify(['EVENT', 'auto-hide-reports', reportEvent]));
+
+      await vi.waitFor(() => {
+        const prepareCalls = (ageEnv.DB!.prepare as ReturnType<typeof vi.fn>).mock.calls;
+        const insertCall = prepareCalls.find(
+          (c: unknown[]) => typeof c[0] === 'string' && c[0].includes('age_review_cases') && c[0].includes('INSERT')
+        );
+        expect(insertCall).toBeDefined();
+        expect(insertCall![0]).toContain('cleared');
+      }, { timeout: 2000 });
     });
   });
 });

--- a/worker/src/ReportWatcher.ts
+++ b/worker/src/ReportWatcher.ts
@@ -17,11 +17,12 @@ import {
   TERMINAL_STATES,
   defaultResolutionForBand,
 } from '../../shared/age-review';
+import { getUserStatus, type KeycastEnv } from './keycast-client';
 
 /**
  * Extended environment for ReportWatcher DO
  */
-export interface ReportWatcherEnv extends Nip86Env {
+export interface ReportWatcherEnv extends Nip86Env, KeycastEnv {
   DB?: D1Database;
   AUTO_HIDE_ENABLED?: string;
   TRUSTED_CLIENTS?: string;
@@ -909,6 +910,33 @@ export class ReportWatcher implements DurableObject {
     if (existing) {
       console.log(`[ReportWatcher] Active age review case ${existing.id} already exists for ${reportedPubkey}, skipping`);
       return;
+    }
+
+    // Auto-clear: if user is a previously verified minor, create case as immediately cleared
+    try {
+      const keycastStatus = await getUserStatus(reportedPubkey, this.env);
+      if (keycastStatus.success && keycastStatus.verified_minor) {
+        const caseId = crypto.randomUUID();
+        await this.env.DB.prepare(`
+          INSERT INTO age_review_cases
+          (id, pubkey, reporter_pubkey, report_id, suspected_age_band, state, allowed_resolution, resolution_note, created_via)
+          VALUES (?, ?, ?, ?, 'age_13_15', 'cleared', 'parent_video_or_email', 'Auto-cleared: previously verified minor', 'report')
+        `).bind(caseId, reportedPubkey, event.pubkey, event.id).run();
+
+        await this.logDecision({
+          targetType: 'pubkey',
+          targetId: reportedPubkey,
+          action: AGE_REVIEW_ACTION.caseCreated,
+          reason: `Under-16 report auto-cleared: verified minor (case ${caseId})`,
+          reportId: event.id,
+          reporterPubkey: event.pubkey,
+        });
+
+        console.log(`[ReportWatcher] Age review case ${caseId} auto-cleared for verified minor ${reportedPubkey}`);
+        return;
+      }
+    } catch (err) {
+      console.warn(`[ReportWatcher] Keycast verified_minor check failed for ${reportedPubkey}, proceeding with normal case:`, err);
     }
 
     const caseId = crypto.randomUUID();

--- a/worker/src/ReportWatcher.ts
+++ b/worker/src/ReportWatcher.ts
@@ -458,9 +458,10 @@ export class ReportWatcher implements DurableObject {
       });
 
       this.ws.addEventListener('message', (event) => {
-        this.handleMessage(event.data as string).catch(error => {
+        const work = this.handleMessage(event.data as string).catch(error => {
           console.error('[ReportWatcher] Message handler failed:', error);
         });
+        this.state.waitUntil(work);
       });
 
       this.ws.addEventListener('close', (event) => {

--- a/worker/src/ReportWatcher.ts
+++ b/worker/src/ReportWatcher.ts
@@ -458,7 +458,9 @@ export class ReportWatcher implements DurableObject {
       });
 
       this.ws.addEventListener('message', (event) => {
-        this.handleMessage(event.data as string);
+        this.handleMessage(event.data as string).catch(error => {
+          console.error('[ReportWatcher] Message handler failed:', error);
+        });
       });
 
       this.ws.addEventListener('close', (event) => {
@@ -530,7 +532,7 @@ export class ReportWatcher implements DurableObject {
   /**
    * Handle incoming WebSocket message
    */
-  private handleMessage(data: string): void {
+  private async handleMessage(data: string): Promise<void> {
     try {
       const message = JSON.parse(data) as unknown[];
 
@@ -544,7 +546,7 @@ export class ReportWatcher implements DurableObject {
         case 'EVENT': {
           const [subId, event] = rest as [string, ReportEvent];
           if (subId === this.subscriptionId && event.kind === 1984) {
-            this.handleReportEvent(event);
+            await this.handleReportEvent(event);
           }
           break;
         }
@@ -578,7 +580,7 @@ export class ReportWatcher implements DurableObject {
   /**
    * Handle a kind 1984 report event
    */
-  private handleReportEvent(event: ReportEvent): void {
+  private async handleReportEvent(event: ReportEvent): Promise<void> {
     this.lastEventAt = Date.now();
     this.eventsProcessed++;
 
@@ -619,20 +621,25 @@ export class ReportWatcher implements DurableObject {
 
     // Process auto-hide if enabled and category qualifies
     if (targetType === 'event' && targetId !== 'unknown') {
-      this.processAutoHide(event, category, targetId).catch(error => {
+      try {
+        await this.processAutoHide(event, category, targetId);
+      } catch (error) {
         console.error('[ReportWatcher] Auto-hide processing failed:', error);
-      });
+      }
     }
 
-    // Create age review case for under-16 reports (pubkey-level, independent of auto-hide).
-    // In-memory Set guards against the SELECT-then-INSERT race: the Set check+add is
-    // synchronous, so concurrent WebSocket messages can't interleave between them.
+    // Create age review case for under-16 reports (pubkey-level).
+    // Runs after auto-hide completes; both awaited so work survives DO eviction.
     const reportedPubkey = targetPubkeyTag?.[1];
     if (category === 'NS-underageUser' && reportedPubkey && !this.pendingAgeReviewPubkeys.has(reportedPubkey)) {
       this.pendingAgeReviewPubkeys.add(reportedPubkey);
-      this.createAgeReviewCase(event, reportedPubkey)
-        .catch(error => console.error('[ReportWatcher] Age review case creation failed:', error))
-        .finally(() => this.pendingAgeReviewPubkeys.delete(reportedPubkey));
+      try {
+        await this.createAgeReviewCase(event, reportedPubkey);
+      } catch (error) {
+        console.error('[ReportWatcher] Age review case creation failed:', error);
+      } finally {
+        this.pendingAgeReviewPubkeys.delete(reportedPubkey);
+      }
     }
   }
 

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -6,18 +6,20 @@ import {
   handleGetModerationStatus,
   handleParentContact,
   handleAgeReviewReplyWebhook,
+  handleCreateMinorAccount,
   checkAgeReviewDeadlines,
   syncAgeReviewTicketResolution,
   getAgeReviewConfig,
   updateAgeReviewConfig,
 } from './age-review';
 import type { AgeReviewCase } from '../../shared/age-review';
-import { suspendUser, unsuspendUser, banUser } from './keycast-client';
+import { suspendUser, unsuspendUser, banUser, createMinorAccount } from './keycast-client';
 
 vi.mock('./keycast-client', () => ({
   suspendUser: vi.fn().mockResolvedValue({ success: true }),
   unsuspendUser: vi.fn().mockResolvedValue({ success: true }),
   banUser: vi.fn().mockResolvedValue({ success: true }),
+  createMinorAccount: vi.fn().mockResolvedValue({ success: true, pubkey: 'a'.repeat(64), claim_url: 'https://login.test/claim/abc' }),
 }));
 
 const corsHeaders = { 'Access-Control-Allow-Origin': '*' };
@@ -1446,5 +1448,126 @@ describe('updateAgeReviewConfig', () => {
     };
     const config = await updateAgeReviewConfig(db as unknown as D1Database, { auto_delete_on_deny: false });
     expect(config.auto_delete_on_deny).toBe(false);
+  });
+});
+
+// -- handleCreateMinorAccount -------------------------------------------------
+
+describe('handleCreateMinorAccount', () => {
+  const mockCreateMinorAccount = createMinorAccount as ReturnType<typeof vi.fn>;
+
+  function makeRequest(body: unknown) {
+    return new Request('https://api.test/api/age-review/minor-account', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  function makeMinorDb(runImpl?: () => Promise<unknown>) {
+    return {
+      prepare: vi.fn().mockReturnValue({
+        bind: vi.fn().mockReturnValue({
+          run: vi.fn().mockImplementation(runImpl ?? (() => Promise.resolve({ success: true }))),
+        }),
+      }),
+    } as unknown as D1Database;
+  }
+
+  beforeEach(() => {
+    mockCreateMinorAccount.mockReset();
+    mockCreateMinorAccount.mockResolvedValue({
+      success: true,
+      pubkey: 'a'.repeat(64),
+      claim_url: 'https://login.test/claim/abc',
+      expires_at: '2026-06-15T00:00:00Z',
+    });
+  });
+
+  it('creates account and returns success with claim_url', async () => {
+    const db = makeMinorDb();
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db } as any, corsHeaders);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.claim_url).toBe('https://login.test/claim/abc');
+    expect(body.pubkey).toBe('a'.repeat(64));
+    expect(body.case_id).toBeDefined();
+  });
+
+  it('rejects missing username', async () => {
+    const db = makeMinorDb();
+    const res = await handleCreateMinorAccount(makeRequest({}), { DB: db } as any, corsHeaders);
+    expect(res.status).toBe(400);
+    expect(mockCreateMinorAccount).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid username characters', async () => {
+    const db = makeMinorDb();
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'BAD USER!' }), { DB: db } as any, corsHeaders);
+    expect(res.status).toBe(400);
+    expect(mockCreateMinorAccount).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-string display_name', async () => {
+    const db = makeMinorDb();
+    const res = await handleCreateMinorAccount(
+      makeRequest({ username: 'test', display_name: 12345 }),
+      { DB: db } as any,
+      corsHeaders,
+    );
+    expect(res.status).toBe(400);
+    expect(mockCreateMinorAccount).not.toHaveBeenCalled();
+  });
+
+  it('strips empty display_name before calling Keycast', async () => {
+    const db = makeMinorDb();
+    await handleCreateMinorAccount(makeRequest({ username: 'test', display_name: '  ' }), { DB: db } as any, corsHeaders);
+    expect(mockCreateMinorAccount).toHaveBeenCalledWith('test', undefined, expect.anything());
+  });
+
+  it('rejects non-integer zendesk_ticket_id', async () => {
+    const db = makeMinorDb();
+    const res = await handleCreateMinorAccount(
+      makeRequest({ username: 'test', zendesk_ticket_id: 'abc' }),
+      { DB: db } as any,
+      corsHeaders,
+    );
+    expect(res.status).toBe(400);
+    expect(mockCreateMinorAccount).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 without claim_url when D1 insert fails after Keycast success', async () => {
+    const db = makeMinorDb(() => Promise.reject(new Error('D1 write failed')));
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db } as any, corsHeaders);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(500);
+    expect(body.success).toBe(false);
+    expect(body.claim_url).toBeUndefined();
+    expect(body.pubkey).toBe('a'.repeat(64));
+    expect(body.error).toContain('audit record failed');
+  });
+
+  it('maps Keycast 409 to 409 status', async () => {
+    mockCreateMinorAccount.mockResolvedValue({ success: false, error: '409: Username taken' });
+    const db = makeMinorDb();
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'taken' }), { DB: db } as any, corsHeaders);
+    expect(res.status).toBe(409);
+  });
+
+  it('maps other Keycast 4xx to 400 status', async () => {
+    mockCreateMinorAccount.mockResolvedValue({ success: false, error: '422: Invalid input' });
+    const db = makeMinorDb();
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db } as any, corsHeaders);
+    expect(res.status).toBe(400);
+  });
+
+  it('maps Keycast server errors to 502 status', async () => {
+    mockCreateMinorAccount.mockResolvedValue({ success: false, error: 'Connection refused' });
+    const db = makeMinorDb();
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db } as any, corsHeaders);
+    expect(res.status).toBe(502);
   });
 });

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -13,7 +13,7 @@ import {
 import { handleBulkModerate, type BulkModerateEnv } from './bulk-moderate';
 import { resolveZendeskCreds } from './zendesk-sync';
 import type { BulkAction, BulkModerateResult } from '../../shared/bulk-moderation';
-import { suspendUser, unsuspendUser, banUser, type KeycastEnv } from './keycast-client';
+import { suspendUser, unsuspendUser, banUser, createMinorAccount, type KeycastEnv } from './keycast-client';
 import type { SecretStoreSecret } from './nip86';
 
 interface AgeReviewEnv extends BulkModerateEnv, KeycastEnv {
@@ -283,6 +283,64 @@ export async function handleUpdateAgeReviewCase(
   }
 
   return json({ success: true, case: updated, bulkActionTriggered, keycastUpdated }, 200, corsHeaders);
+}
+
+// ---------------------------------------------------------------------------
+// Minor onboarding (behind admin auth)
+// ---------------------------------------------------------------------------
+
+export async function handleCreateMinorAccount(
+  request: Request,
+  env: AgeReviewEnv,
+  corsHeaders: Record<string, string>,
+): Promise<Response> {
+  if (!env.DB) return json({ success: false, error: 'Database not configured' }, 500, corsHeaders);
+
+  let body: { username?: string; display_name?: string; zendesk_ticket_id?: number };
+  try {
+    body = await request.json();
+  } catch {
+    return json({ success: false, error: 'Invalid JSON body' }, 400, corsHeaders);
+  }
+
+  const username = body.username?.trim().toLowerCase();
+  if (!username) {
+    return json({ success: false, error: 'username is required' }, 400, corsHeaders);
+  }
+  if (username.length > 64 || !/^[a-z0-9_-]+$/.test(username)) {
+    return json({ success: false, error: 'username must be 1-64 characters, lowercase alphanumeric, hyphens, or underscores' }, 400, corsHeaders);
+  }
+
+  const result = await createMinorAccount(username, body.display_name, env);
+  if (!result.success || !result.pubkey || !result.claim_url) {
+    const is409 = result.error?.startsWith('409:');
+    const is4xx = result.error?.match(/^4\d{2}:/);
+    const status = is409 ? 409 : is4xx ? 400 : 502;
+    return json({ success: false, error: result.error ?? 'Keycast account creation failed' }, status, corsHeaders);
+  }
+
+  // Create a cleared audit record in D1. If this fails, the Keycast account
+  // exists but has no audit trail -- log enough context to recover manually.
+  const caseId = crypto.randomUUID();
+  try {
+    await env.DB.prepare(`
+      INSERT INTO age_review_cases
+      (id, pubkey, suspected_age_band, state, allowed_resolution, resolution_note, created_via, claim_link_url, zendesk_ticket_id)
+      VALUES (?, ?, 'age_13_15', 'cleared', 'parent_video_or_email', 'Approved via parental consent (minor onboarding)', 'minor_onboarding', ?, ?)
+    `).bind(caseId, result.pubkey, result.claim_url, body.zendesk_ticket_id ?? null).run();
+  } catch (err) {
+    console.error(`[age-review] D1 audit record failed for minor account: pubkey=${result.pubkey}, claim_url=${result.claim_url}, case=${caseId}`, err);
+  }
+
+  console.log(`[age-review] Minor account created: pubkey=${result.pubkey}, case=${caseId}, username=${username}`);
+
+  return json({
+    success: true,
+    pubkey: result.pubkey,
+    claim_url: result.claim_url,
+    expires_at: result.expires_at,
+    case_id: caseId,
+  }, 200, corsHeaders);
 }
 
 // ---------------------------------------------------------------------------

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -311,6 +311,12 @@ export async function handleCreateMinorAccount(
     return json({ success: false, error: 'username must be 1-64 characters, lowercase alphanumeric, hyphens, or underscores' }, 400, corsHeaders);
   }
 
+  if (body.zendesk_ticket_id !== undefined && body.zendesk_ticket_id !== null) {
+    if (typeof body.zendesk_ticket_id !== 'number' || !Number.isInteger(body.zendesk_ticket_id) || body.zendesk_ticket_id <= 0) {
+      return json({ success: false, error: 'zendesk_ticket_id must be a positive integer' }, 400, corsHeaders);
+    }
+  }
+
   const result = await createMinorAccount(username, body.display_name, env);
   if (!result.success || !result.pubkey || !result.claim_url) {
     const is409 = result.error?.startsWith('409:');
@@ -319,8 +325,6 @@ export async function handleCreateMinorAccount(
     return json({ success: false, error: result.error ?? 'Keycast account creation failed' }, status, corsHeaders);
   }
 
-  // Create a cleared audit record in D1. If this fails, the Keycast account
-  // exists but has no audit trail -- log enough context to recover manually.
   const caseId = crypto.randomUUID();
   try {
     await env.DB.prepare(`
@@ -329,7 +333,13 @@ export async function handleCreateMinorAccount(
       VALUES (?, ?, 'age_13_15', 'cleared', 'parent_video_or_email', 'Approved via parental consent (minor onboarding)', 'minor_onboarding', ?, ?)
     `).bind(caseId, result.pubkey, result.claim_url, body.zendesk_ticket_id ?? null).run();
   } catch (err) {
-    console.error(`[age-review] D1 audit record failed for minor account: pubkey=${result.pubkey}, claim_url=${result.claim_url}, case=${caseId}`, err);
+    console.error(`[age-review] D1 audit record failed for minor account: pubkey=${result.pubkey}, case=${caseId}`, err);
+    return json({
+      success: false,
+      error: 'Account created in Keycast but audit record failed. Contact engineering to reconcile.',
+      pubkey: result.pubkey,
+      case_id: caseId,
+    }, 500, corsHeaders);
   }
 
   console.log(`[age-review] Minor account created: pubkey=${result.pubkey}, case=${caseId}, username=${username}`);

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -307,9 +307,15 @@ export async function handleCreateMinorAccount(
   if (!username) {
     return json({ success: false, error: 'username is required' }, 400, corsHeaders);
   }
-  if (username.length > 64 || !/^[a-z0-9_-]+$/.test(username)) {
-    return json({ success: false, error: 'username must be 1-64 characters, lowercase alphanumeric, hyphens, or underscores' }, 400, corsHeaders);
+  // Matches divine-mobile's DivineUsernamePolicy (3-63 chars, [a-z0-9-], no leading/trailing hyphens)
+  if (username.length < 3 || username.length > 63 || !/^[a-z0-9-]+$/.test(username) || username.startsWith('-') || username.endsWith('-')) {
+    return json({ success: false, error: 'username must be 3-63 characters, lowercase alphanumeric or hyphens, cannot start or end with a hyphen' }, 400, corsHeaders);
   }
+
+  if (body.display_name !== undefined && typeof body.display_name !== 'string') {
+    return json({ success: false, error: 'display_name must be a string' }, 400, corsHeaders);
+  }
+  const displayName = body.display_name?.trim() || undefined;
 
   if (body.zendesk_ticket_id !== undefined && body.zendesk_ticket_id !== null) {
     if (typeof body.zendesk_ticket_id !== 'number' || !Number.isInteger(body.zendesk_ticket_id) || body.zendesk_ticket_id <= 0) {
@@ -317,7 +323,7 @@ export async function handleCreateMinorAccount(
     }
   }
 
-  const result = await createMinorAccount(username, body.display_name, env);
+  const result = await createMinorAccount(username, displayName, env);
   if (!result.success || !result.pubkey || !result.claim_url) {
     const is409 = result.error?.startsWith('409:');
     const is4xx = result.error?.match(/^4\d{2}:/);

--- a/worker/src/db.ts
+++ b/worker/src/db.ts
@@ -69,14 +69,28 @@ export async function ensureSchema(db: D1Database): Promise<void> {
       resolution_note TEXT,
       last_alerted_at TEXT,
       zendesk_ticket_id INTEGER,
+      created_via TEXT DEFAULT 'report',
+      claim_link_url TEXT,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT DEFAULT CURRENT_TIMESTAMP
     )
   `).run();
 
-  // Add zendesk_ticket_id to existing tables that were created without it
+  // Add columns to existing tables that were created without them
   try {
     await db.prepare(`ALTER TABLE age_review_cases ADD COLUMN zendesk_ticket_id INTEGER`).run();
+  } catch {
+    // Column already exists
+  }
+
+  try {
+    await db.prepare(`ALTER TABLE age_review_cases ADD COLUMN created_via TEXT DEFAULT 'report'`).run();
+  } catch {
+    // Column already exists
+  }
+
+  try {
+    await db.prepare(`ALTER TABLE age_review_cases ADD COLUMN claim_link_url TEXT`).run();
   } catch {
     // Column already exists
   }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -20,6 +20,7 @@ import {
   handleGetAgeReviewCases,
   handleGetAgeReviewCase,
   handleUpdateAgeReviewCase,
+  handleCreateMinorAccount,
   handleGetModerationStatus,
   handleParentContact,
   handleAgeReviewReplyWebhook,
@@ -492,6 +493,10 @@ export default {
         if (env.DB) await ensureSchemaOnce(env.DB);
         const caseId = path.replace('/api/age-review/cases/', '');
         return handleUpdateAgeReviewCase(request, caseId, env, corsHeaders);
+      }
+      if (path === '/api/age-review/create-minor-account' && request.method === 'POST') {
+        if (env.DB) await ensureSchemaOnce(env.DB);
+        return handleCreateMinorAccount(request, env, corsHeaders);
       }
 
       // 404 for unknown routes

--- a/worker/src/keycast-client.test.ts
+++ b/worker/src/keycast-client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest';
-import { suspendUser, unsuspendUser, banUser, getUserStatus, type KeycastEnv } from './keycast-client';
+import { suspendUser, unsuspendUser, banUser, getUserStatus, createMinorAccount, type KeycastEnv } from './keycast-client';
 
 const VALID_PUBKEY = 'a'.repeat(64);
 
@@ -174,6 +174,62 @@ describe('keycast-client', () => {
       const result = await getUserStatus(VALID_PUBKEY, makeEnv());
       expect(result.success).toBe(false);
       expect(result.error).toContain('500');
+    });
+  });
+
+  describe('createMinorAccount', () => {
+    it('sends POST with username and returns pubkey and claim_url', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          pubkey: VALID_PUBKEY,
+          claim_url: 'https://login.test/claim/abc',
+          expires_at: '2026-06-15T00:00:00Z',
+        }),
+      });
+      const result = await createMinorAccount('testuser', undefined, makeEnv());
+      expect(result.success).toBe(true);
+      expect(result.pubkey).toBe(VALID_PUBKEY);
+      expect(result.claim_url).toBe('https://login.test/claim/abc');
+      expect(result.expires_at).toBe('2026-06-15T00:00:00Z');
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://login.test.divine.video/api/admin/create-minor-account');
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body)).toEqual({ username: 'testuser' });
+    });
+
+    it('includes display_name when provided', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ pubkey: VALID_PUBKEY, claim_url: 'https://x' }),
+      });
+      await createMinorAccount('testuser', 'Test User', makeEnv());
+      expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+        username: 'testuser',
+        display_name: 'Test User',
+      });
+    });
+
+    it('returns error on non-OK response', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 409, text: () => Promise.resolve('Username taken') });
+      const result = await createMinorAccount('taken', undefined, makeEnv());
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('409');
+    });
+
+    it('returns error on network failure', async () => {
+      fetchMock.mockRejectedValue(new Error('DNS lookup failed'));
+      const result = await createMinorAccount('testuser', undefined, makeEnv());
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('DNS lookup failed');
+    });
+
+    it('returns not configured when env is missing', async () => {
+      const result = await createMinorAccount('testuser', undefined, makeEnv({ KEYCAST_URL: undefined }));
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('not configured');
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/worker/src/keycast-client.test.ts
+++ b/worker/src/keycast-client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest';
-import { suspendUser, unsuspendUser, banUser, type KeycastEnv } from './keycast-client';
+import { suspendUser, unsuspendUser, banUser, getUserStatus, type KeycastEnv } from './keycast-client';
 
 const VALID_PUBKEY = 'a'.repeat(64);
 
@@ -110,6 +110,70 @@ describe('keycast-client', () => {
       const result = await suspendUser('g'.repeat(64), 'age_review', makeEnv());
       expect(result).toEqual({ success: false, error: expect.stringContaining('pubkey') });
       expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getUserStatus', () => {
+    it('returns verified_minor true only for boolean true', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ pubkey: VALID_PUBKEY, status: 'active', verified_minor: true }),
+      });
+      const result = await getUserStatus(VALID_PUBKEY, makeEnv());
+      expect(result.success).toBe(true);
+      expect(result.verified_minor).toBe(true);
+    });
+
+    it('returns verified_minor false for string "true"', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ pubkey: VALID_PUBKEY, status: 'active', verified_minor: 'true' }),
+      });
+      const result = await getUserStatus(VALID_PUBKEY, makeEnv());
+      expect(result.verified_minor).toBe(false);
+    });
+
+    it('returns verified_minor false for string "false"', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ pubkey: VALID_PUBKEY, status: 'active', verified_minor: 'false' }),
+      });
+      const result = await getUserStatus(VALID_PUBKEY, makeEnv());
+      expect(result.verified_minor).toBe(false);
+    });
+
+    it('returns verified_minor false for numeric 1', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ pubkey: VALID_PUBKEY, status: 'active', verified_minor: 1 }),
+      });
+      const result = await getUserStatus(VALID_PUBKEY, makeEnv());
+      expect(result.verified_minor).toBe(false);
+    });
+
+    it('returns verified_minor false when field is missing', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ pubkey: VALID_PUBKEY, status: 'active' }),
+      });
+      const result = await getUserStatus(VALID_PUBKEY, makeEnv());
+      expect(result.verified_minor).toBe(false);
+    });
+
+    it('returns verified_minor false for null', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ pubkey: VALID_PUBKEY, status: 'active', verified_minor: null }),
+      });
+      const result = await getUserStatus(VALID_PUBKEY, makeEnv());
+      expect(result.verified_minor).toBe(false);
+    });
+
+    it('returns error on non-OK response', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve('Server error') });
+      const result = await getUserStatus(VALID_PUBKEY, makeEnv());
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('500');
     });
   });
 });

--- a/worker/src/keycast-client.ts
+++ b/worker/src/keycast-client.ts
@@ -108,12 +108,12 @@ export async function getUserStatus(pubkey: string, env: KeycastEnv): Promise<Us
     const data = await res.json() as Record<string, unknown>;
     return {
       success: true,
-      pubkey: data.pubkey as string,
-      status: data.status as string,
-      suspended_reason: data.suspended_reason as string | undefined,
-      suspended_at: data.suspended_at as string | undefined,
-      verified_minor: data.verified_minor as boolean | undefined,
-      verified_minor_at: data.verified_minor_at as string | undefined,
+      pubkey: typeof data.pubkey === 'string' ? data.pubkey : undefined,
+      status: typeof data.status === 'string' ? data.status : undefined,
+      suspended_reason: typeof data.suspended_reason === 'string' ? data.suspended_reason : undefined,
+      suspended_at: typeof data.suspended_at === 'string' ? data.suspended_at : undefined,
+      verified_minor: data.verified_minor === true,
+      verified_minor_at: typeof data.verified_minor_at === 'string' ? data.verified_minor_at : undefined,
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -161,9 +161,9 @@ export async function createMinorAccount(
     const data = await res.json() as Record<string, unknown>;
     return {
       success: true,
-      pubkey: data.pubkey as string,
-      claim_url: data.claim_url as string,
-      expires_at: data.expires_at as string,
+      pubkey: typeof data.pubkey === 'string' ? data.pubkey : undefined,
+      claim_url: typeof data.claim_url === 'string' ? data.claim_url : undefined,
+      expires_at: typeof data.expires_at === 'string' ? data.expires_at : undefined,
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/worker/src/keycast-client.ts
+++ b/worker/src/keycast-client.ts
@@ -143,7 +143,7 @@ export async function createMinorAccount(
   }
   try {
     const body: Record<string, string> = { username };
-    if (displayName) body.display_name = displayName;
+    if (displayName !== undefined) body.display_name = displayName;
 
     const res = await fetch(`${env.KEYCAST_URL}/api/admin/create-minor-account`, {
       method: 'POST',

--- a/worker/src/keycast-client.ts
+++ b/worker/src/keycast-client.ts
@@ -74,3 +74,100 @@ export async function unsuspendUser(pubkey: string, env: KeycastEnv): Promise<Ke
 export async function banUser(pubkey: string, reason: KeycastReason, env: KeycastEnv): Promise<KeycastResult> {
   return callKeycast(pubkey, { status: 'banned', reason }, env);
 }
+
+export interface UserStatusResult {
+  success: boolean;
+  pubkey?: string;
+  status?: string;
+  suspended_reason?: string;
+  suspended_at?: string;
+  verified_minor?: boolean;
+  verified_minor_at?: string;
+  error?: string;
+}
+
+export async function getUserStatus(pubkey: string, env: KeycastEnv): Promise<UserStatusResult> {
+  if (!env.KEYCAST_URL || !env.KEYCAST_SERVICE_TOKEN) {
+    return { success: false, error: 'not configured' };
+  }
+  if (!HEX_64.test(pubkey)) {
+    return { success: false, error: 'invalid pubkey: must be 64 hex chars' };
+  }
+  const token = await resolveToken(env.KEYCAST_SERVICE_TOKEN);
+  if (!token) {
+    return { success: false, error: 'not configured' };
+  }
+  try {
+    const res = await fetch(`${env.KEYCAST_URL}/api/admin/users/${pubkey}/status`, {
+      headers: { 'Authorization': `Bearer ${token}` },
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      return { success: false, error: `${res.status}: ${text}` };
+    }
+    const data = await res.json() as Record<string, unknown>;
+    return {
+      success: true,
+      pubkey: data.pubkey as string,
+      status: data.status as string,
+      suspended_reason: data.suspended_reason as string | undefined,
+      suspended_at: data.suspended_at as string | undefined,
+      verified_minor: data.verified_minor as boolean | undefined,
+      verified_minor_at: data.verified_minor_at as string | undefined,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { success: false, error: msg };
+  }
+}
+
+export interface CreateMinorAccountResult {
+  success: boolean;
+  pubkey?: string;
+  claim_url?: string;
+  expires_at?: string;
+  error?: string;
+}
+
+export async function createMinorAccount(
+  username: string,
+  displayName: string | undefined,
+  env: KeycastEnv,
+): Promise<CreateMinorAccountResult> {
+  if (!env.KEYCAST_URL || !env.KEYCAST_SERVICE_TOKEN) {
+    return { success: false, error: 'not configured' };
+  }
+  const token = await resolveToken(env.KEYCAST_SERVICE_TOKEN);
+  if (!token) {
+    return { success: false, error: 'not configured' };
+  }
+  try {
+    const body: Record<string, string> = { username };
+    if (displayName) body.display_name = displayName;
+
+    const res = await fetch(`${env.KEYCAST_URL}/api/admin/create-minor-account`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      console.error(`[keycast] create-minor-account failed: ${res.status} ${text}`);
+      return { success: false, error: `${res.status}: ${text}` };
+    }
+    const data = await res.json() as Record<string, unknown>;
+    return {
+      success: true,
+      pubkey: data.pubkey as string,
+      claim_url: data.claim_url as string,
+      expires_at: data.expires_at as string,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[keycast] create-minor-account failed: ${msg}`);
+    return { success: false, error: msg };
+  }
+}


### PR DESCRIPTION
## Summary

- Worker endpoint `POST /api/age-review/create-minor-account` proxies to Keycast, creates D1 audit record with `state=cleared` and `created_via=minor_onboarding`
- ReportWatcher auto-clears age review cases for users with `verified_minor=true` in Keycast (fail-open if Keycast unreachable)
- Admin UI: CreateMinorAccountDialog with username/display name/Zendesk ticket ID form, claim link display on success
- D1 migration + ensureSchema for `created_via` and `claim_link_url` columns
- "Minor Onboarding" and "Auto-cleared" badges in case detail view

Relates to divinevideo/support-trust-safety#148
Part of divinevideo/support-trust-safety#138

Depends on divinevideo/keycast#244 being deployed first (new `create-minor-account` endpoint + `verified_minor` flag on status response).

## Test plan

- [ ] Create minor account via admin UI with username + optional display name + optional Zendesk ticket ID
- [ ] Success state shows pubkey and copyable claim link
- [ ] Invalid username (special chars, too long) shows validation error
- [ ] Duplicate username shows 409 conflict error
- [ ] Created case appears in age review list with "Cleared" state
- [ ] Case detail shows "Minor Onboarding" badge
- [ ] Submit an age report for a verified minor; case auto-clears with "Auto-cleared" badge
- [ ] Submit an age report for a non-verified user; case creates normally with deadline
- [ ] Keycast unreachable during report: case still creates normally (fail-open)

## Local verification

- [x] tsc, eslint, vitest all pass locally
- [x] CreateMinorAccountDialog renders in Age Review tab header
- [x] Dialog opens with username (required), display name (optional), zendesk ticket ID (optional) fields
- [x] Submit button disabled when username is empty
- [x] Vite build succeeds (CI green)