### PR TITLE
perf: use REST API for bulk-moderate video hashes

### DIFF
--- a/worker/src/bulk-moderate.test.ts
+++ b/worker/src/bulk-moderate.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { handleBulkModerate, extractMediaHashes, queryRelayEvents, type BulkModerateEnv } from './bulk-moderate';
+import { handleBulkModerate, queryRelayEvents, type BulkModerateEnv } from './bulk-moderate';
 
 vi.mock('./nip86', () => ({
   getAdminPubkey: vi.fn().mockResolvedValue('moderator-pubkey'),
@@ -205,6 +205,31 @@ describe('handleBulkModerate', () => {
     expect(body.eventsProcessed).toBe(0);
     expect(body.failures[0]).toContain('relay refused');
   });
+
+  it('age-restrict-all fails closed when the videos REST call errors (no false success)', async () => {
+    // A failed enumeration must NOT report a successful withhold; queryUserMediaHashes
+    // throws so the worker returns an error rather than a 200 success.
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('err', { status: 500 }));
+    const request = new Request('https://test/api/bulk-moderate', {
+      method: 'POST',
+      body: JSON.stringify({ pubkey: 'a'.repeat(64), action: 'age-restrict-all' }),
+    });
+    await expect(handleBulkModerate(request, mockEnv, {})).rejects.toThrow(/Video query failed: 500/);
+    expect(vi.mocked((mockEnv.MODERATION_API as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch)).not.toHaveBeenCalled();
+  });
+
+  it('delete-all fails closed when the videos REST call errors (no events banned)', async () => {
+    const { banEvent } = await import('./nip86');
+    vi.mocked(banEvent).mockClear(); // call history accumulates across tests
+    mockRelay([{ id: 'e'.repeat(64), kind: 34235, content: '', tags: [] }]);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('err', { status: 500 }));
+    const request = new Request('https://test/api/bulk-moderate', {
+      method: 'POST',
+      body: JSON.stringify({ pubkey: 'a'.repeat(64), action: 'delete-all' }),
+    });
+    await expect(handleBulkModerate(request, mockEnv, {})).rejects.toThrow(/Video query failed: 500/);
+    expect(vi.mocked(banEvent)).not.toHaveBeenCalled();
+  });
 });
 
 // Paginating mock relay: responds to each REQ with up to `limit` events whose
@@ -261,74 +286,5 @@ describe('queryRelayEvents pagination', () => {
     expect(complete).toBe(false);            // surfaced, not a silent success
     expect(events.length).toBe(500);         // escaped the saturated second after one page
     expect(events.length).toBeLessThan(600); // the excess at that second was not silently claimed as done
-  });
-});
-
-describe('extractMediaHashes', () => {
-  it('extracts sha256 from imeta tags on video events', () => {
-    const events = [
-      {
-        id: 'e1',
-        kind: 34235,
-        content: '',
-        tags: [
-          ['imeta', `url https://example.com/${hashA}.mp4`, 'm video/mp4', `x ${hashA}`],
-          ['imeta', `url https://example.com/${hashB}.jpg`, 'm image/jpeg', `x ${hashB}`],
-        ],
-      },
-    ];
-    const hashes = extractMediaHashes(events);
-    expect(hashes).toContain(hashA);
-    expect(hashes).toContain(hashB);
-    expect(hashes).toHaveLength(2);
-  });
-
-  it('extracts from x tags', () => {
-    const events = [
-      { id: 'e1', kind: 34236, content: '', tags: [['x', hashA]] },
-    ];
-    expect(extractMediaHashes(events)).toEqual([hashA]);
-  });
-
-  it('extracts from content URLs and url tags', () => {
-    const events = [
-      { id: 'e1', kind: 1, content: `https://cdn.test/${hashA}.jpg`, tags: [] },
-      { id: 'e2', kind: 30023, content: '', tags: [['url', `https://cdn.test/${hashB}.png`]] },
-    ];
-    expect(extractMediaHashes(events)).toEqual([hashA, hashB]);
-  });
-
-  it('deduplicates hashes', () => {
-    const events = [
-      { id: 'e1', kind: 34235, content: '', tags: [['x', hashA]] },
-      { id: 'e2', kind: 34236, content: '', tags: [['x', hashA]] },
-    ];
-    expect(extractMediaHashes(events)).toEqual([hashA]);
-  });
-
-  it('ignores thumbnail image hashes embedded in video imeta tags', () => {
-    const events = [
-      {
-        id: 'e1',
-        kind: 34235,
-        content: '',
-        tags: [[
-          'imeta',
-          `url https://media.divine.video/${hashA}`,
-          'm video/mp4',
-          `image https://media.divine.video/${hashB}`,
-          `x ${hashA}`,
-        ]],
-      },
-    ];
-    expect(extractMediaHashes(events)).toEqual([hashA]);
-  });
-
-  it('returns empty array when there are no valid hashes', () => {
-    const events = [
-      { id: 'e1', kind: 1, content: '', tags: [] },
-      { id: 'e2', kind: 30023, content: '', tags: [['x', 'not-a-hash']] },
-    ];
-    expect(extractMediaHashes(events)).toEqual([]);
   });
 });

--- a/worker/src/bulk-moderate.test.ts
+++ b/worker/src/bulk-moderate.test.ts
@@ -50,9 +50,13 @@ function mockRelay(events: Array<{ id: string; kind: number; content?: string; t
 // from the WebSocket REQ used for event IDs.
 function mockUserVideos(videos: Array<{ sha256: string }>) {
   vi.spyOn(globalThis, 'fetch').mockImplementation((async (input: RequestInfo | URL) => {
-    const url = String(input);
-    if (url.includes('/api/users/') && url.includes('/videos')) {
-      return new Response(JSON.stringify(videos), { status: 200 });
+    const url = new URL(String(input));
+    if (url.pathname.includes('/api/users/') && url.pathname.includes('/videos')) {
+      // Honor limit/offset so the mock paginates exactly like funnelcake (default
+      // 25, max 100) -- a non-paginating mock would hide the first-page-only bug.
+      const limit = Number(url.searchParams.get('limit') ?? '25');
+      const offset = Number(url.searchParams.get('offset') ?? '0');
+      return new Response(JSON.stringify(videos.slice(offset, offset + limit)), { status: 200 });
     }
     return new Response('not found', { status: 404 });
   }) as typeof fetch);
@@ -159,6 +163,21 @@ describe('handleBulkModerate', () => {
     expect(moderationActionFor(hashA)).toBe('QUARANTINE');
     expect(moderationActionFor(hashB)).toBe('QUARANTINE');
     expect(moderationActionFor(hashC)).toBe('QUARANTINE');
+  });
+
+  it('pages through ALL videos beyond the funnelcake per-page limit, not just the first page', async () => {
+    // 250 videos = 3 pages (100/100/50). funnelcake caps a page at 100 (default 25),
+    // so without offset paging only the first page would be withheld and the rest
+    // would stay live -- the exact under-enforcement this guards against.
+    const many = Array.from({ length: 250 }, (_, i) => ({ sha256: i.toString(16).padStart(64, '0') }));
+    mockUserVideos(many);
+    const request = new Request('https://test/api/bulk-moderate', {
+      method: 'POST',
+      body: JSON.stringify({ pubkey: 'a'.repeat(64), action: 'age-restrict-all' }),
+    });
+    const response = await handleBulkModerate(request, mockEnv, {});
+    const result = await response.json() as { mediaProcessed: number };
+    expect(result.mediaProcessed).toBe(250);
   });
 
   it('un-age-restrict-all sends SAFE (restore) for media', async () => {

--- a/worker/src/bulk-moderate.test.ts
+++ b/worker/src/bulk-moderate.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { handleBulkModerate, queryRelayEvents, type BulkModerateEnv } from './bulk-moderate';
+import { handleBulkModerate, queryRelayEvents, queryUserMediaHashes, type BulkModerateEnv } from './bulk-moderate';
 
 vi.mock('./nip86', () => ({
   getAdminPubkey: vi.fn().mockResolvedValue('moderator-pubkey'),
@@ -178,6 +178,67 @@ describe('handleBulkModerate', () => {
     const response = await handleBulkModerate(request, mockEnv, {});
     const result = await response.json() as { mediaProcessed: number };
     expect(result.mediaProcessed).toBe(250);
+  });
+
+  it('keeps paging when the server caps a page below the requested limit (no short-page early stop)', async () => {
+    // The server clamps every page to 50 even though we ask for 100. The old
+    // `videos.length < VIDEO_PAGE_SIZE` check read the first 50-row page as the
+    // end and enumerated only page 0. Advancing offset by the actual count and
+    // terminating on an EMPTY page collects all 120.
+    const many = Array.from({ length: 120 }, (_, i) => ({ sha256: i.toString(16).padStart(64, '0') }));
+    vi.spyOn(globalThis, 'fetch').mockImplementation((async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+      if (url.pathname.includes('/api/users/') && url.pathname.includes('/videos')) {
+        const offset = Number(url.searchParams.get('offset') ?? '0');
+        return new Response(JSON.stringify(many.slice(offset, offset + 50)), { status: 200 }); // hard cap at 50
+      }
+      return new Response('not found', { status: 404 });
+    }) as typeof fetch);
+    const hashes = await queryUserMediaHashes('a'.repeat(64), { RELAY_URL: 'wss://relay.test' });
+    expect(hashes).toHaveLength(120);
+  });
+
+  it('enumerates an account whose video count exactly fills the page bound (no false over-limit throw)', async () => {
+    // Exactly 10000 videos: every page is full, so the loop only knows it is done
+    // when the next fetch returns empty. The <= VIDEO_MAX_TOTAL headroom lets that
+    // terminating empty fetch happen instead of throwing on a completed account.
+    const many = Array.from({ length: 10000 }, (_, i) => ({ sha256: i.toString(16).padStart(64, '0') }));
+    mockUserVideos(many);
+    const hashes = await queryUserMediaHashes('a'.repeat(64), { RELAY_URL: 'wss://relay.test' });
+    expect(hashes).toHaveLength(10000);
+  });
+
+  it('throws past the anti-runaway ceiling (over-limit account still fails closed)', async () => {
+    const many = Array.from({ length: 10101 }, (_, i) => ({ sha256: i.toString(16).padStart(64, '0') }));
+    mockUserVideos(many);
+    await expect(queryUserMediaHashes('a'.repeat(64), { RELAY_URL: 'wss://relay.test' }))
+      .rejects.toThrow(/More than 10000 videos/);
+  });
+
+  it('fails closed when a page returns rows but no valid sha256 (shape drift)', async () => {
+    // 200 OK full of rows whose sha256 field is missing/renamed -> zero hashes.
+    // Reporting success here would withhold nothing while showing "done".
+    vi.spyOn(globalThis, 'fetch').mockImplementation((async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+      if (url.pathname.includes('/api/users/') && url.pathname.includes('/videos')) {
+        return new Response(JSON.stringify([{ id: 'v1' }, { id: 'v2' }]), { status: 200 });
+      }
+      return new Response('not found', { status: 404 });
+    }) as typeof fetch);
+    await expect(queryUserMediaHashes('a'.repeat(64), { RELAY_URL: 'wss://relay.test' }))
+      .rejects.toThrow(/no valid sha256/);
+  });
+
+  it('fails closed on a non-array body instead of throwing an opaque "not iterable"', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+      if (url.pathname.includes('/api/users/') && url.pathname.includes('/videos')) {
+        return new Response(JSON.stringify({ videos: [{ sha256: hashA }], total: 1 }), { status: 200 });
+      }
+      return new Response('not found', { status: 404 });
+    }) as typeof fetch);
+    await expect(queryUserMediaHashes('a'.repeat(64), { RELAY_URL: 'wss://relay.test' }))
+      .rejects.toThrow(/non-array body/);
   });
 
   it('un-age-restrict-all sends SAFE (restore) for media', async () => {

--- a/worker/src/bulk-moderate.test.ts
+++ b/worker/src/bulk-moderate.test.ts
@@ -13,6 +13,7 @@ vi.mock('./zendesk-sync', () => ({
 
 const hashA = 'a'.repeat(64);
 const hashB = 'b'.repeat(64);
+const hashC = 'c'.repeat(64);
 
 function mockRelay(events: Array<{ id: string; kind: number; content?: string; tags: string[][] }>) {
   vi.spyOn(globalThis, 'WebSocket').mockImplementation((function () {
@@ -44,11 +45,25 @@ function mockRelay(events: Array<{ id: string; kind: number; content?: string; t
   } as unknown as typeof WebSocket));
 }
 
+// Mock the funnelcake REST videos endpoint that queryUserMediaHashes fetches.
+// This is the dedup-correct source for media hashes (funnelcake#471), distinct
+// from the WebSocket REQ used for event IDs.
+function mockUserVideos(videos: Array<{ sha256: string }>) {
+  vi.spyOn(globalThis, 'fetch').mockImplementation((async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/api/users/') && url.includes('/videos')) {
+      return new Response(JSON.stringify(videos), { status: 200 });
+    }
+    return new Response('not found', { status: 404 });
+  }) as typeof fetch);
+}
+
 describe('handleBulkModerate', () => {
   let mockEnv: BulkModerateEnv;
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockUserVideos([]); // default: no videos unless a test provides them
     mockEnv = {
       NOSTR_NSEC: 'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5',
       RELAY_URL: 'wss://relay.test',
@@ -118,7 +133,7 @@ describe('handleBulkModerate', () => {
   }
 
   it('age-restrict-all sends QUARANTINE (reversible withhold) for media', async () => {
-    mockRelay([{ id: 'e'.repeat(64), kind: 34235, content: '', tags: [['x', hashA]] }]);
+    mockUserVideos([{ sha256: hashA }]); // media hashes come from the REST API now
     const request = new Request('https://test/api/bulk-moderate', {
       method: 'POST',
       body: JSON.stringify({ pubkey: 'a'.repeat(64), action: 'age-restrict-all' }),
@@ -129,14 +144,49 @@ describe('handleBulkModerate', () => {
     expect(moderationActionFor(hashA)).toBe('QUARANTINE');
   });
 
+  it('age-restrict-all QUARANTINEs EVERY video the REST API returns, not 1/kind (funnelcake#471)', async () => {
+    // The WebSocket REQ dedup bug surfaced ~1 video/kind; the REST endpoint
+    // returns all of them. Three same-kind videos must ALL be withheld -- this
+    // is the correctness fix and the guard against regressing to WS extraction.
+    mockUserVideos([{ sha256: hashA }, { sha256: hashB }, { sha256: hashC }]);
+    const request = new Request('https://test/api/bulk-moderate', {
+      method: 'POST',
+      body: JSON.stringify({ pubkey: 'a'.repeat(64), action: 'age-restrict-all' }),
+    });
+    const response = await handleBulkModerate(request, mockEnv, {});
+    const result = await response.json() as { mediaProcessed: number };
+    expect(result.mediaProcessed).toBe(3);
+    expect(moderationActionFor(hashA)).toBe('QUARANTINE');
+    expect(moderationActionFor(hashB)).toBe('QUARANTINE');
+    expect(moderationActionFor(hashC)).toBe('QUARANTINE');
+  });
+
   it('un-age-restrict-all sends SAFE (restore) for media', async () => {
-    mockRelay([{ id: 'e'.repeat(64), kind: 34235, content: '', tags: [['x', hashA]] }]);
+    mockUserVideos([{ sha256: hashA }]);
     const request = new Request('https://test/api/bulk-moderate', {
       method: 'POST',
       body: JSON.stringify({ pubkey: 'a'.repeat(64), action: 'un-age-restrict-all' }),
     });
     await handleBulkModerate(request, mockEnv, {});
     expect(moderationActionFor(hashA)).toBe('SAFE');
+  });
+
+  it('delete-all bans events from the relay (WS) and DELETEs media hashes from the REST API', async () => {
+    // Events still come from the WebSocket (delete needs event IDs); media
+    // hashes come from REST. The WS event's x-tag (hashB) must NOT be the media
+    // source -- only the REST list (hashA) is.
+    mockRelay([{ id: 'e'.repeat(64), kind: 34235, content: '', tags: [['x', hashB]] }]);
+    mockUserVideos([{ sha256: hashA }]);
+    const request = new Request('https://test/api/bulk-moderate', {
+      method: 'POST',
+      body: JSON.stringify({ pubkey: 'a'.repeat(64), action: 'delete-all' }),
+    });
+    const response = await handleBulkModerate(request, mockEnv, {});
+    const result = await response.json() as { eventsProcessed: number; mediaProcessed: number };
+    expect(result.eventsProcessed).toBe(1);
+    expect(result.mediaProcessed).toBe(1);
+    expect(moderationActionFor(hashA)).toBe('DELETE'); // from REST
+    expect(moderationActionFor(hashB)).toBeUndefined(); // NOT from the WS x-tag
   });
 
   it('marks bulk delete as failed when relay deletion returns success false', async () => {

--- a/worker/src/bulk-moderate.ts
+++ b/worker/src/bulk-moderate.ts
@@ -1,7 +1,7 @@
 import { getAdminPubkey, banEvent, publishKind5Deletion, type Nip86Env } from './nip86';
 import { syncZendeskAfterAction, type ZendeskSyncEnv } from './zendesk-sync';
 import { VALID_BULK_ACTIONS, type BulkAction, type BulkModerateResult } from '../../shared/bulk-moderation';
-import { extractMediaHashes as extractSharedMediaHashes } from '../../shared/media-hashes';
+import { deriveFunnelcakeApiUrl } from './funnelcake-proxy';
 
 const BULK_ACTION_CONCURRENCY = 5;
 // Page through ALL of an author's events via `until` cursoring instead of
@@ -16,6 +16,8 @@ export interface BulkModerateEnv extends Nip86Env, ZendeskSyncEnv {
   MODERATION_API?: Fetcher;
   MODERATION_ADMIN_URL?: string;
   SERVICE_API_TOKEN?: string | { get(): Promise<string> };
+  // Explicit Funnelcake REST API URL; derived from RELAY_URL when unset.
+  FUNNELCAKE_API_URL?: string;
 }
 
 interface RelayEventSummary {
@@ -256,30 +258,27 @@ export async function queryRelayEvents(
   });
 }
 
-export function extractMediaHashes(events: RelayEventSummary[]): string[] {
-  const hashes = new Set<string>();
-  for (const event of events) {
-    const eventHashes = extractSharedMediaHashes(event.content, event.tags);
-    eventHashes.forEach((hash) => hashes.add(hash));
-  }
-  return Array.from(hashes);
-}
-
 const SHA256_HEX = /^[a-f0-9]{64}$/i;
+const VIDEO_QUERY_TIMEOUT_MS = 10000;
 
 // Enumerate a user's video media hashes via the Funnelcake REST API instead of a
 // WebSocket REQ. Funnelcake's `relay_events_by_kind_time` materialized view
 // deduplicates addressable video events by (pubkey, kind) rather than
 // (pubkey, kind, d_tag), so a REQ returns only ~1 video/kind (funnelcake#471).
 // The REST endpoint routes through the correct `events_deduped` view and returns
-// `sha256` directly, so every video is actioned. The base URL is derived from
-// RELAY_URL (the relay host also serves the REST surface in every environment).
+// `sha256` directly, so every video is actioned. The base URL goes through the
+// shared deriveFunnelcakeApiUrl so it honors FUNNELCAKE_API_URL when the REST and
+// relay hosts diverge. Bounded by a timeout so a hung endpoint can't stall bulk
+// moderation (for age-restrict this is the only upstream); throws on failure so
+// the caller fails closed rather than reporting a false "withheld everything".
 export async function queryUserMediaHashes(
   pubkey: string,
-  env: Pick<BulkModerateEnv, 'RELAY_URL'>,
+  env: Pick<BulkModerateEnv, 'RELAY_URL' | 'FUNNELCAKE_API_URL'>,
 ): Promise<string[]> {
-  const baseUrl = env.RELAY_URL.replace(/^wss:/, 'https:').replace(/^ws:/, 'http:');
-  const res = await fetch(`${baseUrl}/api/users/${pubkey}/videos`);
+  const baseUrl = deriveFunnelcakeApiUrl(env.RELAY_URL, env.FUNNELCAKE_API_URL);
+  const res = await fetch(`${baseUrl}/api/users/${pubkey}/videos`, {
+    signal: AbortSignal.timeout(VIDEO_QUERY_TIMEOUT_MS),
+  });
   if (!res.ok) {
     throw new Error(`Video query failed: ${res.status}`);
   }

--- a/worker/src/bulk-moderate.ts
+++ b/worker/src/bulk-moderate.ts
@@ -265,7 +265,8 @@ const VIDEO_QUERY_TIMEOUT_MS = 10000; // per page
 // silently action only the first 25 videos and leave the rest live (a withhold
 // gap on a child-safety path). Page at the max size, with a safety bound.
 const VIDEO_PAGE_SIZE = 100;
-const VIDEO_MAX_PAGES = 100; // ~10k videos; throws if exceeded rather than under-enforcing
+const VIDEO_MAX_PAGES = 100;
+const VIDEO_MAX_TOTAL = VIDEO_MAX_PAGES * VIDEO_PAGE_SIZE; // ~10k videos; throws if exceeded rather than under-enforcing
 
 // Enumerate a user's video media hashes via the Funnelcake REST API instead of a
 // WebSocket REQ. Funnelcake's `relay_events_by_kind_time` materialized view
@@ -284,8 +285,15 @@ export async function queryUserMediaHashes(
   const baseUrl = deriveFunnelcakeApiUrl(env.RELAY_URL, env.FUNNELCAKE_API_URL);
   const hashes = new Set<string>();
 
-  for (let page = 0; page < VIDEO_MAX_PAGES; page++) {
-    const offset = page * VIDEO_PAGE_SIZE;
+  // Page until an EMPTY page (the true end of the list), not a short one. The
+  // server may cap a page below the requested limit; reading a short page as
+  // end-of-data would stop after page 0 and leave the rest of an account's media
+  // live on a withhold path. Advance the offset by the actual row count returned
+  // so a server-side cap below VIDEO_PAGE_SIZE can't skip rows. The <= bound gives
+  // one page of headroom so an account whose count exactly fills VIDEO_MAX_TOTAL
+  // terminates via the empty page instead of false-throwing.
+  let offset = 0;
+  while (offset <= VIDEO_MAX_TOTAL) {
     const res = await fetch(
       `${baseUrl}/api/users/${pubkey}/videos?limit=${VIDEO_PAGE_SIZE}&offset=${offset}`,
       { signal: AbortSignal.timeout(VIDEO_QUERY_TIMEOUT_MS) },
@@ -293,21 +301,35 @@ export async function queryUserMediaHashes(
     if (!res.ok) {
       throw new Error(`Video query failed: ${res.status}`);
     }
-    const videos = await res.json() as Array<{ sha256?: string }>;
+    const body = await res.json();
+    if (!Array.isArray(body)) {
+      // A pagination wrapper, null, or an error envelope: don't blindly iterate a
+      // non-array (which would throw an opaque "not iterable"). Fail closed loudly.
+      throw new Error(`Video query returned a non-array body for ${pubkey} (got ${body === null ? 'null' : typeof body})`);
+    }
+    const videos = body as Array<{ sha256?: string }>;
+    if (videos.length === 0) {
+      return Array.from(hashes); // true end of the list
+    }
+    let validInPage = 0;
     for (const v of videos) {
       if (v.sha256 && SHA256_HEX.test(v.sha256)) {
         hashes.add(v.sha256.toLowerCase());
+        validInPage++;
       }
     }
-    // A short page (fewer than the page size) means we've reached the end.
-    if (videos.length < VIDEO_PAGE_SIZE) {
-      return Array.from(hashes);
+    if (validInPage === 0) {
+      // Rows present but none carried a usable sha256: the response shape drifted
+      // (field renamed / non-string). Treating zero hashes as a clean success
+      // would report "withheld everything" having withheld nothing. Fail closed.
+      throw new Error(`Video query returned ${videos.length} rows with no valid sha256 for ${pubkey}; response shape may have changed`);
     }
+    offset += videos.length;
   }
 
-  // Hit the page bound: fail closed rather than silently enforcing over a partial
-  // set on a withhold path.
-  throw new Error(`More than ${VIDEO_MAX_PAGES * VIDEO_PAGE_SIZE} videos for ${pubkey}; narrow the scope or add deeper pagination`);
+  // Past the anti-runaway ceiling without ever seeing an empty page: fail closed
+  // rather than silently enforcing over a partial set on a withhold path.
+  throw new Error(`More than ${VIDEO_MAX_TOTAL} videos for ${pubkey}; narrow the scope or add deeper pagination`);
 }
 
 async function runWithConcurrency<T>(

--- a/worker/src/bulk-moderate.ts
+++ b/worker/src/bulk-moderate.ts
@@ -259,7 +259,13 @@ export async function queryRelayEvents(
 }
 
 const SHA256_HEX = /^[a-f0-9]{64}$/i;
-const VIDEO_QUERY_TIMEOUT_MS = 10000;
+const VIDEO_QUERY_TIMEOUT_MS = 10000; // per page
+// The funnelcake videos endpoint defaults to limit=25 and caps at 100, so we MUST
+// page explicitly: without ?limit + offset paging, bulk delete/age-restrict would
+// silently action only the first 25 videos and leave the rest live (a withhold
+// gap on a child-safety path). Page at the max size, with a safety bound.
+const VIDEO_PAGE_SIZE = 100;
+const VIDEO_MAX_PAGES = 100; // ~10k videos; throws if exceeded rather than under-enforcing
 
 // Enumerate a user's video media hashes via the Funnelcake REST API instead of a
 // WebSocket REQ. Funnelcake's `relay_events_by_kind_time` materialized view
@@ -276,20 +282,32 @@ export async function queryUserMediaHashes(
   env: Pick<BulkModerateEnv, 'RELAY_URL' | 'FUNNELCAKE_API_URL'>,
 ): Promise<string[]> {
   const baseUrl = deriveFunnelcakeApiUrl(env.RELAY_URL, env.FUNNELCAKE_API_URL);
-  const res = await fetch(`${baseUrl}/api/users/${pubkey}/videos`, {
-    signal: AbortSignal.timeout(VIDEO_QUERY_TIMEOUT_MS),
-  });
-  if (!res.ok) {
-    throw new Error(`Video query failed: ${res.status}`);
-  }
-  const videos = await res.json() as Array<{ sha256?: string }>;
   const hashes = new Set<string>();
-  for (const v of videos) {
-    if (v.sha256 && SHA256_HEX.test(v.sha256)) {
-      hashes.add(v.sha256.toLowerCase());
+
+  for (let page = 0; page < VIDEO_MAX_PAGES; page++) {
+    const offset = page * VIDEO_PAGE_SIZE;
+    const res = await fetch(
+      `${baseUrl}/api/users/${pubkey}/videos?limit=${VIDEO_PAGE_SIZE}&offset=${offset}`,
+      { signal: AbortSignal.timeout(VIDEO_QUERY_TIMEOUT_MS) },
+    );
+    if (!res.ok) {
+      throw new Error(`Video query failed: ${res.status}`);
+    }
+    const videos = await res.json() as Array<{ sha256?: string }>;
+    for (const v of videos) {
+      if (v.sha256 && SHA256_HEX.test(v.sha256)) {
+        hashes.add(v.sha256.toLowerCase());
+      }
+    }
+    // A short page (fewer than the page size) means we've reached the end.
+    if (videos.length < VIDEO_PAGE_SIZE) {
+      return Array.from(hashes);
     }
   }
-  return Array.from(hashes);
+
+  // Hit the page bound: fail closed rather than silently enforcing over a partial
+  // set on a withhold path.
+  throw new Error(`More than ${VIDEO_MAX_PAGES * VIDEO_PAGE_SIZE} videos for ${pubkey}; narrow the scope or add deeper pagination`);
 }
 
 async function runWithConcurrency<T>(

--- a/worker/src/bulk-moderate.ts
+++ b/worker/src/bulk-moderate.ts
@@ -49,20 +49,28 @@ export async function handleBulkModerate(
   const action = body.action as BulkAction;
   const reason = body.reason || `Bulk ${action} by moderator`;
 
-  const { events, complete } = await queryRelayEvents(body.pubkey, env);
-  const mediaHashes = extractMediaHashes(events);
   const moderatorPubkey = await getAdminPubkey(env);
   const result: BulkModerateResult = { success: true, eventsProcessed: 0, mediaProcessed: 0, failures: [] };
 
-  // If the relay could not be fully paginated (e.g. more than one page of events
-  // share a single created_at second, which an until-cursor cannot subdivide),
-  // surface it rather than silently enforcing over a partial set. The events we
-  // did gather are still actioned below (best effort).
-  if (!complete) {
-    result.failures.push(`enumeration:${body.pubkey}:relay could not be fully paginated; actioned a partial set`);
-  }
-
   if (action === 'delete-all') {
+    // Events come from the relay (WebSocket, paginated) because delete needs the
+    // event IDs for banevent + kind-5. Media hashes come from the Funnelcake REST
+    // API, which routes through the dedup-correct view and returns ALL of a user's
+    // videos -- the WebSocket REQ returns ~1 video/kind (funnelcake#471). Fetch
+    // both in parallel.
+    const [{ events, complete }, mediaHashes] = await Promise.all([
+      queryRelayEvents(body.pubkey, env),
+      queryUserMediaHashes(body.pubkey, env),
+    ]);
+
+    // If the relay could not be fully paginated (e.g. more than one page of events
+    // share a single created_at second, which an until-cursor cannot subdivide),
+    // surface it rather than silently enforcing over a partial set. The events we
+    // did gather are still actioned below (best effort).
+    if (!complete) {
+      result.failures.push(`enumeration:${body.pubkey}:relay could not be fully paginated; actioned a partial set`);
+    }
+
     const successfulEventIds: string[] = [];
 
     await runWithConcurrency(events, BULK_ACTION_CONCURRENCY, async (event) => {
@@ -109,7 +117,13 @@ export async function handleBulkModerate(
       }
     });
   } else {
-    result.eventsProcessed = events.length;
+    // age-restrict-all / un-age-restrict-all are media-only: no event IDs needed,
+    // so we skip the WebSocket entirely and enumerate media from the REST API
+    // (dedup-correct, all videos -- funnelcake#471).
+    const mediaHashes = await queryUserMediaHashes(body.pubkey, env);
+    // REST returns one entry per video, so video count == event count for video
+    // kinds; report it so the UI's "across N events" stays meaningful.
+    result.eventsProcessed = mediaHashes.length;
     // Age-review restriction must WITHHOLD the media, not adult-gate it.
     // QUARANTINE -> (moderation-service) RESTRICT -> blossom BlobStatus::Restricted,
     // which 404s to everyone except the owner and is reversible to Active. The
@@ -247,6 +261,34 @@ export function extractMediaHashes(events: RelayEventSummary[]): string[] {
   for (const event of events) {
     const eventHashes = extractSharedMediaHashes(event.content, event.tags);
     eventHashes.forEach((hash) => hashes.add(hash));
+  }
+  return Array.from(hashes);
+}
+
+const SHA256_HEX = /^[a-f0-9]{64}$/i;
+
+// Enumerate a user's video media hashes via the Funnelcake REST API instead of a
+// WebSocket REQ. Funnelcake's `relay_events_by_kind_time` materialized view
+// deduplicates addressable video events by (pubkey, kind) rather than
+// (pubkey, kind, d_tag), so a REQ returns only ~1 video/kind (funnelcake#471).
+// The REST endpoint routes through the correct `events_deduped` view and returns
+// `sha256` directly, so every video is actioned. The base URL is derived from
+// RELAY_URL (the relay host also serves the REST surface in every environment).
+export async function queryUserMediaHashes(
+  pubkey: string,
+  env: Pick<BulkModerateEnv, 'RELAY_URL'>,
+): Promise<string[]> {
+  const baseUrl = env.RELAY_URL.replace(/^wss:/, 'https:').replace(/^ws:/, 'http:');
+  const res = await fetch(`${baseUrl}/api/users/${pubkey}/videos`);
+  if (!res.ok) {
+    throw new Error(`Video query failed: ${res.status}`);
+  }
+  const videos = await res.json() as Array<{ sha256?: string }>;
+  const hashes = new Set<string>();
+  for (const v of videos) {
+    if (v.sha256 && SHA256_HEX.test(v.sha256)) {
+      hashes.add(v.sha256.toLowerCase());
+    }
   }
   return Array.from(hashes);
 }


### PR DESCRIPTION
## Summary

- Replaces WebSocket REQ with Funnelcake REST API (`/api/users/{pubkey}/videos`) for fetching video sha256 hashes in bulk-moderate actions
- Fixes silent data loss where age-restrict-all / un-age-restrict-all missed videos due to Funnelcake's addressable event dedup bug
- For delete-all, fetches events (WebSocket) and media hashes (REST) in parallel for correctness and speed

## Motivation

Funnelcake's `relay_events_by_kind_time` materialized view deduplicates addressable events by `(pubkey, kind)` instead of `(pubkey, kind, d_tag)`, returning only 1 video per kind instead of all videos. The REST API routes through the correct `events_deduped` view.

Workaround for divinevideo/divine-funnelcake#471.

Secondary goal: the REST API returns `sha256` directly in the response, eliminating tag parsing and reducing latency vs. a WebSocket REQ round-trip.

## Test plan

- [x] 18 bulk-moderate tests pass (4 new: REST API unit tests)
- [x] Full worker suite: 191 tests pass
- [x] `npx tsc --noEmit` clean
- [ ] Deploy to staging, test age-restrict-all on a multi-video profile
- [ ] Verify all video hashes are sent to moderation service (not just 1)

Closes #107.


---

## Update — rebuilt on current main (force-pushed)

The branch was 20 commits behind main and its old form reverted two landed fixes (#120 `age-restrict-all` → QUARANTINE withhold, and #121 event pagination). I reset it onto current main and re-applied **only** the REST media-hash swap on top, so it preserves both:

- `age-restrict-all` stays `QUARANTINE` (withhold), never `AGE_RESTRICTED` — guarded by a test.
- `queryRelayEvents` stays paginated; the partial-set failure is surfaced for delete-all.

Review fixes also folded in: `queryUserMediaHashes` now routes through the shared `deriveFunnelcakeApiUrl` (honors `FUNNELCAKE_API_URL`, strips trailing slash) and bounds the fetch with a 10s `AbortSignal`; added fail-closed tests (a videos-REST 500 throws, with no moderation calls and no events banned); removed the now-dead WS-based `extractMediaHashes`.

Worker suite green (231); tsc + eslint clean. The funnel-returns-all-videos leg remains a staging smoke test (local funnel `/api/videos` 500s for an unrelated funnelcake-side reason). Sequencing: #134 → this → #135 (async).


---

## Update 2 — paginate the videos endpoint (deploy-review fix)

The funnelcake `/api/users/{pubkey}/videos` endpoint defaults to `limit=25` (max 100). The first rebuild fetched it without `?limit`, so bulk delete/age-restrict would silently action only the first 25 videos and leave the rest live on a withhold path. Now pages at `limit=100` with `offset` until a short page (safety bound that throws rather than under-enforcing), and the test mock honors `limit`/`offset` (with a 250-video / 3-page regression test) so the gap can't hide.
