### PR TITLE
fix(moderate): wire ban/unban into Keycast for enforcement parity (#100)

### DIFF
--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import worker from './index';
 
 const env = {
@@ -192,8 +192,9 @@ describe('notifyModerationService null token', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(waitUntil).toHaveBeenCalledOnce();
-    await waitUntil.mock.calls[0][0];
+    // banpubkey schedules two non-critical tasks: the Keycast ban and the DM.
+    expect(waitUntil).toHaveBeenCalledTimes(2);
+    await Promise.all(waitUntil.mock.calls.map(c => c[0]));
     expect(errorSpy).toHaveBeenCalledWith(
       '[notifyAccountState] DM notification error:',
       expect.objectContaining({
@@ -207,6 +208,10 @@ describe('notifyModerationService null token', () => {
 });
 
 describe('relay-rpc account-state side effects', () => {
+  // Restore the global fetch spy even if a test throws mid-assertion, so a
+  // failure can't leak its spy and cascade into later tests.
+  afterEach(() => { vi.restoreAllMocks(); });
+
   const VALID_PUBKEY = 'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234';
 
   function makeAccountStateEnv() {
@@ -282,7 +287,7 @@ describe('relay-rpc account-state side effects', () => {
     await Promise.all(waitUntil.mock.calls.map(c => c[0]));
   }
 
-  it('banpubkey sends DM action ACCOUNT_BANNED', async () => {
+  it('banpubkey triggers Keycast ban and DM action ACCOUNT_BANNED', async () => {
     const fetchSpy = makeFetchSpy();
     const waitUntil = vi.fn();
     const testCtx = { waitUntil } as unknown as ExecutionContext;
@@ -295,8 +300,11 @@ describe('relay-rpc account-state side effects', () => {
     expect(bodies).toHaveLength(1);
     expect(bodies[0].action).toBe('ACCOUNT_BANNED');
     expect(bodies[0].recipientPubkey).toBe(VALID_PUBKEY);
-    // No Keycast suspend/unsuspend on ban
-    expect(keycastCalls(fetchSpy)).toHaveLength(0);
+
+    const kc = keycastCalls(fetchSpy);
+    expect(kc).toHaveLength(1);
+    expect(kc[0].url).toContain(`/api/admin/users/${VALID_PUBKEY}/status`);
+    expect(kc[0].status).toBe('banned');
 
     fetchSpy.mockRestore();
   });
@@ -342,6 +350,25 @@ describe('relay-rpc account-state side effects', () => {
     fetchSpy.mockRestore();
   });
 
+  it('unbanpubkey triggers Keycast restore (active) and sends no DM', async () => {
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+
+    const response = await callRelayRpc('unbanpubkey', [VALID_PUBKEY], makeAccountStateEnv(), testCtx);
+    expect(response.status).toBe(200);
+    await drain(waitUntil);
+
+    const kc = keycastCalls(fetchSpy);
+    expect(kc).toHaveLength(1);
+    expect(kc[0].url).toContain(`/api/admin/users/${VALID_PUBKEY}/status`);
+    expect(kc[0].status).toBe('active');
+    // unban lifts the Keycast ban but sends no DM (restore-on-unban DM tracked in #96)
+    expect(await notifyBodies(fetchSpy)).toHaveLength(0);
+
+    fetchSpy.mockRestore();
+  });
+
   it('ban_pubkey via /api/moderate sends exactly one ACCOUNT_BANNED DM (no double)', async () => {
     const fetchSpy = makeFetchSpy();
     const waitUntil = vi.fn();
@@ -368,6 +395,40 @@ describe('relay-rpc account-state side effects', () => {
     const bodies = await notifyBodies(fetchSpy);
     expect(bodies).toHaveLength(1);
     expect(bodies[0].action).toBe('ACCOUNT_BANNED');
+    // ...and the same path reaches Keycast (status banned).
+    const kc = keycastCalls(fetchSpy);
+    expect(kc).toHaveLength(1);
+    expect(kc[0].status).toBe('banned');
+
+    fetchSpy.mockRestore();
+  });
+
+  it('allow_pubkey via /api/moderate restores the Keycast account (active)', async () => {
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+
+    const response = await worker.fetch(
+      new Request('https://api-relay-prod.divine.video/api/moderate', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Key': 'test-admin-key',
+          Origin: 'https://app.divine.video',
+        },
+        body: JSON.stringify({ action: 'allow_pubkey', pubkey: VALID_PUBKEY }),
+      }),
+      makeAccountStateEnv(),
+      testCtx,
+    );
+    expect(response.status).toBe(200);
+    await drain(waitUntil);
+
+    // allow_pubkey -> unbanpubkey -> Keycast active. Requires ctx to be passed
+    // through handleModerate's allow_pubkey case.
+    const kc = keycastCalls(fetchSpy);
+    expect(kc).toHaveLength(1);
+    expect(kc[0].status).toBe('active');
 
     fetchSpy.mockRestore();
   });

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -16,7 +16,7 @@ import { ensureSchema } from './db';
 import { generatePreAuthToken, verifyPreAuthToken, base64UrlEncode } from './zendesk-preauth';
 import { deriveFunnelcakeApiUrl, proxyFunnelcakeRequest } from './funnelcake-proxy';
 import type { KeycastEnv } from './keycast-client';
-import { suspendUser, unsuspendUser } from './keycast-client';
+import { suspendUser, unsuspendUser, banUser } from './keycast-client';
 import {
   handleGetAgeReviewCases,
   handleGetAgeReviewCase,
@@ -226,6 +226,31 @@ function notifyAccountState(
   const dmPromise = notifyModerationService(env, pubkey, action, reason)
     .catch(err => console.error('[notifyAccountState] DM notification error:', err));
   ctx.waitUntil(dmPromise);
+}
+
+/**
+ * Apply a Keycast account-state change (ban / suspend / restore) as a
+ * NON-CRITICAL enrichment alongside the relay RPC the caller already accepted:
+ * dispatched via ctx.waitUntil, failures logged and swallowed, never
+ * propagated. Without a ctx the work cannot outlive the response, so it is
+ * skipped with a warning rather than started and silently dropped. `op` only
+ * labels the log lines.
+ */
+function enforceKeycastState(
+  op: string,
+  pubkey: string,
+  fn: () => Promise<{ success: boolean; error?: string }>,
+  ctx?: ExecutionContext
+): void {
+  if (!ctx) {
+    console.warn(`[handleRelayRpc] No ExecutionContext; skipping Keycast ${op} for ${pubkey}`);
+    return;
+  }
+  ctx.waitUntil(
+    fn().then(res => {
+      if (!res.success) console.error(`[handleRelayRpc] Keycast ${op} failed for ${pubkey}: ${res.error}`);
+    }).catch(err => console.error(`[handleRelayRpc] Keycast ${op} error:`, err))
+  );
 }
 
 function getAllowedOrigin(requestOrigin: string | null, allowedOriginsEnv: string | undefined): string | null {
@@ -834,7 +859,8 @@ async function handleModerate(
             params: [body.pubkey],
           }),
         });
-        const rpcResponse = await handleRelayRpc(rpcRequest, env, corsHeaders);
+        // Pass ctx so the unbanpubkey Keycast restore (non-critical) is kept alive.
+        const rpcResponse = await handleRelayRpc(rpcRequest, env, corsHeaders, ctx);
         const rpcResult = await rpcResponse.json() as { success: boolean; error?: string };
         if (!rpcResult.success) {
           return jsonResponse({ success: false, error: rpcResult.error || 'unbanpubkey RPC failed' }, 500, corsHeaders);
@@ -889,39 +915,24 @@ async function handleRelayRpc(
     const pubkey = String(body.params[0]);
     const reason = body.params[1] ? String(body.params[1]) : undefined;
 
-    // Note: unbanpubkey intentionally sends no DM here. A restore-on-unban DM
-    // is tracked in #96 (moderation-DM coverage gaps).
+    // Mirror each account-state relay action into Keycast (non-critical) and DM
+    // the user. unbanpubkey lifts the Keycast ban (status -> active) so a
+    // reinstated user can log in again, but sends no DM here -- restore-on-unban
+    // DM is tracked in #96.
     switch (body.method) {
       case 'banpubkey':
-        // Unlike suspend, banpubkey does not yet call Keycast (banUser), so a
-        // relay ban leaves the Keycast account active. Enforcement parity is
-        // tracked in #100; this PR is scoped to the suspend path.
+        enforceKeycastState('ban', pubkey, () => banUser(pubkey, 'moderation', env), ctx);
         notifyAccountState(env, pubkey, 'ACCOUNT_BANNED', reason || 'Account banned by moderator', ctx);
         break;
+      case 'unbanpubkey':
+        enforceKeycastState('unban', pubkey, () => unsuspendUser(pubkey, env), ctx);
+        break;
       case 'suspendpubkey':
-        // Keycast suspend is a non-critical enrichment here: log on failure,
-        // do not fail the RPC the relay already accepted.
-        if (ctx) {
-          ctx.waitUntil(
-            suspendUser(pubkey, 'moderation', env).then(res => {
-              if (!res.success) console.error(`[handleRelayRpc] Keycast suspend failed for ${pubkey}: ${res.error}`);
-            }).catch(err => console.error('[handleRelayRpc] Keycast suspend error:', err))
-          );
-        } else {
-          console.warn(`[handleRelayRpc] No ExecutionContext; skipping Keycast suspend for ${pubkey}`);
-        }
+        enforceKeycastState('suspend', pubkey, () => suspendUser(pubkey, 'moderation', env), ctx);
         notifyAccountState(env, pubkey, 'ACCOUNT_SUSPENDED', reason || 'Account suspended by moderator', ctx);
         break;
       case 'unsuspendpubkey':
-        if (ctx) {
-          ctx.waitUntil(
-            unsuspendUser(pubkey, env).then(res => {
-              if (!res.success) console.error(`[handleRelayRpc] Keycast unsuspend failed for ${pubkey}: ${res.error}`);
-            }).catch(err => console.error('[handleRelayRpc] Keycast unsuspend error:', err))
-          );
-        } else {
-          console.warn(`[handleRelayRpc] No ExecutionContext; skipping Keycast unsuspend for ${pubkey}`);
-        }
+        enforceKeycastState('unsuspend', pubkey, () => unsuspendUser(pubkey, env), ctx);
         notifyAccountState(env, pubkey, 'ACCOUNT_RESTORED', reason || 'Account restored by moderator', ctx);
         break;
     }

--- a/worker/src/keycast-client.ts
+++ b/worker/src/keycast-client.ts
@@ -67,6 +67,11 @@ export async function suspendUser(pubkey: string, reason: KeycastReason, env: Ke
   return callKeycast(pubkey, { status: 'suspended', reason }, env);
 }
 
+/**
+ * Set a Keycast account back to `active`. Lifts BOTH `suspended` and `banned`
+ * (Keycast uses a single status transition), so this is the restore path for
+ * unsuspend AND unban.
+ */
 export async function unsuspendUser(pubkey: string, env: KeycastEnv): Promise<KeycastResult> {
   return callKeycast(pubkey, { status: 'active' }, env);
 }


### PR DESCRIPTION
Closes #100.

## Problem

`banpubkey` enforced at the relay (Funnelcake hides content + blocks posting) and sent an `ACCOUNT_BANNED` DM, but never updated **Keycast** — so a banned user's Keycast account stayed `active` and they could still sign in (landing in a broken/empty state) instead of hitting a clear gate at login. Same login-side gap #94/#98 closed for suspend.

## Changes

- `banpubkey` → `banUser` (Keycast `status: banned`); **add `unbanpubkey`** → `unsuspendUser` (Keycast `active`) so a reinstated user can log in again. `unbanpubkey` sends no DM (restore-on-unban DM tracked in #96).
- Extract `enforceKeycastState()` and route ban/suspend/unsuspend/unban through it — collapses four near-identical non-critical `ctx.waitUntil` blocks (each logs+swallows failure, warns when no `ctx`).
- `handleModerate` `allow_pubkey` now passes `ctx`, so unban reaches Keycast via that path too.
- Tests (TDD): ban → Keycast `banned`, unban → Keycast `active`, on both the relay-rpc and `/api/moderate` paths. Also added a scoped `afterEach` so a failing test can't leak its global `fetch` spy and cascade into later tests.

## Notes

- Ban remains **destructive at the relay** (Funnelcake purge is irreversible); this only adds the Keycast login gate. Suspend stays the reversible tool for cases that may be restored.
- Reason value reuses `'moderation'`; the Keycast `status` (`banned` vs `suspended`) carries the distinction, so no new `KeycastReason` enum value.

## Verification (local, clean install)
- worker `tsc`: 0 errors · worker vitest: 219 pass · root `tsc -p tsconfig.app.json` + `eslint`: clean
