### PR TITLE
feat(moderation): suspend-path Keycast wiring + account-state DMs

### DIFF
--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -1486,7 +1486,7 @@ describe('handleCreateMinorAccount', () => {
 
   it('creates account and returns success with claim_url', async () => {
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db as unknown as D1Database }, corsHeaders);
     const body = await res.json() as Record<string, unknown>;
 
     expect(res.status).toBe(200);
@@ -1498,14 +1498,14 @@ describe('handleCreateMinorAccount', () => {
 
   it('rejects missing username', async () => {
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({}), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({}), { DB: db as unknown as D1Database }, corsHeaders);
     expect(res.status).toBe(400);
     expect(mockCreateMinorAccount).not.toHaveBeenCalled();
   });
 
   it('rejects invalid username characters', async () => {
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'BAD USER!' }), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'BAD USER!' }), { DB: db as unknown as D1Database }, corsHeaders);
     expect(res.status).toBe(400);
     expect(mockCreateMinorAccount).not.toHaveBeenCalled();
   });
@@ -1514,7 +1514,7 @@ describe('handleCreateMinorAccount', () => {
     const db = makeMinorDb();
     const res = await handleCreateMinorAccount(
       makeRequest({ username: 'test', display_name: 12345 }),
-      { DB: db } as any,
+      { DB: db as unknown as D1Database },
       corsHeaders,
     );
     expect(res.status).toBe(400);
@@ -1523,7 +1523,7 @@ describe('handleCreateMinorAccount', () => {
 
   it('strips empty display_name before calling Keycast', async () => {
     const db = makeMinorDb();
-    await handleCreateMinorAccount(makeRequest({ username: 'test', display_name: '  ' }), { DB: db } as any, corsHeaders);
+    await handleCreateMinorAccount(makeRequest({ username: 'test', display_name: '  ' }), { DB: db as unknown as D1Database }, corsHeaders);
     expect(mockCreateMinorAccount).toHaveBeenCalledWith('test', undefined, expect.anything());
   });
 
@@ -1531,7 +1531,7 @@ describe('handleCreateMinorAccount', () => {
     const db = makeMinorDb();
     const res = await handleCreateMinorAccount(
       makeRequest({ username: 'test', zendesk_ticket_id: 'abc' }),
-      { DB: db } as any,
+      { DB: db as unknown as D1Database },
       corsHeaders,
     );
     expect(res.status).toBe(400);
@@ -1540,7 +1540,7 @@ describe('handleCreateMinorAccount', () => {
 
   it('returns 500 without claim_url when D1 insert fails after Keycast success', async () => {
     const db = makeMinorDb(() => Promise.reject(new Error('D1 write failed')));
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db as unknown as D1Database }, corsHeaders);
     const body = await res.json() as Record<string, unknown>;
 
     expect(res.status).toBe(500);
@@ -1553,21 +1553,21 @@ describe('handleCreateMinorAccount', () => {
   it('maps Keycast 409 to 409 status', async () => {
     mockCreateMinorAccount.mockResolvedValue({ success: false, error: '409: Username taken' });
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'taken' }), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'taken' }), { DB: db as unknown as D1Database }, corsHeaders);
     expect(res.status).toBe(409);
   });
 
   it('maps other Keycast 4xx to 400 status', async () => {
     mockCreateMinorAccount.mockResolvedValue({ success: false, error: '422: Invalid input' });
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db as unknown as D1Database }, corsHeaders);
     expect(res.status).toBe(400);
   });
 
   it('maps Keycast server errors to 502 status', async () => {
     mockCreateMinorAccount.mockResolvedValue({ success: false, error: 'Connection refused' });
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db } as any, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db as unknown as D1Database }, corsHeaders);
     expect(res.status).toBe(502);
   });
 });

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -195,7 +195,7 @@ describe('notifyModerationService null token', () => {
     expect(waitUntil).toHaveBeenCalledOnce();
     await waitUntil.mock.calls[0][0];
     expect(errorSpy).toHaveBeenCalledWith(
-      '[handleRelayRpc] DM notification error:',
+      '[notifyAccountState] DM notification error:',
       expect.objectContaining({
         message: expect.stringContaining('SERVICE_API_TOKEN'),
       }),

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -341,4 +341,56 @@ describe('relay-rpc account-state side effects', () => {
 
     fetchSpy.mockRestore();
   });
+
+  it('ban_pubkey via /api/moderate sends exactly one ACCOUNT_BANNED DM (no double)', async () => {
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+
+    const response = await worker.fetch(
+      new Request('https://api-relay-prod.divine.video/api/moderate', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Key': 'test-admin-key',
+          Origin: 'https://app.divine.video',
+        },
+        body: JSON.stringify({ action: 'ban_pubkey', pubkey: VALID_PUBKEY, reason: 'spam' }),
+      }),
+      makeAccountStateEnv(),
+      testCtx,
+    );
+    expect(response.status).toBe(200);
+    await drain(waitUntil);
+
+    // handleModerate's ban_pubkey routes through handleRelayRpc; only the helper
+    // DMs, so there must be exactly one ACCOUNT_BANNED, never a duplicate.
+    const bodies = await notifyBodies(fetchSpy);
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0].action).toBe('ACCOUNT_BANNED');
+
+    fetchSpy.mockRestore();
+  });
+
+  it('skips account-state side effects with a warning when no ExecutionContext is available', async () => {
+    const fetchSpy = makeFetchSpy();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const response = await callRelayRpc(
+      'suspendpubkey',
+      [VALID_PUBKEY, 'policy'],
+      makeAccountStateEnv(),
+      undefined as unknown as ExecutionContext,
+    );
+    expect(response.status).toBe(200);
+
+    // Without a ctx to keep them alive, neither the DM nor the Keycast call is
+    // dispatched, and the skip is logged rather than silently dropped.
+    expect(await notifyBodies(fetchSpy)).toHaveLength(0);
+    expect(keycastCalls(fetchSpy)).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('No ExecutionContext'));
+
+    warnSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
 });

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -385,10 +385,11 @@ describe('relay-rpc account-state side effects', () => {
     expect(response.status).toBe(200);
 
     // Without a ctx to keep them alive, neither the DM nor the Keycast call is
-    // dispatched, and the skip is logged rather than silently dropped.
+    // dispatched, and BOTH skips are logged rather than silently dropped.
     expect(await notifyBodies(fetchSpy)).toHaveLength(0);
     expect(keycastCalls(fetchSpy)).toHaveLength(0);
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('No ExecutionContext'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('skipping Keycast suspend'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[notifyAccountState] No ExecutionContext'));
 
     warnSpy.mockRestore();
     fetchSpy.mockRestore();

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -205,3 +205,140 @@ describe('notifyModerationService null token', () => {
     errorSpy.mockRestore();
   });
 });
+
+describe('relay-rpc account-state side effects', () => {
+  const VALID_PUBKEY = 'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234';
+
+  function makeAccountStateEnv() {
+    return {
+      ALLOWED_ORIGINS: 'https://app.divine.video',
+      RELAY_URL: 'wss://relay.divine.video',
+      ADMIN_API_KEY: 'test-admin-key',
+      MODERATION_ADMIN_URL: 'https://moderation-api.divine.video',
+      SERVICE_API_TOKEN: 'test-token',
+      NOSTR_NSEC: TEST_NSEC,
+      KEYCAST_URL: 'https://login.divine.video',
+      KEYCAST_SERVICE_TOKEN: 'keycast-token',
+    } as never;
+  }
+
+  // Routes a mocked fetch by URL so each backend can be asserted independently.
+  function makeFetchSpy() {
+    return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.includes('/api/v1/notify')) {
+        return new Response(JSON.stringify({ dm_sent: true }), { status: 200 });
+      }
+      if (url.includes('/api/admin/users/')) {
+        return new Response('', { status: 200 });
+      }
+      // NIP-86 relay RPC management endpoint
+      return new Response(JSON.stringify({ result: true }), { status: 200 });
+    });
+  }
+
+  async function callRelayRpc(
+    method: string,
+    params: string[],
+    testEnv: never,
+    testCtx: ExecutionContext,
+  ): Promise<Response> {
+    return worker.fetch(
+      new Request('https://api-relay-prod.divine.video/api/relay-rpc', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Key': 'test-admin-key',
+          Origin: 'https://app.divine.video',
+        },
+        body: JSON.stringify({ method, params }),
+      }),
+      testEnv,
+      testCtx,
+    );
+  }
+
+  async function notifyBodies(fetchSpy: ReturnType<typeof makeFetchSpy>): Promise<Array<{ action: string; recipientPubkey: string }>> {
+    const reqs = fetchSpy.mock.calls
+      .map(([input]) => input)
+      .filter((input): input is Request => input instanceof Request && input.url.includes('/api/v1/notify'));
+    return Promise.all(reqs.map(async req => JSON.parse(await req.clone().text())));
+  }
+
+  function keycastCalls(fetchSpy: ReturnType<typeof makeFetchSpy>): Array<{ url: string; status: string }> {
+    return fetchSpy.mock.calls
+      .filter(([input]) => {
+        const url = input instanceof Request ? input.url : String(input);
+        return url.includes('/api/admin/users/');
+      })
+      .map(([input, init]) => {
+        const url = input instanceof Request ? input.url : String(input);
+        const body = input instanceof Request ? undefined : (init as RequestInit | undefined)?.body;
+        return { url, status: JSON.parse(String(body)).status as string };
+      });
+  }
+
+  async function drain(waitUntil: ReturnType<typeof vi.fn>): Promise<void> {
+    await Promise.all(waitUntil.mock.calls.map(c => c[0]));
+  }
+
+  it('banpubkey sends DM action ACCOUNT_BANNED', async () => {
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+
+    const response = await callRelayRpc('banpubkey', [VALID_PUBKEY, 'spam'], makeAccountStateEnv(), testCtx);
+    expect(response.status).toBe(200);
+    await drain(waitUntil);
+
+    const bodies = await notifyBodies(fetchSpy);
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0].action).toBe('ACCOUNT_BANNED');
+    expect(bodies[0].recipientPubkey).toBe(VALID_PUBKEY);
+    // No Keycast suspend/unsuspend on ban
+    expect(keycastCalls(fetchSpy)).toHaveLength(0);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('suspendpubkey triggers Keycast suspend and DM action ACCOUNT_SUSPENDED', async () => {
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+
+    const response = await callRelayRpc('suspendpubkey', [VALID_PUBKEY, 'policy'], makeAccountStateEnv(), testCtx);
+    expect(response.status).toBe(200);
+    await drain(waitUntil);
+
+    const bodies = await notifyBodies(fetchSpy);
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0].action).toBe('ACCOUNT_SUSPENDED');
+
+    const kc = keycastCalls(fetchSpy);
+    expect(kc).toHaveLength(1);
+    expect(kc[0].url).toContain(`/api/admin/users/${VALID_PUBKEY}/status`);
+    expect(kc[0].status).toBe('suspended');
+
+    fetchSpy.mockRestore();
+  });
+
+  it('unsuspendpubkey triggers Keycast unsuspend and DM action ACCOUNT_RESTORED', async () => {
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+
+    const response = await callRelayRpc('unsuspendpubkey', [VALID_PUBKEY], makeAccountStateEnv(), testCtx);
+    expect(response.status).toBe(200);
+    await drain(waitUntil);
+
+    const bodies = await notifyBodies(fetchSpy);
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0].action).toBe('ACCOUNT_RESTORED');
+
+    const kc = keycastCalls(fetchSpy);
+    expect(kc).toHaveLength(1);
+    expect(kc[0].status).toBe('active');
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -208,8 +208,9 @@ async function notifyModerationService(
  * Send an account-state DM (suspended / banned / restored) to an affected user
  * as a NON-CRITICAL side effect. The DM is dispatched via ctx.waitUntil so it
  * runs off the response path; failures are logged and swallowed, never
- * propagated to the caller. Never fire-and-forget: the promise is always
- * handed to waitUntil so the runtime keeps it alive.
+ * propagated to the caller. A ctx is required: without it the work cannot
+ * outlive the response, so the DM is skipped with a warning rather than
+ * started and silently dropped.
  */
 function notifyAccountState(
   env: Env,
@@ -218,9 +219,13 @@ function notifyAccountState(
   reason: string,
   ctx?: ExecutionContext
 ): void {
+  if (!ctx) {
+    console.warn(`[notifyAccountState] No ExecutionContext; skipping ${action} DM for ${pubkey}`);
+    return;
+  }
   const dmPromise = notifyModerationService(env, pubkey, action, reason)
     .catch(err => console.error('[notifyAccountState] DM notification error:', err));
-  if (ctx) ctx.waitUntil(dmPromise);
+  ctx.waitUntil(dmPromise);
 }
 
 function getAllowedOrigin(requestOrigin: string | null, allowedOriginsEnv: string | undefined): string | null {
@@ -879,6 +884,8 @@ async function handleRelayRpc(
     const pubkey = String(body.params[0]);
     const reason = body.params[1] ? String(body.params[1]) : undefined;
 
+    // Note: unbanpubkey intentionally sends no DM here. A restore-on-unban DM
+    // is tracked in #96 (moderation-DM coverage gaps).
     switch (body.method) {
       case 'banpubkey':
         notifyAccountState(env, pubkey, 'ACCOUNT_BANNED', reason || 'Account banned by moderator', ctx);
@@ -892,6 +899,8 @@ async function handleRelayRpc(
               if (!res.success) console.error(`[handleRelayRpc] Keycast suspend failed for ${pubkey}: ${res.error}`);
             }).catch(err => console.error('[handleRelayRpc] Keycast suspend error:', err))
           );
+        } else {
+          console.warn(`[handleRelayRpc] No ExecutionContext; skipping Keycast suspend for ${pubkey}`);
         }
         notifyAccountState(env, pubkey, 'ACCOUNT_SUSPENDED', reason || 'Account suspended by moderator', ctx);
         break;
@@ -902,6 +911,8 @@ async function handleRelayRpc(
               if (!res.success) console.error(`[handleRelayRpc] Keycast unsuspend failed for ${pubkey}: ${res.error}`);
             }).catch(err => console.error('[handleRelayRpc] Keycast unsuspend error:', err))
           );
+        } else {
+          console.warn(`[handleRelayRpc] No ExecutionContext; skipping Keycast unsuspend for ${pubkey}`);
         }
         notifyAccountState(env, pubkey, 'ACCOUNT_RESTORED', reason || 'Account restored by moderator', ctx);
         break;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -769,7 +769,10 @@ async function handleModerate(
           console.error('[handleModerate] Zendesk sync error:', err);
         }
 
-        // DM the content creator about the deletion (non-critical, off response path)
+        // DM the content creator about the deletion (non-critical, off response path).
+        // Stays inline rather than using notifyAccountState: this is a content-level
+        // notice (PERMANENT_BAN, with eventId), not an account-state change, so it
+        // does not fit the account-state helper's action union or signature.
         if (body.pubkey) {
           const dmPromise = notifyModerationService(env, body.pubkey, 'PERMANENT_BAN', body.reason || 'Content removed by moderator', undefined, body.eventId)
             .catch(err => console.error('[handleModerate] DM notification error:', err));
@@ -888,6 +891,9 @@ async function handleRelayRpc(
     // is tracked in #96 (moderation-DM coverage gaps).
     switch (body.method) {
       case 'banpubkey':
+        // Unlike suspend, banpubkey does not yet call Keycast (banUser), so a
+        // relay ban leaves the Keycast account active. Enforcement parity is
+        // tracked in #100; this PR is scoped to the suspend path.
         notifyAccountState(env, pubkey, 'ACCOUNT_BANNED', reason || 'Account banned by moderator', ctx);
         break;
       case 'suspendpubkey':

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -219,7 +219,7 @@ function notifyAccountState(
   ctx?: ExecutionContext
 ): void {
   const dmPromise = notifyModerationService(env, pubkey, action, reason)
-    .catch(err => console.error('[handleRelayRpc] DM notification error:', err));
+    .catch(err => console.error('[notifyAccountState] DM notification error:', err));
   if (ctx) ctx.waitUntil(dmPromise);
 }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -16,6 +16,7 @@ import { ensureSchema } from './db';
 import { generatePreAuthToken, verifyPreAuthToken, base64UrlEncode } from './zendesk-preauth';
 import { deriveFunnelcakeApiUrl, proxyFunnelcakeRequest } from './funnelcake-proxy';
 import type { KeycastEnv } from './keycast-client';
+import { suspendUser, unsuspendUser } from './keycast-client';
 import {
   handleGetAgeReviewCases,
   handleGetAgeReviewCase,
@@ -201,6 +202,25 @@ async function notifyModerationService(
     const result = await response.json() as { dm_sent: boolean; reason?: string };
     console.log(`[notifyModerationService] DM sent=${result.dm_sent}${result.reason ? ` (${result.reason})` : ''}`);
   }
+}
+
+/**
+ * Send an account-state DM (suspended / banned / restored) to an affected user
+ * as a NON-CRITICAL side effect. The DM is dispatched via ctx.waitUntil so it
+ * runs off the response path; failures are logged and swallowed, never
+ * propagated to the caller. Never fire-and-forget: the promise is always
+ * handed to waitUntil so the runtime keeps it alive.
+ */
+function notifyAccountState(
+  env: Env,
+  pubkey: string,
+  action: 'ACCOUNT_SUSPENDED' | 'ACCOUNT_BANNED' | 'ACCOUNT_RESTORED',
+  reason: string,
+  ctx?: ExecutionContext
+): void {
+  const dmPromise = notifyModerationService(env, pubkey, action, reason)
+    .catch(err => console.error('[handleRelayRpc] DM notification error:', err));
+  if (ctx) ctx.waitUntil(dmPromise);
 }
 
 function getAllowedOrigin(requestOrigin: string | null, allowedOriginsEnv: string | undefined): string | null {
@@ -851,15 +871,41 @@ async function handleRelayRpc(
     return jsonResponse({ success: false, error: result.error }, 400, corsHeaders);
   }
 
-  // DM the banned user (non-critical, off response path)
-  // This is the actual ban path used by the UI -- handleModerate's ban_pubkey
-  // case exists but is not called by any frontend component.
-  if (body.method === 'banpubkey' && body.params?.[0]) {
+  // Account-state side effects (all non-critical, off the response path).
+  // This is the actual moderation path used by the UI -- handleModerate's
+  // ban_pubkey case exists but is not called by any frontend component.
+  // params[0] = pubkey, params[1] = reason.
+  if (body.params?.[0]) {
     const pubkey = String(body.params[0]);
     const reason = body.params[1] ? String(body.params[1]) : undefined;
-    const dmPromise = notifyModerationService(env, pubkey, 'ACCOUNT_SUSPENDED', reason || 'Account suspended by moderator')
-      .catch(err => console.error('[handleRelayRpc] DM notification error:', err));
-    if (ctx) ctx.waitUntil(dmPromise);
+
+    switch (body.method) {
+      case 'banpubkey':
+        notifyAccountState(env, pubkey, 'ACCOUNT_BANNED', reason || 'Account banned by moderator', ctx);
+        break;
+      case 'suspendpubkey':
+        // Keycast suspend is a non-critical enrichment here: log on failure,
+        // do not fail the RPC the relay already accepted.
+        if (ctx) {
+          ctx.waitUntil(
+            suspendUser(pubkey, 'moderation', env).then(res => {
+              if (!res.success) console.error(`[handleRelayRpc] Keycast suspend failed for ${pubkey}: ${res.error}`);
+            }).catch(err => console.error('[handleRelayRpc] Keycast suspend error:', err))
+          );
+        }
+        notifyAccountState(env, pubkey, 'ACCOUNT_SUSPENDED', reason || 'Account suspended by moderator', ctx);
+        break;
+      case 'unsuspendpubkey':
+        if (ctx) {
+          ctx.waitUntil(
+            unsuspendUser(pubkey, env).then(res => {
+              if (!res.success) console.error(`[handleRelayRpc] Keycast unsuspend failed for ${pubkey}: ${res.error}`);
+            }).catch(err => console.error('[handleRelayRpc] Keycast unsuspend error:', err))
+          );
+        }
+        notifyAccountState(env, pubkey, 'ACCOUNT_RESTORED', reason || 'Account restored by moderator', ctx);
+        break;
+    }
   }
 
   return new Response(JSON.stringify({ success: true, result: result.result }), {

--- a/worker/src/keycast-client.test.ts
+++ b/worker/src/keycast-client.test.ts
@@ -40,6 +40,13 @@ describe('keycast-client', () => {
       expect(opts.headers['Content-Type']).toBe('application/json');
     });
 
+    it('sends reason "moderation" for general moderation suspends', async () => {
+      const result = await suspendUser(VALID_PUBKEY, 'moderation', makeEnv());
+      expect(result).toEqual({ success: true });
+      const [, opts] = fetchMock.mock.calls[0];
+      expect(JSON.parse(opts.body)).toEqual({ status: 'suspended', reason: 'moderation' });
+    });
+
     it('returns success false with status on 4xx', async () => {
       fetchMock.mockResolvedValue({ ok: false, status: 404, text: () => Promise.resolve('Not found') });
       const result = await suspendUser(VALID_PUBKEY, 'age_review', makeEnv());

--- a/worker/src/keycast-client.ts
+++ b/worker/src/keycast-client.ts
@@ -11,7 +11,7 @@ export interface KeycastResult {
   error?: string;
 }
 
-export type KeycastReason = 'age_review' | 'age_review_denied' | 'age_review_expired';
+export type KeycastReason = 'age_review' | 'age_review_denied' | 'age_review_expired' | 'moderation';
 
 const HEX_64 = /^[0-9a-f]{64}$/;
 


### PR DESCRIPTION
Closes #94, #95.

## What this does

Wires account suspend/unsuspend into the general moderation path and notifies affected users, modeled on the Keycast account-state work from under-16 management.

## Changes

- **`worker/src/keycast-client.ts`** — added `'moderation'` to `KeycastReason` for general-moderation suspends.
- **`worker/src/index.ts`** — added a `notifyAccountState(env, pubkey, action, reason, ctx)` helper (non-critical DM, awaited inside `ctx.waitUntil` with `.catch`, never fire-and-forget). `handleRelayRpc` now dispatches by method after a successful RPC:
  - `banpubkey` -> DM `ACCOUNT_BANNED` (fixes the prior bug where a ban sent the `ACCOUNT_SUSPENDED` template)
  - `suspendpubkey` -> `suspendUser(pubkey, 'moderation', env)` + DM `ACCOUNT_SUSPENDED`
  - `unsuspendpubkey` -> `unsuspendUser(pubkey, env)` + DM `ACCOUNT_RESTORED`
  Keycast calls are non-critical enrichment (logged on failure, do not fail the already-accepted RPC).

## Tests

- `worker/src/index.test.ts` — asserts the three action strings on `/api/v1/notify` and the Keycast suspend/unsuspend calls; `banpubkey` triggers no Keycast call.
- `worker/src/keycast-client.test.ts` — `'moderation'` reason.

## Verification

- Funnelcake implements `suspendpubkey`/`unsuspendpubkey` natively (`crates/proto/src/management.rs`, handled in `crates/clickhouse/src/management.rs`, advertised in supported methods) — these are real methods, not the kind of non-existent method that caused #88/#89. No alias needed.
- `Env extends KeycastEnv`, so `KEYCAST_URL`/`KEYCAST_SERVICE_TOKEN` are in scope; no Env change required.

## Notes

- Also carries the inherited PR #90 lint fix in `age-review.test.ts` (identical to #89/#97, no conflict). Worker-`tsc` typing gap tracked in #99. Part of the broader DM coverage in #96.

## Merge order

**Land the companion divine-moderation-service PR (divinevideo/divine-moderation-service#150) first**, so the new `ACCOUNT_BANNED`/`ACCOUNT_RESTORED` actions are accepted by `/api/v1/notify`. If this lands first, those two DMs simply fail and are logged (non-critical) until #150 ships; suspend's `ACCOUNT_SUSPENDED` already works today. Independent of #97 (disjoint files). CI green.
