### PR TITLE
fix(staging): bind MOD_RELAY_ADMIN_KEY to match prod (#170 parity)

### DIFF
--- a/worker/wrangler.staging.toml
+++ b/worker/wrangler.staging.toml
@@ -16,6 +16,14 @@ binding = "NOSTR_NSEC"
 store_id = "ef490704b12a4feb91c7feb51229c364"
 secret_name = "NOSTR_NSEC"
 
+# Shared X-Admin-Key for the divine-moderation-service -> /api/relay-rpc connection (#170).
+# verifyAdminAccess accepts this only for POST /api/relay-rpc, so the moderation-service
+# ban path can reach the worker via service binding without CF Access.
+[[secrets_store_secrets]]
+binding = "MOD_RELAY_ADMIN_KEY"
+store_id = "ef490704b12a4feb91c7feb51229c364"
+secret_name = "MODERATION_TO_RELAY_ADMIN_KEY"
+
 # CF Access credentials for realness proxy (shared across workers)
 [[secrets_store_secrets]]
 binding = "CF_ACCESS_CLIENT_ID"


### PR DESCRIPTION
Restores prod/staging parity for the moderation-service -> relay-rpc admin key.

#104 added the `MOD_RELAY_ADMIN_KEY` Secrets Store binding (#170) to `wrangler.prod.toml` only; `wrangler.staging.toml` was missing it. Without it, the moderation-service ban path can't reach the staging worker's `/api/relay-rpc` via the shared admin key. This mirrors the prod binding exactly — same shared Secrets Store secret (`MODERATION_TO_RELAY_ADMIN_KEY`).

Validated with `wrangler deploy --config wrangler.staging.toml --dry-run`: the `MOD_RELAY_ADMIN_KEY` binding resolves.

Config-only: one binding block.

no reviewer requested on purpose 😉 seeing how fast the review bot beats a human to it.
