### PR TITLE
feat: accept a dedicated Secrets Store admin key for moderation-service -> relay-rpc (#170)

### DIFF
--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -395,3 +395,57 @@ describe('relay-rpc account-state side effects', () => {
     fetchSpy.mockRestore();
   });
 });
+
+describe('admin access via MOD_RELAY_ADMIN_KEY (Secrets Store shared key)', () => {
+  function makeEnvWithModKey(modKeyValue: string) {
+    return {
+      ALLOWED_ORIGINS: 'https://app.divine.video',
+      RELAY_URL: 'wss://relay.divine.video',
+      ADMIN_API_KEY: 'test-admin-key',
+      MOD_RELAY_ADMIN_KEY: { get: vi.fn(async () => modKeyValue) },
+      MODERATION_ADMIN_URL: 'https://moderation-api.divine.video',
+      SERVICE_API_TOKEN: 'svc-token',
+      MODERATION_API: {
+        fetch: vi.fn(async () => new Response(JSON.stringify({ success: true, sha256: 'abc123', action: 'AGE_RESTRICTED' }), { status: 200 })),
+      },
+    } as never;
+  }
+
+  it('authorizes a request whose X-Admin-Key matches the resolved MOD_RELAY_ADMIN_KEY (not ADMIN_API_KEY)', async () => {
+    const testEnv = makeEnvWithModKey('mod-shared-key');
+    const response = await worker.fetch(
+      new Request('https://api-relay-prod.divine.video/api/moderate-media', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Key': 'mod-shared-key',
+          Origin: 'https://app.divine.video',
+        },
+        body: JSON.stringify({ sha256: 'abc123', action: 'AGE_RESTRICTED' }),
+      }),
+      testEnv,
+      ctx,
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it('rejects a request whose X-Admin-Key matches neither ADMIN_API_KEY nor MOD_RELAY_ADMIN_KEY', async () => {
+    const testEnv = makeEnvWithModKey('mod-shared-key');
+    const response = await worker.fetch(
+      new Request('https://api-relay-prod.divine.video/api/moderate-media', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Key': 'totally-wrong-key',
+          Origin: 'https://app.divine.video',
+        },
+        body: JSON.stringify({ sha256: 'abc123', action: 'AGE_RESTRICTED' }),
+      }),
+      testEnv,
+      ctx,
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -396,7 +396,7 @@ describe('relay-rpc account-state side effects', () => {
   });
 });
 
-describe('admin access via MOD_RELAY_ADMIN_KEY (Secrets Store shared key)', () => {
+describe('relay-rpc admin access via MOD_RELAY_ADMIN_KEY (Secrets Store shared key)', () => {
   function makeEnvWithModKey(modKeyValue: string) {
     return {
       ALLOWED_ORIGINS: 'https://app.divine.video',
@@ -411,7 +411,28 @@ describe('admin access via MOD_RELAY_ADMIN_KEY (Secrets Store shared key)', () =
     } as never;
   }
 
-  it('authorizes a request whose X-Admin-Key matches the resolved MOD_RELAY_ADMIN_KEY (not ADMIN_API_KEY)', async () => {
+  it('authorizes relay-rpc when X-Admin-Key matches the resolved MOD_RELAY_ADMIN_KEY (not ADMIN_API_KEY)', async () => {
+    const testEnv = makeEnvWithModKey('mod-shared-key');
+    const response = await worker.fetch(
+      new Request('https://api-relay-prod.divine.video/api/relay-rpc', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Key': 'mod-shared-key',
+          Origin: 'https://app.divine.video',
+        },
+        body: JSON.stringify({}),
+      }),
+      testEnv,
+      ctx,
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json() as { success: boolean; error: string };
+    expect(body.error).toBe('Missing method');
+  });
+
+  it('does not authorize other admin endpoints with MOD_RELAY_ADMIN_KEY', async () => {
     const testEnv = makeEnvWithModKey('mod-shared-key');
     const response = await worker.fetch(
       new Request('https://api-relay-prod.divine.video/api/moderate-media', {
@@ -427,20 +448,20 @@ describe('admin access via MOD_RELAY_ADMIN_KEY (Secrets Store shared key)', () =
       ctx,
     );
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(401);
   });
 
-  it('rejects a request whose X-Admin-Key matches neither ADMIN_API_KEY nor MOD_RELAY_ADMIN_KEY', async () => {
+  it('rejects relay-rpc when X-Admin-Key matches neither ADMIN_API_KEY nor MOD_RELAY_ADMIN_KEY', async () => {
     const testEnv = makeEnvWithModKey('mod-shared-key');
     const response = await worker.fetch(
-      new Request('https://api-relay-prod.divine.video/api/moderate-media', {
+      new Request('https://api-relay-prod.divine.video/api/relay-rpc', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           'X-Admin-Key': 'totally-wrong-key',
           Origin: 'https://app.divine.video',
         },
-        body: JSON.stringify({ sha256: 'abc123', action: 'AGE_RESTRICTED' }),
+        body: JSON.stringify({}),
       }),
       testEnv,
       ctx,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -86,6 +86,10 @@ interface Env extends KeycastEnv {
   AUTO_HIDE_ENABLED?: string;
   // Admin API key — required on all admin endpoints when request doesn't come through CF Access
   ADMIN_API_KEY?: string;
+  // Dedicated shared key for the divine-moderation-service -> /api/relay-rpc connection.
+  // Secrets Store secret (MODERATION_TO_RELAY_ADMIN_KEY), accepted in addition to
+  // ADMIN_API_KEY so it can be rotated independently of other callers (#170).
+  MOD_RELAY_ADMIN_KEY?: string | SecretStoreSecret;
   // Slack webhook for age review deadline alerts
   SLACK_WEBHOOK_URL?: string;
   // Environment identifier for deep links (e.g., "production", "staging")
@@ -315,21 +319,31 @@ interface ApiResponse {
 }
 
 // Verify that the request is authorized for admin API access.
-// Accepts either:
+// Accepts any of:
 //   1. Cf-Access-Jwt-Assertion header (request came through CF Access on relay.admin.divine.video)
 //   2. X-Admin-Key header matching ADMIN_API_KEY env var (server-to-server callers)
+//   3. X-Admin-Key header matching MOD_RELAY_ADMIN_KEY (Secrets Store shared key for the
+//      divine-moderation-service -> /api/relay-rpc connection, #170)
 // Returns null if authorized, or an error string if not.
-function verifyAdminAccess(request: Request, env: Env): string | null {
+async function verifyAdminAccess(request: Request, env: Env): Promise<string | null> {
   // CF Access validates the JWT at the edge before the request reaches the worker.
   // Header presence here means the request passed CF Access authentication.
   if (request.headers.get('Cf-Access-Jwt-Assertion')) {
     return null;
   }
 
-  // Server-to-server callers use a shared API key
+  // Server-to-server callers use a shared API key.
   const adminKey = request.headers.get('X-Admin-Key');
-  if (env.ADMIN_API_KEY && adminKey === env.ADMIN_API_KEY) {
-    return null;
+  if (adminKey) {
+    if (env.ADMIN_API_KEY && adminKey === env.ADMIN_API_KEY) {
+      return null;
+    }
+    // Dedicated moderation-service key (Secrets Store), accepted in addition to
+    // ADMIN_API_KEY so it can be rotated without disrupting other callers.
+    const modRelayKey = await resolveSecret(env.MOD_RELAY_ADMIN_KEY);
+    if (modRelayKey && adminKey === modRelayKey) {
+      return null;
+    }
   }
 
   return 'Unauthorized: admin access requires CF Access or X-Admin-Key header';
@@ -378,7 +392,7 @@ export default {
       }
 
       // All other /api/* endpoints require admin access (CF Access or API key)
-      const adminAuthError = verifyAdminAccess(request, env);
+      const adminAuthError = await verifyAdminAccess(request, env);
       if (adminAuthError) {
         return jsonResponse({ success: false, error: adminAuthError }, 401, corsHeaders);
       }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -88,7 +88,7 @@ interface Env extends KeycastEnv {
   ADMIN_API_KEY?: string;
   // Dedicated shared key for the divine-moderation-service -> /api/relay-rpc connection.
   // Secrets Store secret (MODERATION_TO_RELAY_ADMIN_KEY), accepted in addition to
-  // ADMIN_API_KEY so it can be rotated independently of other callers (#170).
+  // ADMIN_API_KEY on that route so it can be rotated independently of other callers (#170).
   MOD_RELAY_ADMIN_KEY?: string | SecretStoreSecret;
   // Slack webhook for age review deadline alerts
   SLACK_WEBHOOK_URL?: string;
@@ -322,10 +322,14 @@ interface ApiResponse {
 // Accepts any of:
 //   1. Cf-Access-Jwt-Assertion header (request came through CF Access on relay.admin.divine.video)
 //   2. X-Admin-Key header matching ADMIN_API_KEY env var (server-to-server callers)
-//   3. X-Admin-Key header matching MOD_RELAY_ADMIN_KEY (Secrets Store shared key for the
-//      divine-moderation-service -> /api/relay-rpc connection, #170)
+//   3. X-Admin-Key header matching MOD_RELAY_ADMIN_KEY, only when allowModRelayAdminKey
+//      is true for the divine-moderation-service -> /api/relay-rpc connection (#170)
 // Returns null if authorized, or an error string if not.
-async function verifyAdminAccess(request: Request, env: Env): Promise<string | null> {
+async function verifyAdminAccess(
+  request: Request,
+  env: Env,
+  options: { allowModRelayAdminKey?: boolean } = {}
+): Promise<string | null> {
   // CF Access validates the JWT at the edge before the request reaches the worker.
   // Header presence here means the request passed CF Access authentication.
   if (request.headers.get('Cf-Access-Jwt-Assertion')) {
@@ -338,11 +342,13 @@ async function verifyAdminAccess(request: Request, env: Env): Promise<string | n
     if (env.ADMIN_API_KEY && adminKey === env.ADMIN_API_KEY) {
       return null;
     }
-    // Dedicated moderation-service key (Secrets Store), accepted in addition to
-    // ADMIN_API_KEY so it can be rotated without disrupting other callers.
-    const modRelayKey = await resolveSecret(env.MOD_RELAY_ADMIN_KEY);
-    if (modRelayKey && adminKey === modRelayKey) {
-      return null;
+    if (options.allowModRelayAdminKey) {
+      // Dedicated moderation-service key (Secrets Store), accepted in addition to
+      // ADMIN_API_KEY for relay-rpc so it can be rotated without disrupting other callers.
+      const modRelayKey = await resolveSecret(env.MOD_RELAY_ADMIN_KEY);
+      if (modRelayKey && adminKey === modRelayKey) {
+        return null;
+      }
     }
   }
 
@@ -392,7 +398,9 @@ export default {
       }
 
       // All other /api/* endpoints require admin access (CF Access or API key)
-      const adminAuthError = await verifyAdminAccess(request, env);
+      const adminAuthError = await verifyAdminAccess(request, env, {
+        allowModRelayAdminKey: path === '/api/relay-rpc' && request.method === 'POST',
+      });
       if (adminAuthError) {
         return jsonResponse({ success: false, error: adminAuthError }, 401, corsHeaders);
       }

--- a/worker/wrangler.prod.toml
+++ b/worker/wrangler.prod.toml
@@ -17,8 +17,8 @@ store_id = "ef490704b12a4feb91c7feb51229c364"
 secret_name = "NOSTR_NSEC"
 
 # Shared X-Admin-Key for the divine-moderation-service -> /api/relay-rpc connection (#170).
-# verifyAdminAccess accepts this in addition to ADMIN_API_KEY / CF Access, so the
-# moderation-service ban path can reach the worker via service binding without CF Access.
+# verifyAdminAccess accepts this only for POST /api/relay-rpc, so the moderation-service
+# ban path can reach the worker via service binding without CF Access.
 [[secrets_store_secrets]]
 binding = "MOD_RELAY_ADMIN_KEY"
 store_id = "ef490704b12a4feb91c7feb51229c364"

--- a/worker/wrangler.prod.toml
+++ b/worker/wrangler.prod.toml
@@ -16,6 +16,14 @@ binding = "NOSTR_NSEC"
 store_id = "ef490704b12a4feb91c7feb51229c364"
 secret_name = "NOSTR_NSEC"
 
+# Shared X-Admin-Key for the divine-moderation-service -> /api/relay-rpc connection (#170).
+# verifyAdminAccess accepts this in addition to ADMIN_API_KEY / CF Access, so the
+# moderation-service ban path can reach the worker via service binding without CF Access.
+[[secrets_store_secrets]]
+binding = "MOD_RELAY_ADMIN_KEY"
+store_id = "ef490704b12a4feb91c7feb51229c364"
+secret_name = "MODERATION_TO_RELAY_ADMIN_KEY"
+
 # CF Access credentials for realness proxy (shared across workers)
 [[secrets_store_secrets]]
 binding = "CF_ACCESS_CLIENT_ID"


### PR DESCRIPTION
## Why

Paired with divinevideo/divine-moderation-service#170. The moderation dashboard's per-card **Ban User** calls this worker's `POST /api/relay-rpc` over the public host `api-relay-prod.divine.video`, which returns **HTTP 522** (the CF edge can't reach the worker — reproduced live). The fix on the moderation-service side is to call this worker via a **service binding** (worker-to-worker, by name), which bypasses the edge and DNS — but also bypasses CF Access. So this worker needs to authenticate that caller another way.

## What

`verifyAdminAccess` now **additively** accepts a dedicated shared key on the `X-Admin-Key` header:

- New `MOD_RELAY_ADMIN_KEY` binding — a Cloudflare Secrets Store secret (`MODERATION_TO_RELAY_ADMIN_KEY`, store `ef490704…`), bound in `worker/wrangler.prod.toml`.
- Accepted **in addition to** the existing `ADMIN_API_KEY` and CF Access paths — those are unchanged, so no other caller is affected.
- Resolved via the existing `resolveSecret()` helper, so `verifyAdminAccess` is now `async` (its single caller awaits it).

A dedicated secret (rather than reusing `ADMIN_API_KEY`) keeps this connection isolated, so it can be rotated without disrupting other admin-key callers.

## Deploy notes

- The secret already exists in the store. This worker's deploy already binds 9 Secrets Store secrets, so its deploy token has the needed Secrets Store access.
- The moderation-service side (divine-moderation-service#170 / its PR) sends this key. **Order:** this PR can land first safely (it only widens what's accepted); the moderation-service side must not deploy until this is live.

## Review / tests

- Independent code review: no issues (auth bypass via null/empty key, missing header, and the CF Access path all verified safe; only caller awaited; config matches the established pattern).
- `tsc` clean; full suite **219 tests pass**, including new tests proving the new key is accepted and a wrong key is rejected (401).

Relates to divinevideo/divine-moderation-service#170.
