### PR TITLE
chore(worker): gate worker typecheck + tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       # Split into separate steps so a typecheck vs test failure is obvious.
       - name: Worker install
         working-directory: worker
-        run: npm install --legacy-peer-deps
+        run: npm ci --legacy-peer-deps
 
       - name: Worker typecheck
         working-directory: worker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,14 @@ jobs:
           
       - name: Run tests
         run: npm run test
+
+      # The worker has its own package/lockfile and was previously not
+      # type-checked or tested in CI (root vitest excludes worker/**).
+      # --legacy-peer-deps: worker lockfile has a known peer-dep conflict
+      # (@cloudflare/vitest-pool-workers wants vitest 2-3.x, lockfile pins 4.x).
+      - name: Worker typecheck and tests
+        run: |
+          cd worker
+          npm install --legacy-peer-deps
+          npm run typecheck
+          npx vitest run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,4 +44,4 @@ jobs:
 
       - name: Worker tests
         working-directory: worker
-        run: npx vitest run
+        run: npm run test:run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,15 @@ jobs:
       # type-checked or tested in CI (root vitest excludes worker/**).
       # --legacy-peer-deps: worker lockfile has a known peer-dep conflict
       # (@cloudflare/vitest-pool-workers wants vitest 2-3.x, lockfile pins 4.x).
-      - name: Worker typecheck and tests
-        run: |
-          cd worker
-          npm install --legacy-peer-deps
-          npm run typecheck
-          npx vitest run
+      # Split into separate steps so a typecheck vs test failure is obvious.
+      - name: Worker install
+        working-directory: worker
+        run: npm install --legacy-peer-deps
+
+      - name: Worker typecheck
+        working-directory: worker
+        run: npm run typecheck
+
+      - name: Worker tests
+        working-directory: worker
+        run: npx vitest run

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.12.8",
         "@cloudflare/workers-types": "^4.20241127.0",
+        "typescript": "^5.9.3",
         "vitest": "^4.0.18",
         "wrangler": "^4.60.0"
       }
@@ -2336,6 +2337,20 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/undici": {
       "version": "7.18.2",

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1793,74 +1793,12 @@
         }
       }
     },
-    "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vitest/utils": "3.2.4",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "magic-string": "^0.30.17",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/@vitest/spy": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
       "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
       "dev": true,
       "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
@@ -2035,14 +1973,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -2052,14 +1982,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -2360,20 +2282,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/strip-literal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
     "node_modules/supports-color": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -2419,17 +2327,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.12.8",
     "@cloudflare/workers-types": "^4.20241127.0",
+    "typescript": "^5.9.3",
     "vitest": "^4.0.18",
     "wrangler": "^4.60.0"
   }

--- a/worker/package.json
+++ b/worker/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest",
     "test:run": "vitest run",
     "generate-keys": "node scripts/generate-keys.js"

--- a/worker/src/ReportWatcher.test.ts
+++ b/worker/src/ReportWatcher.test.ts
@@ -1211,10 +1211,14 @@ describe('ReportWatcher', () => {
           { kind: 'threshold', name: 'Threshold', categories: ['NS-spam'], threshold: 5, requireTrustedClient: true },
         ],
       };
-      vi.mocked(mockState.storage.get).mockImplementation(async (key: string) => {
-        if (key === 'autoHideConfig') return storedConfig;
-        return undefined;
-      });
+      // storage.get is an overloaded method (single key vs. key array). The DO only
+      // calls the single-key form, so cast the single-key impl onto the mocked overload.
+      vi.mocked(mockState.storage.get).mockImplementation(
+        (async (key: string) => {
+          if (key === 'autoHideConfig') return storedConfig;
+          return undefined;
+        }) as unknown as DurableObjectStorage['get'],
+      );
 
       watcher = new ReportWatcher(mockState, mockEnv);
       await new Promise(resolve => setTimeout(resolve, 10));
@@ -1238,10 +1242,12 @@ describe('ReportWatcher', () => {
           { name: 'Threshold', categories: ['NS-spam'], threshold: 3, requireTrustedClient: false },
         ],
       };
-      vi.mocked(mockState.storage.get).mockImplementation(async (key: string) => {
-        if (key === 'autoHideConfig') return legacyStoredConfig;
-        return undefined;
-      });
+      vi.mocked(mockState.storage.get).mockImplementation(
+        (async (key: string) => {
+          if (key === 'autoHideConfig') return legacyStoredConfig;
+          return undefined;
+        }) as unknown as DurableObjectStorage['get'],
+      );
 
       watcher = new ReportWatcher(mockState, mockEnv);
       await new Promise(resolve => setTimeout(resolve, 10));

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -11,6 +11,7 @@ import {
   syncAgeReviewTicketResolution,
   getAgeReviewConfig,
   updateAgeReviewConfig,
+  type AgeReviewEnv,
 } from './age-review';
 import type { AgeReviewCase } from '../../shared/age-review';
 import { suspendUser, unsuspendUser, banUser, createMinorAccount } from './keycast-client';
@@ -23,6 +24,15 @@ vi.mock('./keycast-client', () => ({
 }));
 
 const corsHeaders = { 'Access-Control-Allow-Origin': '*' };
+
+function makeEnv(db?: unknown, overrides: Partial<AgeReviewEnv> = {}): AgeReviewEnv {
+  return {
+    NOSTR_NSEC: 'nsec1test',
+    RELAY_URL: 'wss://relay.test',
+    ...(db !== undefined ? { DB: db as D1Database } : {}),
+    ...overrides,
+  };
+}
 
 function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
   return {
@@ -42,6 +52,9 @@ function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
     resolution_note: null,
     last_alerted_at: null,
     zendesk_ticket_id: null,
+    created_via: null,
+    claim_link_url: null,
+    claim_link_expires_at: null,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
     ...overrides,
@@ -79,7 +92,7 @@ describe('handleGetAgeReviewCases', () => {
     const c = makeCase();
     const db = createMockDb([c]);
     const req = new Request('https://api.test/api/age-review/cases');
-    const res = await handleGetAgeReviewCases(req, { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleGetAgeReviewCases(req, makeEnv(db), corsHeaders);
     const body = await res.json() as { success: boolean; cases: AgeReviewCase[] };
 
     expect(res.status).toBe(200);
@@ -89,7 +102,7 @@ describe('handleGetAgeReviewCases', () => {
 
   it('returns 500 when DB not configured', async () => {
     const req = new Request('https://api.test/api/age-review/cases');
-    const res = await handleGetAgeReviewCases(req, {}, corsHeaders);
+    const res = await handleGetAgeReviewCases(req, makeEnv(), corsHeaders);
     expect(res.status).toBe(500);
   });
 });
@@ -100,7 +113,7 @@ describe('handleGetAgeReviewCase', () => {
   it('returns a single case', async () => {
     const c = makeCase();
     const db = createMockDb([c]);
-    const res = await handleGetAgeReviewCase('case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleGetAgeReviewCase('case-1', makeEnv(db), corsHeaders);
     const body = await res.json() as { success: boolean; case: AgeReviewCase };
 
     expect(res.status).toBe(200);
@@ -109,7 +122,7 @@ describe('handleGetAgeReviewCase', () => {
 
   it('returns 404 for unknown case', async () => {
     const db = createMockDb([]);
-    const res = await handleGetAgeReviewCase('nonexistent', { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleGetAgeReviewCase('nonexistent', makeEnv(db), corsHeaders);
     expect(res.status).toBe(404);
   });
 });
@@ -133,7 +146,7 @@ describe('handleUpdateAgeReviewCase', () => {
       method: 'PATCH',
       body: JSON.stringify({ state: 'under_moderator_review' }),
     });
-    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db), corsHeaders);
     expect(res.status).toBe(200);
 
     const updateCall = db.prepare.mock.calls.find(
@@ -147,7 +160,7 @@ describe('handleUpdateAgeReviewCase', () => {
       method: 'PATCH',
       body: JSON.stringify({ state: 'bogus_state' }),
     });
-    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db), corsHeaders);
     expect(res.status).toBe(400);
     const body = await res.json() as { error: string };
     expect(body.error).toContain('Invalid state');
@@ -158,7 +171,7 @@ describe('handleUpdateAgeReviewCase', () => {
       method: 'PATCH',
       body: JSON.stringify({ state: 'submitted_for_review' }),
     });
-    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db), corsHeaders);
     expect(res.status).toBe(400);
     const body = await res.json() as { error: string };
     expect(body.error).toContain('Cannot transition');
@@ -171,7 +184,7 @@ describe('handleUpdateAgeReviewCase', () => {
       method: 'PATCH',
       body: JSON.stringify({ state: 'under_moderator_review' }),
     });
-    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: closedDb as unknown as D1Database }, corsHeaders);
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(closedDb), corsHeaders);
     expect(res.status).toBe(400);
     const body = await res.json() as { error: string };
     expect(body.error).toContain('closed case');
@@ -182,7 +195,7 @@ describe('handleUpdateAgeReviewCase', () => {
       method: 'PATCH',
       body: JSON.stringify({ clock_paused: true }),
     });
-    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db), corsHeaders);
     expect(res.status).toBe(200);
 
     const updateCall = db.prepare.mock.calls.find(
@@ -203,7 +216,7 @@ describe('handleUpdateAgeReviewCase', () => {
       method: 'PATCH',
       body: JSON.stringify({ clock_paused: false }),
     });
-    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: pausedDb as unknown as D1Database }, corsHeaders);
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(pausedDb), corsHeaders);
     expect(res.status).toBe(200);
 
     const updateCall = pausedDb.prepare.mock.calls.find(
@@ -217,7 +230,7 @@ describe('handleUpdateAgeReviewCase', () => {
       method: 'PATCH',
       body: JSON.stringify({ parent_contact_email: 'not-an-email' }),
     });
-    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db), corsHeaders);
     expect(res.status).toBe(400);
     const body = await res.json() as { error: string };
     expect(body.error).toContain('email');
@@ -228,7 +241,7 @@ describe('handleUpdateAgeReviewCase', () => {
       method: 'PATCH',
       body: JSON.stringify({ parent_contact_email: null }),
     });
-    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db), corsHeaders);
     expect(res.status).toBe(200);
   });
 
@@ -246,12 +259,11 @@ describe('handleUpdateAgeReviewCase', () => {
       method: 'PATCH',
       body: JSON.stringify({ state: 'cleared', resolution_note: 'Age verified' }),
     });
-    const res = await handleUpdateAgeReviewCase(req, 'case-1', {
-      DB: reviewDb as unknown as D1Database,
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(reviewDb, {
       ZENDESK_SUBDOMAIN: 'test',
       ZENDESK_API_TOKEN: 'tok',
       ZENDESK_EMAIL: 'agent@test.com',
-    }, corsHeaders);
+    }), corsHeaders);
     expect(res.status).toBe(200);
 
     const zendeskCall = mockFetch.mock.calls.find(
@@ -306,15 +318,14 @@ describe('handleUpdateAgeReviewCase', () => {
       method: 'PATCH',
       body: JSON.stringify({ state: 'restricted_pending_support_email' }),
     });
-    const res = await handleUpdateAgeReviewCase(req, 'case-1', {
-      DB: db as unknown as D1Database,
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db, {
       ZENDESK_SUBDOMAIN: 'test',
       ZENDESK_API_TOKEN: 'tok',
       ZENDESK_EMAIL: 'agent@test.com',
       ZENDESK_FIELD_CATEGORY: '1001',
       ZENDESK_FIELD_ISSUE: '1002',
       ZENDESK_FIELD_AGE_REVIEW_DEADLINE: '1003',
-    }, corsHeaders);
+    }), corsHeaders);
     const body = await res.json() as { success: boolean; case: AgeReviewCase };
 
     expect(res.status).toBe(200);
@@ -374,7 +385,7 @@ describe('Keycast suspension wiring', () => {
       method: 'PATCH',
       body: JSON.stringify({ state: 'restricted_pending_user_response' }),
     });
-    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db), corsHeaders);
     const body = await res.json() as { success: boolean; keycastUpdated: boolean };
 
     expect(res.status).toBe(200);
@@ -408,7 +419,7 @@ describe('Keycast suspension wiring', () => {
       method: 'PATCH',
       body: JSON.stringify({ state: 'cleared' }),
     });
-    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db), corsHeaders);
     const body = await res.json() as { success: boolean; keycastUpdated: boolean };
 
     expect(res.status).toBe(200);
@@ -442,7 +453,7 @@ describe('Keycast suspension wiring', () => {
       method: 'PATCH',
       body: JSON.stringify({ state: 'cleared' }),
     });
-    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db), corsHeaders);
     const body = await res.json() as { success: boolean; keycastUpdated: boolean };
 
     expect(res.status).toBe(200);
@@ -475,7 +486,7 @@ describe('Keycast suspension wiring', () => {
       method: 'PATCH',
       body: JSON.stringify({ state: 'restricted_pending_parental_consent' }),
     });
-    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db), corsHeaders);
     const body = await res.json() as { success: boolean; keycastUpdated: boolean; bulkActionTriggered?: string };
 
     expect(res.status).toBe(200);
@@ -509,7 +520,7 @@ describe('Keycast suspension wiring', () => {
       method: 'PATCH',
       body: JSON.stringify({ state: 'cleared' }),
     });
-    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db), corsHeaders);
     const body = await res.json() as { success: boolean; keycastUpdated: boolean };
 
     expect(res.status).toBe(200);
@@ -542,7 +553,7 @@ describe('Keycast suspension wiring', () => {
       method: 'PATCH',
       body: JSON.stringify({ state: 'cleared' }),
     });
-    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db), corsHeaders);
     const body = await res.json() as { success: boolean; keycastUpdated: boolean };
 
     expect(res.status).toBe(200);
@@ -575,7 +586,7 @@ describe('Keycast suspension wiring', () => {
       method: 'PATCH',
       body: JSON.stringify({ state: 'denied_closed' }),
     });
-    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db), corsHeaders);
     const body = await res.json() as { success: boolean; keycastUpdated: boolean };
 
     expect(res.status).toBe(200);
@@ -611,7 +622,7 @@ describe('Keycast suspension wiring', () => {
       method: 'PATCH',
       body: JSON.stringify({ state: 'restricted_pending_user_response' }),
     });
-    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db), corsHeaders);
     const body = await res.json() as { success: boolean; keycastUpdated: boolean };
 
     expect(res.status).toBe(200);
@@ -645,7 +656,7 @@ describe('Keycast suspension wiring', () => {
       method: 'PATCH',
       body: JSON.stringify({ state: 'denied_closed' }),
     });
-    const res = await handleUpdateAgeReviewCase(req, 'case-1', { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db), corsHeaders);
     const body = await res.json() as { success: boolean };
 
     expect(res.status).toBe(200);
@@ -658,7 +669,7 @@ describe('Keycast suspension wiring', () => {
 describe('handleGetModerationStatus', () => {
   it('returns active when no case exists', async () => {
     const db = createMockDb([]);
-    const res = await handleGetModerationStatus('a'.repeat(64), { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleGetModerationStatus('a'.repeat(64), makeEnv(db), corsHeaders);
     const body = await res.json() as { restriction: { status: string } };
 
     expect(res.status).toBe(200);
@@ -677,7 +688,7 @@ describe('handleGetModerationStatus', () => {
       }),
     }));
 
-    const res = await handleGetModerationStatus(c.pubkey, { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleGetModerationStatus(c.pubkey, makeEnv(db), corsHeaders);
     const body = await res.json() as {
       restriction: { status: string };
       minorReviewCase: { id: string; state: string };
@@ -700,7 +711,7 @@ describe('handleGetModerationStatus', () => {
       }),
     }));
 
-    const res = await handleGetModerationStatus(c.pubkey, { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleGetModerationStatus(c.pubkey, makeEnv(db), corsHeaders);
     const body = await res.json() as { restriction: { status: string } };
 
     expect(res.status).toBe(200);
@@ -708,7 +719,7 @@ describe('handleGetModerationStatus', () => {
   });
 
   it('returns active (fail-open) when DB unavailable', async () => {
-    const res = await handleGetModerationStatus('a'.repeat(64), {}, corsHeaders);
+    const res = await handleGetModerationStatus('a'.repeat(64), makeEnv(), corsHeaders);
     const body = await res.json() as { restriction: { status: string } };
 
     expect(res.status).toBe(200);
@@ -736,7 +747,7 @@ describe('handleParentContact', () => {
       method: 'POST',
       body: JSON.stringify({ email: 'parent@example.com' }),
     });
-    const res = await handleParentContact(req, 'case-1', c.pubkey, { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleParentContact(req, 'case-1', c.pubkey, makeEnv(db), corsHeaders);
     expect(res.status).toBe(200);
 
     const updateCall = db.prepare.mock.calls.find(
@@ -760,7 +771,7 @@ describe('handleParentContact', () => {
       method: 'POST',
       body: JSON.stringify({ email: 'parent@example.com' }),
     });
-    const res = await handleParentContact(req, 'case-1', c.pubkey, { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleParentContact(req, 'case-1', c.pubkey, makeEnv(db), corsHeaders);
     expect(res.status).toBe(400);
     const body = await res.json() as { error: string };
     expect(body.error).toContain('Under-13');
@@ -780,7 +791,7 @@ describe('handleParentContact', () => {
       method: 'POST',
       body: JSON.stringify({ email: 'parent@example.com' }),
     });
-    const res = await handleParentContact(req, 'case-1', 'c'.repeat(64), { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleParentContact(req, 'case-1', 'c'.repeat(64), makeEnv(db), corsHeaders);
     expect(res.status).toBe(404);
   });
 
@@ -799,7 +810,7 @@ describe('handleParentContact', () => {
       method: 'POST',
       body: JSON.stringify({ email: 'parent@example.com' }),
     });
-    const res = await handleParentContact(req, 'case-1', c.pubkey, { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleParentContact(req, 'case-1', c.pubkey, makeEnv(db), corsHeaders);
     expect(res.status).toBe(400);
     const body = await res.json() as { error: string };
     expect(body.error).toContain('closed');
@@ -821,7 +832,7 @@ describe('handleParentContact', () => {
       method: 'POST',
       body: JSON.stringify({ email: 'parent@example.com' }),
     });
-    const res = await handleParentContact(req, 'case-1', c.pubkey, { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleParentContact(req, 'case-1', c.pubkey, makeEnv(db), corsHeaders);
     expect(res.status).toBe(400);
     const body = await res.json() as { error: string };
     expect(body.error).toContain('Cannot submit parent contact');
@@ -842,7 +853,7 @@ describe('handleParentContact', () => {
       method: 'POST',
       body: JSON.stringify({ email: 'not-valid' }),
     });
-    const res = await handleParentContact(req, 'case-1', c.pubkey, { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleParentContact(req, 'case-1', c.pubkey, makeEnv(db), corsHeaders);
     expect(res.status).toBe(400);
   });
 });
@@ -857,7 +868,7 @@ describe('checkAgeReviewDeadlines', () => {
   });
 
   it('does nothing when DB unavailable', async () => {
-    await checkAgeReviewDeadlines({});
+    await checkAgeReviewDeadlines(makeEnv());
     // No throw — just returns
   });
 
@@ -885,12 +896,11 @@ describe('checkAgeReviewDeadlines', () => {
       })),
     };
 
-    await checkAgeReviewDeadlines({
-      DB: db as unknown as D1Database,
+    await checkAgeReviewDeadlines(makeEnv(db, {
       ZENDESK_SUBDOMAIN: 'test',
       ZENDESK_API_TOKEN: 'tok',
       ZENDESK_EMAIL: 'agent@test.com',
-    });
+    }));
 
     const closeCalls = db.prepare.mock.calls.filter(
       (c: string[]) => c[0]?.includes('denied_closed')
@@ -933,7 +943,7 @@ describe('checkAgeReviewDeadlines', () => {
       })),
     };
 
-    await checkAgeReviewDeadlines({ DB: db as unknown as D1Database });
+    await checkAgeReviewDeadlines(makeEnv(db));
 
     const closeCalls = db.prepare.mock.calls.filter(
       (c: string[]) => c[0]?.includes('denied_closed')
@@ -961,10 +971,9 @@ describe('checkAgeReviewDeadlines', () => {
       })),
     };
 
-    await checkAgeReviewDeadlines({
-      DB: db as unknown as D1Database,
+    await checkAgeReviewDeadlines(makeEnv(db, {
       SLACK_WEBHOOK_URL: 'https://hooks.slack.com/test',
-    });
+    }));
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockFetch.mock.calls[0][0]).toBe('https://hooks.slack.com/test');
@@ -996,10 +1005,9 @@ describe('checkAgeReviewDeadlines', () => {
       })),
     };
 
-    await checkAgeReviewDeadlines({
-      DB: db as unknown as D1Database,
+    await checkAgeReviewDeadlines(makeEnv(db, {
       SLACK_WEBHOOK_URL: 'https://hooks.slack.com/test',
-    });
+    }));
 
     const stampCalls = db.prepare.mock.calls.filter(
       (c: string[]) => c[0]?.includes('UPDATE') && c[0]?.includes('last_alerted_at')
@@ -1027,7 +1035,7 @@ describe('checkAgeReviewDeadlines', () => {
       })),
     };
 
-    await checkAgeReviewDeadlines({ DB: db as unknown as D1Database });
+    await checkAgeReviewDeadlines(makeEnv(db));
     expect(mockFetch).not.toHaveBeenCalled();
 
     vi.unstubAllGlobals();
@@ -1061,12 +1069,11 @@ describe('handleParentContact Zendesk integration', () => {
       method: 'POST',
       body: JSON.stringify({ email: 'parent@example.com' }),
     });
-    const res = await handleParentContact(req, 'case-1', c.pubkey, {
-      DB: db as unknown as D1Database,
+    const res = await handleParentContact(req, 'case-1', c.pubkey, makeEnv(db, {
       ZENDESK_SUBDOMAIN: 'test',
       ZENDESK_API_TOKEN: 'tok',
       ZENDESK_EMAIL: 'agent@test.com',
-    }, corsHeaders);
+    }), corsHeaders);
     expect(res.status).toBe(200);
 
     // Zendesk API was called to create ticket
@@ -1111,12 +1118,11 @@ describe('handleParentContact Zendesk integration', () => {
       method: 'POST',
       body: JSON.stringify({ email: 'parent@example.com' }),
     });
-    const res = await handleParentContact(req, 'case-1', c.pubkey, {
-      DB: db as unknown as D1Database,
+    const res = await handleParentContact(req, 'case-1', c.pubkey, makeEnv(db, {
       ZENDESK_SUBDOMAIN: 'test',
       ZENDESK_API_TOKEN: 'tok',
       ZENDESK_EMAIL: 'agent@test.com',
-    }, corsHeaders);
+    }), corsHeaders);
 
     // Still succeeds — Zendesk is non-critical
     expect(res.status).toBe(200);
@@ -1144,9 +1150,8 @@ describe('handleParentContact Zendesk integration', () => {
       method: 'POST',
       body: JSON.stringify({ email: 'parent@example.com' }),
     });
-    const res = await handleParentContact(req, 'case-1', c.pubkey, {
-      DB: db as unknown as D1Database,
-    }, corsHeaders);
+    const res = await handleParentContact(req, 'case-1', c.pubkey, makeEnv(db, {
+    }), corsHeaders);
 
     expect(res.status).toBe(200);
     // No Zendesk API call made
@@ -1175,12 +1180,11 @@ describe('handleParentContact Zendesk integration', () => {
       method: 'POST',
       body: JSON.stringify({ email: 'parent@example.com' }),
     });
-    const res = await handleParentContact(req, 'case-1', c.pubkey, {
-      DB: db as unknown as D1Database,
+    const res = await handleParentContact(req, 'case-1', c.pubkey, makeEnv(db, {
       ZENDESK_SUBDOMAIN: 'test',
       ZENDESK_API_TOKEN: 'tok',
       ZENDESK_EMAIL: 'agent@test.com',
-    }, corsHeaders);
+    }), corsHeaders);
 
     expect(res.status).toBe(200);
     expect(mockFetch).toHaveBeenCalledOnce();
@@ -1210,12 +1214,11 @@ describe('syncAgeReviewTicketResolution', () => {
       })),
     };
 
-    await syncAgeReviewTicketResolution('case-1', 'cleared', 'All good', {
-      DB: db as unknown as D1Database,
+    await syncAgeReviewTicketResolution('case-1', 'cleared', 'All good', makeEnv(db, {
       ZENDESK_SUBDOMAIN: 'test',
       ZENDESK_API_TOKEN: 'tok',
       ZENDESK_EMAIL: 'agent@test.com',
-    });
+    }));
 
     expect(mockFetch).not.toHaveBeenCalled();
     vi.unstubAllGlobals();
@@ -1233,12 +1236,11 @@ describe('syncAgeReviewTicketResolution', () => {
       })),
     };
 
-    await syncAgeReviewTicketResolution('case-1', 'denied_closed', 'Expired', {
-      DB: db as unknown as D1Database,
+    await syncAgeReviewTicketResolution('case-1', 'denied_closed', 'Expired', makeEnv(db, {
       ZENDESK_SUBDOMAIN: 'test',
       ZENDESK_API_TOKEN: 'tok',
       ZENDESK_EMAIL: 'agent@test.com',
-    });
+    }));
 
     expect(mockFetch).toHaveBeenCalledOnce();
     const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
@@ -1263,14 +1265,13 @@ describe('syncAgeReviewTicketResolution', () => {
       })),
     };
 
-    await syncAgeReviewTicketResolution('case-1', 'cleared', null, {
-      DB: db as unknown as D1Database,
+    await syncAgeReviewTicketResolution('case-1', 'cleared', null, makeEnv(db, {
       ZENDESK_SUBDOMAIN: 'test',
       ZENDESK_API_TOKEN: 'tok',
       ZENDESK_EMAIL: 'agent@test.com',
       ZENDESK_FIELD_CATEGORY: '12345',
       ZENDESK_FIELD_ISSUE: '67890',
-    });
+    }));
 
     const payload = JSON.parse((mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string);
     expect(payload.ticket.custom_fields).toEqual([
@@ -1306,7 +1307,7 @@ describe('handleAgeReviewReplyWebhook', () => {
       method: 'POST',
       body: JSON.stringify({ ticket_id: 42 }),
     });
-    const res = await handleAgeReviewReplyWebhook(req, { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleAgeReviewReplyWebhook(req, makeEnv(db), corsHeaders);
     const body = await res.json() as { success: boolean; new_state: string };
 
     expect(res.status).toBe(200);
@@ -1347,7 +1348,7 @@ describe('handleAgeReviewReplyWebhook', () => {
       method: 'POST',
       body: JSON.stringify({ ticket_id: 42 }),
     });
-    const res = await handleAgeReviewReplyWebhook(req, { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleAgeReviewReplyWebhook(req, makeEnv(db), corsHeaders);
     expect(res.status).toBe(200);
 
     // Should have bound an ISO timestamp and remaining days (~5)
@@ -1370,7 +1371,7 @@ describe('handleAgeReviewReplyWebhook', () => {
       method: 'POST',
       body: JSON.stringify({ ticket_id: 999 }),
     });
-    const res = await handleAgeReviewReplyWebhook(req, { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleAgeReviewReplyWebhook(req, makeEnv(db), corsHeaders);
     expect(res.status).toBe(404);
   });
 
@@ -1394,7 +1395,7 @@ describe('handleAgeReviewReplyWebhook', () => {
       method: 'POST',
       body: JSON.stringify({ ticket_id: 42 }),
     });
-    const res = await handleAgeReviewReplyWebhook(req, { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleAgeReviewReplyWebhook(req, makeEnv(db), corsHeaders);
     const body = await res.json() as { success: boolean; message: string };
 
     expect(res.status).toBe(200);
@@ -1407,7 +1408,7 @@ describe('handleAgeReviewReplyWebhook', () => {
       method: 'POST',
       body: JSON.stringify({}),
     });
-    const res = await handleAgeReviewReplyWebhook(req, { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleAgeReviewReplyWebhook(req, makeEnv(db), corsHeaders);
     expect(res.status).toBe(400);
   });
 });
@@ -1486,7 +1487,7 @@ describe('handleCreateMinorAccount', () => {
 
   it('creates account and returns success with claim_url', async () => {
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), makeEnv(db), corsHeaders);
     const body = await res.json() as Record<string, unknown>;
 
     expect(res.status).toBe(200);
@@ -1498,14 +1499,14 @@ describe('handleCreateMinorAccount', () => {
 
   it('rejects missing username', async () => {
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({}), { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({}), makeEnv(db), corsHeaders);
     expect(res.status).toBe(400);
     expect(mockCreateMinorAccount).not.toHaveBeenCalled();
   });
 
   it('rejects invalid username characters', async () => {
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'BAD USER!' }), { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'BAD USER!' }), makeEnv(db), corsHeaders);
     expect(res.status).toBe(400);
     expect(mockCreateMinorAccount).not.toHaveBeenCalled();
   });
@@ -1514,7 +1515,7 @@ describe('handleCreateMinorAccount', () => {
     const db = makeMinorDb();
     const res = await handleCreateMinorAccount(
       makeRequest({ username: 'test', display_name: 12345 }),
-      { DB: db as unknown as D1Database },
+      makeEnv(db),
       corsHeaders,
     );
     expect(res.status).toBe(400);
@@ -1523,7 +1524,7 @@ describe('handleCreateMinorAccount', () => {
 
   it('strips empty display_name before calling Keycast', async () => {
     const db = makeMinorDb();
-    await handleCreateMinorAccount(makeRequest({ username: 'test', display_name: '  ' }), { DB: db as unknown as D1Database }, corsHeaders);
+    await handleCreateMinorAccount(makeRequest({ username: 'test', display_name: '  ' }), makeEnv(db), corsHeaders);
     expect(mockCreateMinorAccount).toHaveBeenCalledWith('test', undefined, expect.anything());
   });
 
@@ -1531,7 +1532,7 @@ describe('handleCreateMinorAccount', () => {
     const db = makeMinorDb();
     const res = await handleCreateMinorAccount(
       makeRequest({ username: 'test', zendesk_ticket_id: 'abc' }),
-      { DB: db as unknown as D1Database },
+      makeEnv(db),
       corsHeaders,
     );
     expect(res.status).toBe(400);
@@ -1540,7 +1541,7 @@ describe('handleCreateMinorAccount', () => {
 
   it('returns 500 without claim_url when D1 insert fails after Keycast success', async () => {
     const db = makeMinorDb(() => Promise.reject(new Error('D1 write failed')));
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), makeEnv(db), corsHeaders);
     const body = await res.json() as Record<string, unknown>;
 
     expect(res.status).toBe(500);
@@ -1553,21 +1554,21 @@ describe('handleCreateMinorAccount', () => {
   it('maps Keycast 409 to 409 status', async () => {
     mockCreateMinorAccount.mockResolvedValue({ success: false, error: '409: Username taken' });
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'taken' }), { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'taken' }), makeEnv(db), corsHeaders);
     expect(res.status).toBe(409);
   });
 
   it('maps other Keycast 4xx to 400 status', async () => {
     mockCreateMinorAccount.mockResolvedValue({ success: false, error: '422: Invalid input' });
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), makeEnv(db), corsHeaders);
     expect(res.status).toBe(400);
   });
 
   it('maps Keycast server errors to 502 status', async () => {
     mockCreateMinorAccount.mockResolvedValue({ success: false, error: 'Connection refused' });
     const db = makeMinorDb();
-    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), { DB: db as unknown as D1Database }, corsHeaders);
+    const res = await handleCreateMinorAccount(makeRequest({ username: 'test' }), makeEnv(db), corsHeaders);
     expect(res.status).toBe(502);
   });
 
@@ -1584,7 +1585,7 @@ describe('handleCreateMinorAccount', () => {
 
     const res = await handleCreateMinorAccount(
       makeRequest({ username: 'testuser' }),
-      { DB: db as unknown as D1Database },
+      makeEnv(db),
       corsHeaders,
     );
 
@@ -1614,7 +1615,7 @@ describe('handleCreateMinorAccount', () => {
 
     const res = await handleCreateMinorAccount(
       makeRequest({ username: 'testuser' }),
-      { DB: db as unknown as D1Database },
+      makeEnv(db),
       corsHeaders,
     );
 

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -1150,8 +1150,7 @@ describe('handleParentContact Zendesk integration', () => {
       method: 'POST',
       body: JSON.stringify({ email: 'parent@example.com' }),
     });
-    const res = await handleParentContact(req, 'case-1', c.pubkey, makeEnv(db, {
-    }), corsHeaders);
+    const res = await handleParentContact(req, 'case-1', c.pubkey, makeEnv(db), corsHeaders);
 
     expect(res.status).toBe(200);
     // No Zendesk API call made

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -16,7 +16,7 @@ import type { BulkAction, BulkModerateResult } from '../../shared/bulk-moderatio
 import { suspendUser, unsuspendUser, banUser, createMinorAccount, type KeycastEnv } from './keycast-client';
 import type { SecretStoreSecret } from './nip86';
 
-interface AgeReviewEnv extends BulkModerateEnv, KeycastEnv {
+export interface AgeReviewEnv extends BulkModerateEnv, KeycastEnv {
   SLACK_WEBHOOK_URL?: string;
   ZENDESK_SUBDOMAIN?: string | SecretStoreSecret;
   ZENDESK_API_TOKEN?: string | SecretStoreSecret;

--- a/worker/src/bulk-moderate.ts
+++ b/worker/src/bulk-moderate.ts
@@ -125,12 +125,18 @@ export async function queryRelayEvents(
       const events: RelayEventSummary[] = [];
       const subId = `bulk-${Date.now()}`;
 
-      const finish = (fn: (value?: unknown) => void, value?: unknown) => {
+      // `resolve` expects RelayEventSummary[]; `reject` expects an Error. The helper
+      // accepts whichever terminator and its matching value as a single union, so the
+      // settle path (close socket, clear timeout, guard against double-settle) is shared.
+      type Settle =
+        | { fn: typeof resolve; value: RelayEventSummary[] }
+        | { fn: typeof reject; value: Error };
+      const finish = (fn: Settle['fn'], value: RelayEventSummary[] | Error) => {
         if (resolved) return;
         resolved = true;
         clearTimeout(timeout);
         ws.close();
-        fn(value);
+        (fn as (value: RelayEventSummary[] | Error) => void)(value);
       };
 
       const timeout = setTimeout(() => {

--- a/worker/src/funnelcake-proxy.test.ts
+++ b/worker/src/funnelcake-proxy.test.ts
@@ -49,7 +49,7 @@ describe('proxyFunnelcakeRequest', () => {
       expect(response.status).toBe(200);
       expect(response.headers.get('Cache-Control')).toBe('public, max-age=300');
       expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
-      const body = await response.json();
+      const body = await response.json() as { id: string };
       expect(body.id).toBe('abc123');
     } finally {
       globalThis.fetch = originalFetch;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -296,6 +296,8 @@ interface UnsignedEvent {
 interface ApiResponse {
   success: boolean;
   event?: object;
+  // Relay query responses (e.g. /api/reports, /api/resolution-labels) return arrays.
+  events?: object[];
   error?: string;
   pubkey?: string;
   // Moderation action responses


### PR DESCRIPTION
Closes #99.

## Context

Follow-on to the under-16 age-review work (#97/#98). Those PRs surfaced that the
Cloudflare Worker — which hosts the age-review backend — was never type-checked or
tested in CI. The ~64 errors this gate uncovered were almost entirely in
`age-review.test.ts`, and the age-review worker tests weren't running in CI at all.
So this PR hardens the under-16 review flow's backend (and the rest of the worker)
against silent type/test regressions. It does not change the feature, which shipped
in #97/#98 — it gates it.

## What this does

Type-checks and runs the Cloudflare Worker in CI. Previously CI only ran the root
suite, which **excludes `worker/**`** from both `tsc` (root checks `tsconfig.app.json`
only) and vitest. So the worker's TypeScript was never gated and its test suite never
ran in CI.

Turning the gate on surfaced ~64 worker `tsc` errors, almost all from one pattern:
test env-object literals (`{ DB: ... }`, `{}`) passed where handlers expect
`AgeReviewEnv`, which requires `NOSTR_NSEC`/`RELAY_URL`. These were masked before by
`{ DB: db } as any` until the eslint `no-explicit-any` rule forced the cast to change.

## Changes

- **`worker/src/age-review.ts`** — export `AgeReviewEnv`.
- **`worker/src/age-review.test.ts`** — add a typed `makeEnv()` helper and route every handler env arg through it (removes scattered per-call casts); add the minor-onboarding fields (`created_via`, `claim_link_url`, `claim_link_expires_at`) to the `makeCase` mock.
- **`worker/src/index.ts`** — `ApiResponse` gains `events?: object[]` for the relay-query endpoints (`/api/reports`, `/api/resolution-labels`) that legitimately return arrays.
- **`worker/src/bulk-moderate.ts`** — type the `queryRelayEvents` settle helper instead of `unknown`.
- **`worker/src/ReportWatcher.test.ts`**, **`worker/src/funnelcake-proxy.test.ts`** — small test-typing fixes.
- **`worker/package.json`** — add `typecheck` and reuse the `test:run` script.
- **`.github/workflows/test.yml`** — three new steps (`Worker install` / `Worker typecheck` / `Worker tests`, each `working-directory: worker`). Install uses `--legacy-peer-deps` due to a known peer-dep conflict in the worker lockfile.

No `as any` introduced.

## Verification (local, clean install)
- `worker` `tsc`: 0 errors (sanity-checked that tsc is live by injecting a deliberate error, which it caught)
- `worker` vitest: pass
- root `tsc -p tsconfig.app.json`, `eslint`: clean
