### PR TITLE
chore(deploy): use wrangler pages deploy instead of stale surge command

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "npm i && vite",
     "build": "npm i && vite build && cp dist/index.html dist/404.html",
     "test": "npm i && tsc -p tsconfig.app.json --noEmit && eslint && vitest run && vite build",
-    "deploy": "npm run build && npx -y surge@latest dist"
+    "deploy": "npm run build && npx wrangler pages deploy dist"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## What
Replace the `deploy` script's `npx surge@latest dist` with `npx wrangler pages deploy dist`.

## Why
The admin frontend is a Cloudflare Pages project (`wrangler.toml`: `pages_build_output_dir = dist`) deployed by hand with `npx wrangler pages deploy dist`. The `package.json` `deploy` script still pointed at Surge, which we don't use and which contradicts both the wrangler config and our no-Surge convention. No CI workflow referenced it, so this was a latent footgun for anyone who ran `npm run deploy`.

## Scope
One line in `package.json`. No app or CI behavior change.

Closes #124.
