### PR TITLE
feat(age-review): claim link display + expiry

### DIFF
--- a/shared/age-review.ts
+++ b/shared/age-review.ts
@@ -93,6 +93,7 @@ export interface AgeReviewCase {
   zendesk_ticket_id: number | null;
   created_via: string | null;
   claim_link_url: string | null;
+  claim_link_expires_at: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -154,4 +154,26 @@ describe('AgeReviewDetail', () => {
     expect(screen.getByText(/Expires: N\/A/)).toBeInTheDocument();
     expect(screen.queryByText('Expired')).not.toBeInTheDocument();
   });
+
+  it('does not render the claim link for a non-minor-onboarding terminal case', () => {
+    renderDetail(makeCase({
+      state: 'cleared',
+      created_via: 'report',
+      resolution_note: 'Cleared after review',
+      claim_link_url: 'https://login.test/claim/xyz',
+    }));
+
+    expect(screen.queryByText('Claim Link')).not.toBeInTheDocument();
+  });
+
+  it('does not render the claim link for a minor_onboarding case missing the link', () => {
+    renderDetail(makeCase({
+      state: 'cleared',
+      created_via: 'minor_onboarding',
+      resolution_note: 'Approved via parental consent (minor onboarding)',
+      claim_link_url: null,
+    }));
+
+    expect(screen.queryByText('Claim Link')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -140,4 +140,18 @@ describe('AgeReviewDetail', () => {
 
     expect(screen.getByText('Expired')).toBeInTheDocument();
   });
+
+  it('shows N/A expiry and no Expired badge when claim link has no expiry', () => {
+    renderDetail(makeCase({
+      state: 'cleared',
+      created_via: 'minor_onboarding',
+      resolution_note: 'Approved via parental consent (minor onboarding)',
+      claim_link_url: 'https://login.test/claim/xyz',
+      claim_link_expires_at: null,
+    }));
+
+    expect(screen.getByText('Claim Link')).toBeInTheDocument();
+    expect(screen.getByText(/Expires: N\/A/)).toBeInTheDocument();
+    expect(screen.queryByText('Expired')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -40,6 +40,7 @@ function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
     zendesk_ticket_id: null,
     created_via: null,
     claim_link_url: null,
+    claim_link_expires_at: null,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
     ...overrides,

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -113,4 +113,30 @@ describe('AgeReviewDetail', () => {
       expect(writeText).toHaveBeenCalledWith(caseData.pubkey);
     });
   });
+
+  it('renders the claim link and expiry for a minor_onboarding case', () => {
+    renderDetail(makeCase({
+      state: 'cleared',
+      created_via: 'minor_onboarding',
+      resolution_note: 'Approved via parental consent (minor onboarding)',
+      claim_link_url: 'https://login.test/claim/xyz',
+      claim_link_expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    }));
+
+    expect(screen.getByText('Claim Link')).toBeInTheDocument();
+    expect(screen.getByText(/Expires:/)).toBeInTheDocument();
+    expect(screen.queryByText('Expired')).not.toBeInTheDocument();
+  });
+
+  it('shows an Expired badge when the claim link expiry is in the past', () => {
+    renderDetail(makeCase({
+      state: 'cleared',
+      created_via: 'minor_onboarding',
+      resolution_note: 'Approved via parental consent (minor onboarding)',
+      claim_link_url: 'https://login.test/claim/xyz',
+      claim_link_expires_at: new Date(Date.now() - 1000).toISOString(),
+    }));
+
+    expect(screen.getByText('Expired')).toBeInTheDocument();
+  });
 });

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -104,6 +104,7 @@ export function AgeReviewDetail({ caseData: c }: Props) {
 
   const isTerminal = TERMINAL_STATES.includes(c.state);
   const daysRemaining = getDaysRemaining(c);
+  const claimLinkExpired = c.claim_link_expires_at != null && new Date(c.claim_link_expires_at).getTime() < Date.now();
 
   const updateCase = useMutation({
     mutationFn: (updates: Record<string, unknown>) => {
@@ -411,6 +412,23 @@ export function AgeReviewDetail({ caseData: c }: Props) {
                 <Badge className="bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400 text-[10px]">
                   Minor Onboarding
                 </Badge>
+              )}
+              {c.created_via === 'minor_onboarding' && c.claim_link_url && (
+                <div className="space-y-1.5 pt-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs font-medium text-muted-foreground">Claim Link</span>
+                    {claimLinkExpired && (
+                      <Badge className="bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400 text-[10px] gap-1">
+                        <AlertTriangle className="h-3 w-3" />
+                        Expired
+                      </Badge>
+                    )}
+                  </div>
+                  <CopyableId value={c.claim_link_url} type="hex" size="xs" truncateStart={32} truncateEnd={12} />
+                  <div className="text-xs text-muted-foreground">
+                    Expires: {c.claim_link_expires_at ? new Date(c.claim_link_expires_at).toLocaleDateString() : 'N/A'}
+                  </div>
+                </div>
               )}
               {c.resolution_note.startsWith('Auto-cleared:') && (
                 <Badge className="bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400 text-[10px]">

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -424,7 +424,7 @@ export function AgeReviewDetail({ caseData: c }: Props) {
                       </Badge>
                     )}
                   </div>
-                  <CopyableId value={c.claim_link_url} type="hex" size="xs" truncateStart={32} truncateEnd={12} />
+                  <CopyableId value={c.claim_link_url} type="url" size="xs" truncateStart={32} truncateEnd={12} />
                   <div className="text-xs text-muted-foreground">
                     Expires: {c.claim_link_expires_at ? new Date(c.claim_link_expires_at).toLocaleDateString() : 'N/A'}
                   </div>

--- a/src/components/CopyableId.tsx
+++ b/src/components/CopyableId.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Reusable component for displaying truncated IDs with click-to-copy functionality
-// ABOUTME: Handles event IDs, note IDs, hashes, and npubs with appropriate formatting
+// ABOUTME: Handles event IDs, note IDs, hashes, npubs, and URLs with appropriate formatting
 
 import { useState } from "react";
 import { nip19 } from "nostr-tools";
@@ -15,8 +15,8 @@ import { cn } from "@/lib/utils";
 interface CopyableIdProps {
   /** The raw value to copy (hex id, hash, etc.) */
   value: string;
-  /** Type of ID for formatting. 'note' and 'npub' will encode to bech32 */
-  type?: 'event' | 'note' | 'npub' | 'hash' | 'hex';
+  /** Type of ID for formatting. 'note' and 'npub' will encode to bech32; 'url' and 'hex' are shown verbatim */
+  type?: 'event' | 'note' | 'npub' | 'hash' | 'hex' | 'url';
   /** Number of characters to show at start */
   truncateStart?: number;
   /** Number of characters to show at end */

--- a/worker/migrations/0010_claim_link_expiry.sql
+++ b/worker/migrations/0010_claim_link_expiry.sql
@@ -1,0 +1,2 @@
+-- Persist the claim link expiry for minor onboarding cases
+ALTER TABLE age_review_cases ADD COLUMN claim_link_expires_at TEXT;

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -1486,7 +1486,7 @@ describe('handleCreateMinorAccount', () => {
 
   it('creates account and returns success with claim_url', async () => {
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db }, corsHeaders);
     const body = await res.json() as Record<string, unknown>;
 
     expect(res.status).toBe(200);
@@ -1498,14 +1498,14 @@ describe('handleCreateMinorAccount', () => {
 
   it('rejects missing username', async () => {
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({}), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({}), { DB: db }, corsHeaders);
     expect(res.status).toBe(400);
     expect(mockCreateMinorAccount).not.toHaveBeenCalled();
   });
 
   it('rejects invalid username characters', async () => {
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'BAD USER!' }), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'BAD USER!' }), { DB: db }, corsHeaders);
     expect(res.status).toBe(400);
     expect(mockCreateMinorAccount).not.toHaveBeenCalled();
   });
@@ -1514,7 +1514,7 @@ describe('handleCreateMinorAccount', () => {
     const db = makeMinorDb();
     const res = await handleCreateMinorAccount(
       makeRequest({ username: 'test', display_name: 12345 }),
-      { DB: db } as any,
+      { DB: db },
       corsHeaders,
     );
     expect(res.status).toBe(400);
@@ -1523,7 +1523,7 @@ describe('handleCreateMinorAccount', () => {
 
   it('strips empty display_name before calling Keycast', async () => {
     const db = makeMinorDb();
-    await handleCreateMinorAccount(makeRequest({ username: 'test', display_name: '  ' }), { DB: db } as any, corsHeaders);
+    await handleCreateMinorAccount(makeRequest({ username: 'test', display_name: '  ' }), { DB: db }, corsHeaders);
     expect(mockCreateMinorAccount).toHaveBeenCalledWith('test', undefined, expect.anything());
   });
 
@@ -1531,7 +1531,7 @@ describe('handleCreateMinorAccount', () => {
     const db = makeMinorDb();
     const res = await handleCreateMinorAccount(
       makeRequest({ username: 'test', zendesk_ticket_id: 'abc' }),
-      { DB: db } as any,
+      { DB: db },
       corsHeaders,
     );
     expect(res.status).toBe(400);
@@ -1540,7 +1540,7 @@ describe('handleCreateMinorAccount', () => {
 
   it('returns 500 without claim_url when D1 insert fails after Keycast success', async () => {
     const db = makeMinorDb(() => Promise.reject(new Error('D1 write failed')));
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db }, corsHeaders);
     const body = await res.json() as Record<string, unknown>;
 
     expect(res.status).toBe(500);
@@ -1553,21 +1553,72 @@ describe('handleCreateMinorAccount', () => {
   it('maps Keycast 409 to 409 status', async () => {
     mockCreateMinorAccount.mockResolvedValue({ success: false, error: '409: Username taken' });
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'taken' }), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'taken' }), { DB: db }, corsHeaders);
     expect(res.status).toBe(409);
   });
 
   it('maps other Keycast 4xx to 400 status', async () => {
     mockCreateMinorAccount.mockResolvedValue({ success: false, error: '422: Invalid input' });
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db }, corsHeaders);
     expect(res.status).toBe(400);
   });
 
   it('maps Keycast server errors to 502 status', async () => {
     mockCreateMinorAccount.mockResolvedValue({ success: false, error: 'Connection refused' });
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db }, corsHeaders);
     expect(res.status).toBe(502);
+  });
+
+  it('persists claim_link_expires_at from the Keycast response', async () => {
+    const bindArgs: unknown[] = [];
+    const db = {
+      prepare: vi.fn().mockReturnValue({
+        bind: vi.fn().mockImplementation((...args: unknown[]) => {
+          bindArgs.push(...args);
+          return { run: vi.fn().mockResolvedValue({ success: true }) };
+        }),
+      }),
+    };
+
+    const res = await handleCreateMinorAccount(
+      makeRequest({ username: 'testuser' }),
+      { DB: db as unknown as D1Database },
+      corsHeaders,
+    );
+
+    expect(res.status).toBe(200);
+    // The INSERT binds claim_link_expires_at; the Keycast mock returns 2026-06-15T00:00:00Z
+    expect(bindArgs).toContain('2026-06-15T00:00:00Z');
+  });
+
+  it('persists null claim_link_expires_at when Keycast omits expires_at', async () => {
+    mockCreateMinorAccount.mockResolvedValue({
+      success: true,
+      pubkey: 'a'.repeat(64),
+      claim_url: 'https://login.test/claim/abc',
+    });
+
+    const bindArgs: unknown[] = [];
+    const db = {
+      prepare: vi.fn().mockReturnValue({
+        bind: vi.fn().mockImplementation((...args: unknown[]) => {
+          bindArgs.push(...args);
+          return { run: vi.fn().mockResolvedValue({ success: true }) };
+        }),
+      }),
+    };
+
+    const res = await handleCreateMinorAccount(
+      makeRequest({ username: 'testuser' }),
+      { DB: db as unknown as D1Database },
+      corsHeaders,
+    );
+
+    expect(res.status).toBe(200);
+    // claim_url is present (so it binds), but expires_at is absent -> bound as null
+    expect(bindArgs).toContain('https://login.test/claim/abc');
+    expect(bindArgs).toContain(null);
   });
 });

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -1589,8 +1589,10 @@ describe('handleCreateMinorAccount', () => {
     );
 
     expect(res.status).toBe(200);
-    // The INSERT binds claim_link_expires_at; the Keycast mock returns 2026-06-15T00:00:00Z
-    expect(bindArgs).toContain('2026-06-15T00:00:00Z');
+    // INSERT bind order: caseId, pubkey, claim_url, claim_link_expires_at, zendesk_ticket_id.
+    // Assert positionally so this also guards the column/bind ordering.
+    expect(bindArgs[2]).toBe('https://login.test/claim/abc');
+    expect(bindArgs[3]).toBe('2026-06-15T00:00:00Z');
   });
 
   it('persists null claim_link_expires_at when Keycast omits expires_at', async () => {
@@ -1617,8 +1619,9 @@ describe('handleCreateMinorAccount', () => {
     );
 
     expect(res.status).toBe(200);
-    // claim_url is present (so it binds), but expires_at is absent -> bound as null
-    expect(bindArgs).toContain('https://login.test/claim/abc');
-    expect(bindArgs).toContain(null);
+    // claim_url is present (binds at index 2), but expires_at is absent -> bound as null at index 3.
+    // Assert positionally: toContain(null) would also match the null zendesk_ticket_id.
+    expect(bindArgs[2]).toBe('https://login.test/claim/abc');
+    expect(bindArgs[3]).toBeNull();
   });
 });

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -1486,7 +1486,7 @@ describe('handleCreateMinorAccount', () => {
 
   it('creates account and returns success with claim_url', async () => {
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db }, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db as unknown as D1Database }, corsHeaders);
     const body = await res.json() as Record<string, unknown>;
 
     expect(res.status).toBe(200);
@@ -1498,14 +1498,14 @@ describe('handleCreateMinorAccount', () => {
 
   it('rejects missing username', async () => {
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({}), { DB: db }, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({}), { DB: db as unknown as D1Database }, corsHeaders);
     expect(res.status).toBe(400);
     expect(mockCreateMinorAccount).not.toHaveBeenCalled();
   });
 
   it('rejects invalid username characters', async () => {
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'BAD USER!' }), { DB: db }, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'BAD USER!' }), { DB: db as unknown as D1Database }, corsHeaders);
     expect(res.status).toBe(400);
     expect(mockCreateMinorAccount).not.toHaveBeenCalled();
   });
@@ -1514,7 +1514,7 @@ describe('handleCreateMinorAccount', () => {
     const db = makeMinorDb();
     const res = await handleCreateMinorAccount(
       makeRequest({ username: 'test', display_name: 12345 }),
-      { DB: db },
+      { DB: db as unknown as D1Database },
       corsHeaders,
     );
     expect(res.status).toBe(400);
@@ -1523,7 +1523,7 @@ describe('handleCreateMinorAccount', () => {
 
   it('strips empty display_name before calling Keycast', async () => {
     const db = makeMinorDb();
-    await handleCreateMinorAccount(makeRequest({ username: 'test', display_name: '  ' }), { DB: db }, corsHeaders);
+    await handleCreateMinorAccount(makeRequest({ username: 'test', display_name: '  ' }), { DB: db as unknown as D1Database }, corsHeaders);
     expect(mockCreateMinorAccount).toHaveBeenCalledWith('test', undefined, expect.anything());
   });
 
@@ -1531,7 +1531,7 @@ describe('handleCreateMinorAccount', () => {
     const db = makeMinorDb();
     const res = await handleCreateMinorAccount(
       makeRequest({ username: 'test', zendesk_ticket_id: 'abc' }),
-      { DB: db },
+      { DB: db as unknown as D1Database },
       corsHeaders,
     );
     expect(res.status).toBe(400);
@@ -1540,7 +1540,7 @@ describe('handleCreateMinorAccount', () => {
 
   it('returns 500 without claim_url when D1 insert fails after Keycast success', async () => {
     const db = makeMinorDb(() => Promise.reject(new Error('D1 write failed')));
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db }, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db as unknown as D1Database }, corsHeaders);
     const body = await res.json() as Record<string, unknown>;
 
     expect(res.status).toBe(500);
@@ -1553,21 +1553,21 @@ describe('handleCreateMinorAccount', () => {
   it('maps Keycast 409 to 409 status', async () => {
     mockCreateMinorAccount.mockResolvedValue({ success: false, error: '409: Username taken' });
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'taken' }), { DB: db }, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'taken' }), { DB: db as unknown as D1Database }, corsHeaders);
     expect(res.status).toBe(409);
   });
 
   it('maps other Keycast 4xx to 400 status', async () => {
     mockCreateMinorAccount.mockResolvedValue({ success: false, error: '422: Invalid input' });
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db }, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db as unknown as D1Database }, corsHeaders);
     expect(res.status).toBe(400);
   });
 
   it('maps Keycast server errors to 502 status', async () => {
     mockCreateMinorAccount.mockResolvedValue({ success: false, error: 'Connection refused' });
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db }, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db as unknown as D1Database }, corsHeaders);
     expect(res.status).toBe(502);
   });
 

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -335,9 +335,9 @@ export async function handleCreateMinorAccount(
   try {
     await env.DB.prepare(`
       INSERT INTO age_review_cases
-      (id, pubkey, suspected_age_band, state, allowed_resolution, resolution_note, created_via, claim_link_url, zendesk_ticket_id)
-      VALUES (?, ?, 'age_13_15', 'cleared', 'parent_video_or_email', 'Approved via parental consent (minor onboarding)', 'minor_onboarding', ?, ?)
-    `).bind(caseId, result.pubkey, result.claim_url, body.zendesk_ticket_id ?? null).run();
+      (id, pubkey, suspected_age_band, state, allowed_resolution, resolution_note, created_via, claim_link_url, claim_link_expires_at, zendesk_ticket_id)
+      VALUES (?, ?, 'age_13_15', 'cleared', 'parent_video_or_email', 'Approved via parental consent (minor onboarding)', 'minor_onboarding', ?, ?, ?)
+    `).bind(caseId, result.pubkey, result.claim_url, result.expires_at ?? null, body.zendesk_ticket_id ?? null).run();
   } catch (err) {
     console.error(`[age-review] D1 audit record failed for minor account: pubkey=${result.pubkey}, case=${caseId}`, err);
     return json({

--- a/worker/src/db.ts
+++ b/worker/src/db.ts
@@ -71,6 +71,7 @@ export async function ensureSchema(db: D1Database): Promise<void> {
       zendesk_ticket_id INTEGER,
       created_via TEXT DEFAULT 'report',
       claim_link_url TEXT,
+      claim_link_expires_at TEXT,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT DEFAULT CURRENT_TIMESTAMP
     )
@@ -91,6 +92,12 @@ export async function ensureSchema(db: D1Database): Promise<void> {
 
   try {
     await db.prepare(`ALTER TABLE age_review_cases ADD COLUMN claim_link_url TEXT`).run();
+  } catch {
+    // Column already exists
+  }
+
+  try {
+    await db.prepare(`ALTER TABLE age_review_cases ADD COLUMN claim_link_expires_at TEXT`).run();
   } catch {
     // Column already exists
   }


### PR DESCRIPTION
Closes #92. Addresses #93 Part A (expiry persistence + display). #93 Part B (link regeneration) stays open pending a Keycast capability spike.

## What this does

Lets a moderator retrieve and act on an approved-minor onboarding claim link after the creation dialog is closed, and see when it expires.

## Changes

- **`worker/src/db.ts`** — added `claim_link_expires_at TEXT` to `age_review_cases` (added to `CREATE TABLE` plus an idempotent `ALTER` in `ensureSchema`, matching the `created_via`/`claim_link_url` pattern) + mirror migration `worker/migrations/0010_claim_link_expiry.sql`.
- **`worker/src/age-review.ts`** — `handleCreateMinorAccount` now persists `result.expires_at` into `claim_link_expires_at` (stores `null` when Keycast omits it).
- **`shared/age-review.ts`** — added `claim_link_expires_at: string | null` to `AgeReviewCase`.
- **`src/components/AgeReviewDetail.tsx`** — in the `created_via === 'minor_onboarding'` block, renders the claim link (via `CopyableId`) and the expiry date, with an "Expired" badge when the expiry is in the past.
- **`src/components/CopyableId.tsx`** — added a semantic `'url'` type (used for the claim link; previously reused `'hex'`).

## Tests

- `worker/src/age-review.test.ts` — persists `claim_link_expires_at`; stores `null` when absent.
- `src/components/AgeReviewDetail.test.tsx` — renders claim link + expiry; shows Expired badge when past; shows `N/A` when no expiry.

## Notes

- Also normalizes the pre-existing `{ DB: db } as any` casts in `age-review.test.ts` to `{ DB: db as unknown as D1Database }`. This is the inherited PR #90 lint fix that keeps `main` red; it is **identical to the same fix in #89 and #98**, so these merge in any order without conflict.
- The exposed worker-`tsc` typing gap in `age-review.test.ts` (not gated in CI) is tracked in #99, to be cleaned up once these land.

## Merge order

Independent of the suspend-path PR (#98) — disjoint files. Any order. CI green.
