### PR TITLE
Age Review: case, clock, and enforcement hardening

### DIFF
--- a/shared/age-review.ts
+++ b/shared/age-review.ts
@@ -96,4 +96,5 @@ export interface AgeReviewCase {
   claim_link_expires_at: string | null;
   created_at: string;
   updated_at: string;
+  version: number;
 }

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -8,6 +8,7 @@ import type { AgeReviewCase, AgeBand, AgeReviewState } from '../../shared/age-re
 const updateAgeReviewCase = vi.fn().mockResolvedValue({ success: true });
 const getAgeReviewConfig = vi.fn().mockResolvedValue({ auto_delete_on_deny: false });
 const writeText = vi.fn().mockResolvedValue(undefined);
+const toast = vi.fn();
 
 vi.mock('@/hooks/useAdminApi', () => ({
   useAdminApi: () => ({
@@ -18,6 +19,10 @@ vi.mock('@/hooks/useAdminApi', () => ({
 
 vi.mock('@/hooks/useAuthor', () => ({
   useAuthor: () => ({ data: undefined, isLoading: false }),
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ toast }),
 }));
 
 function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
@@ -68,6 +73,8 @@ describe('AgeReviewDetail', () => {
     updateAgeReviewCase.mockClear();
     getAgeReviewConfig.mockClear();
     getAgeReviewConfig.mockResolvedValue({ auto_delete_on_deny: false });
+    updateAgeReviewCase.mockResolvedValue({ success: true });
+    toast.mockClear();
     writeText.mockClear();
     Object.assign(navigator, {
       clipboard: {
@@ -86,7 +93,34 @@ describe('AgeReviewDetail', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Restrict Account' }));
 
     await waitFor(() => {
-      expect(updateAgeReviewCase).toHaveBeenCalledWith('case-1', { state: expectedState });
+      expect(updateAgeReviewCase).toHaveBeenCalledWith('case-1', { state: expectedState, expected_version: 0 });
+    });
+  });
+
+  it('toasts when relay or bulk enforcement fails even if Keycast succeeds', async () => {
+    updateAgeReviewCase.mockResolvedValue({
+      success: false,
+      keycastUpdated: true,
+      enforcementComplete: false,
+      enforcement: {
+        relay: 'failed',
+        bulk: 'failed',
+        keycast: 'ok',
+      },
+    });
+    renderDetail(makeCase({ version: 3 }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restrict Account' }));
+
+    await waitFor(() => {
+      expect(updateAgeReviewCase).toHaveBeenCalledWith('case-1', {
+        state: 'restricted_pending_user_response',
+        expected_version: 3,
+      });
+      expect(toast).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'Account enforcement incomplete',
+        variant: 'destructive',
+      }));
     });
   });
 

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -43,6 +43,7 @@ function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
     claim_link_expires_at: null,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
+    version: 0,
     ...overrides,
   };
 }

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -83,7 +83,7 @@ interface Props {
   caseData: AgeReviewCase;
 }
 
-const KEYCAST_STATES: AgeReviewState[] = [
+const ENFORCEMENT_STATES: AgeReviewState[] = [
   'restricted_pending_user_response',
   'restricted_pending_parental_consent',
   'restricted_pending_support_email',
@@ -109,15 +109,20 @@ export function AgeReviewDetail({ caseData: c }: Props) {
   const updateCase = useMutation({
     mutationFn: (updates: Record<string, unknown>) => {
       pendingStateRef.current = updates.state as string | undefined;
-      return api.updateAgeReviewCase(c.id, updates);
+      return api.updateAgeReviewCase(c.id, { ...updates, expected_version: c.version });
     },
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['age-review-cases'] });
       const requestedState = pendingStateRef.current as AgeReviewState | undefined;
-      if (requestedState && KEYCAST_STATES.includes(requestedState) && data.keycastUpdated === false) {
+      if (requestedState && ENFORCEMENT_STATES.includes(requestedState) && data.enforcementComplete === false) {
+        const failedLegs = [
+          data.enforcement?.relay === 'failed' ? 'relay' : null,
+          data.enforcement?.bulk === 'failed' ? 'content' : null,
+          data.enforcement?.keycast === 'failed' ? 'Keycast' : null,
+        ].filter(Boolean).join(', ');
         toast({
-          title: 'Account enforcement failed',
-          description: 'Case was updated but Keycast account suspension did not apply. The user\'s account may still be active. Retry or escalate.',
+          title: 'Account enforcement incomplete',
+          description: `Case was updated but ${failedLegs || 'one or more enforcement steps'} failed. Escalate for manual remediation.`,
           variant: 'destructive',
         });
       }

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -916,6 +916,15 @@ interface AgeReviewCaseResponse {
   success: boolean;
   case: import('../../shared/age-review').AgeReviewCase;
   keycastUpdated?: boolean;
+  enforcementComplete?: boolean;
+  enforcement?: {
+    relay?: 'not_attempted' | 'ok' | 'failed';
+    relayError?: string;
+    bulk?: 'not_attempted' | 'ok' | 'failed';
+    bulkError?: string;
+    keycast?: 'not_attempted' | 'ok' | 'failed';
+    keycastError?: string;
+  };
 }
 
 export async function getAgeReviewCases(

--- a/worker/migrations/0011_age_review_version.sql
+++ b/worker/migrations/0011_age_review_version.sql
@@ -1,4 +1,4 @@
--- C7: optimistic-concurrency version column for age_review_cases.
+-- optimistic-concurrency version column for age_review_cases.
 -- The case PATCH and the deadline cron were read-modify-write with no guard, so
 -- two concurrent writers (moderator + moderator, or moderator + cron) could
 -- clobber each other's state and each independently fire enforcement side

--- a/worker/migrations/0011_age_review_version.sql
+++ b/worker/migrations/0011_age_review_version.sql
@@ -1,0 +1,7 @@
+-- C7: optimistic-concurrency version column for age_review_cases.
+-- The case PATCH and the deadline cron were read-modify-write with no guard, so
+-- two concurrent writers (moderator + moderator, or moderator + cron) could
+-- clobber each other's state and each independently fire enforcement side
+-- effects, leaving the DB state and the actual Keycast/relay/media state
+-- divergent. Callers now compare-and-swap on this version.
+ALTER TABLE age_review_cases ADD COLUMN version INTEGER NOT NULL DEFAULT 0;

--- a/worker/package.json
+++ b/worker/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest",
     "test:run": "vitest run",
+    "test:d1": "vitest run --config vitest.d1.config.ts",
     "generate-keys": "node scripts/generate-keys.js"
   },
   "dependencies": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -10,6 +10,7 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:d1": "vitest run --config vitest.d1.config.ts",
+    "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "generate-keys": "node scripts/generate-keys.js"
   },
   "dependencies": {

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -15,6 +15,7 @@ import {
 } from './age-review';
 import type { AgeReviewCase } from '../../shared/age-review';
 import { suspendUser, unsuspendUser, banUser, createMinorAccount } from './keycast-client';
+import { suspendPubkey, unsuspendPubkey, banPubkey } from './nip86';
 
 vi.mock('./keycast-client', () => ({
   suspendUser: vi.fn().mockResolvedValue({ success: true }),
@@ -34,6 +35,14 @@ vi.mock('./bulk-moderate', () => ({
       new Response(JSON.stringify({ success: true, eventsProcessed: 0, mediaProcessed: 0, failures: [] }), { status: 200 }),
     ),
   ),
+}));
+
+// Relay-level NIP-86 enforcement (C1/C9). Stubbed to succeed by default; the
+// real wire contract is verified separately in nip86.test.ts.
+vi.mock('./nip86', () => ({
+  suspendPubkey: vi.fn().mockResolvedValue({ success: true }),
+  unsuspendPubkey: vi.fn().mockResolvedValue({ success: true }),
+  banPubkey: vi.fn().mockResolvedValue({ success: true }),
 }));
 
 const corsHeaders = { 'Access-Control-Allow-Origin': '*' };
@@ -693,6 +702,91 @@ describe('Keycast suspension wiring', () => {
     expect(body.success).toBe(false);
     expect(body.enforcement.keycast).toBe('failed');
     expect(body.case.state).toBe('denied_closed');
+  });
+});
+
+// -- Relay pubkey enforcement wiring (C1 / C9) --------------------------------
+
+describe('Relay pubkey enforcement wiring (C1/C9)', () => {
+  beforeEach(() => {
+    vi.mocked(suspendPubkey).mockClear().mockResolvedValue({ success: true });
+    vi.mocked(unsuspendPubkey).mockClear().mockResolvedValue({ success: true });
+    vi.mocked(banPubkey).mockClear().mockResolvedValue({ success: true });
+  });
+
+  function dbReturning(before: AgeReviewCase, after: AgeReviewCase) {
+    let n = 0;
+    const firstFor = (sql: string) => async () => {
+      if (sql.includes('WHERE id = ?')) { n += 1; return n === 1 ? before : after; }
+      return null;
+    };
+    return {
+      prepare: vi.fn().mockImplementation((sql: string) => ({
+        first: vi.fn().mockImplementation(firstFor(sql)),
+        bind: vi.fn().mockReturnValue({
+          first: vi.fn().mockImplementation(firstFor(sql)),
+          run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+        }),
+      })),
+    };
+  }
+
+  async function patchState(before: string, to: string) {
+    const c = makeCase({ state: before as AgeReviewCase['state'] });
+    const db = dbReturning(c, { ...c, state: to as AgeReviewCase['state'] });
+    const req = new Request('https://api.test/api/age-review/cases/case-1', {
+      method: 'PATCH', body: JSON.stringify({ state: to }),
+    });
+    await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db), corsHeaders);
+    return c;
+  }
+
+  it('suspends the pubkey at the relay on restrict', async () => {
+    const c = await patchState('under_moderator_review', 'restricted_pending_user_response');
+    expect(suspendPubkey).toHaveBeenCalledWith(c.pubkey, 'age_review', expect.objectContaining({ DB: expect.anything() }));
+    expect(unsuspendPubkey).not.toHaveBeenCalled();
+    expect(banPubkey).not.toHaveBeenCalled();
+  });
+
+  it('un-suspends the pubkey at the relay on clear', async () => {
+    const c = await patchState('restricted_pending_user_response', 'cleared');
+    expect(unsuspendPubkey).toHaveBeenCalledWith(c.pubkey, expect.objectContaining({ DB: expect.anything() }));
+    expect(suspendPubkey).not.toHaveBeenCalled();
+  });
+
+  it('bans the pubkey at the relay on deny', async () => {
+    const c = await patchState('restricted_pending_user_response', 'denied_closed');
+    expect(banPubkey).toHaveBeenCalledWith(c.pubkey, 'age_review_denied', expect.objectContaining({ DB: expect.anything() }));
+  });
+
+  it('a failed relay leg is surfaced as success:false / 207', async () => {
+    vi.mocked(suspendPubkey).mockResolvedValue({ success: false, error: 'relay 403' });
+    const c = makeCase({ state: 'under_moderator_review' });
+    const db = dbReturning(c, { ...c, state: 'restricted_pending_user_response' });
+    const req = new Request('https://api.test/api/age-review/cases/case-1', {
+      method: 'PATCH', body: JSON.stringify({ state: 'restricted_pending_user_response' }),
+    });
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db), corsHeaders);
+    const body = await res.json() as { success: boolean; enforcement: { relay: string } };
+    expect(res.status).toBe(207);
+    expect(body.success).toBe(false);
+    expect(body.enforcement.relay).toBe('failed');
+  });
+
+  it('cron auto-close bans the pubkey at the relay on expiry', async () => {
+    const expiredCase = makeCase({ state: 'restricted_pending_user_response', deadline_at: new Date(Date.now() - 1000).toISOString() });
+    const db = {
+      prepare: vi.fn().mockImplementation((sql: string) => ({
+        first: vi.fn().mockResolvedValue(null), // config -> default
+        bind: vi.fn().mockReturnValue({
+          all: vi.fn().mockResolvedValue({ results: sql.includes('+2 days') ? [] : [expiredCase] }),
+          first: vi.fn().mockResolvedValue(null),
+          run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+        }),
+      })),
+    };
+    await checkAgeReviewDeadlines(makeEnv(db));
+    expect(banPubkey).toHaveBeenCalledWith(expiredCase.pubkey, 'age_review_expired', expect.objectContaining({ DB: expect.anything() }));
   });
 });
 

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -26,7 +26,7 @@ vi.mock('./keycast-client', () => ({
 
 // Isolate the handler from the relay: these tests exercise state transitions +
 // Keycast wiring, not bulk content moderation. By default the bulk leg succeeds;
-// individual tests can override to assert C5 failure-surfacing.
+// individual tests can override to assert failure-surfacing.
 vi.mock('./bulk-moderate', () => ({
   // mockImplementation (not mockResolvedValue) so each call gets a FRESH Response
   // -- a Response body can only be read once, and triggerBulkModerate consumes it.
@@ -37,7 +37,7 @@ vi.mock('./bulk-moderate', () => ({
   ),
 }));
 
-// Relay-level NIP-86 enforcement (C1/C9). Stubbed to succeed by default; the
+// Relay-level NIP-86 enforcement. Stubbed to succeed by default; the
 // real wire contract is verified separately in nip86.test.ts.
 vi.mock('./nip86', () => ({
   suspendPubkey: vi.fn().mockResolvedValue({ success: true }),
@@ -655,7 +655,7 @@ describe('Keycast suspension wiring', () => {
       enforcement: { keycast: string }; case: { state: string };
     };
 
-    // C5: the failure is surfaced, not masked as success...
+    // the failure is surfaced, not masked as success...
     expect(res.status).toBe(207);
     expect(body.success).toBe(false);
     expect(body.keycastUpdated).toBe(false);
@@ -705,9 +705,9 @@ describe('Keycast suspension wiring', () => {
   });
 });
 
-// -- Relay pubkey enforcement wiring (C1 / C9) --------------------------------
+// -- Relay pubkey enforcement wiring --------------------------------
 
-describe('Relay pubkey enforcement wiring (C1/C9)', () => {
+describe('Relay pubkey enforcement wiring', () => {
   beforeEach(() => {
     vi.mocked(suspendPubkey).mockClear().mockResolvedValue({ success: true });
     vi.mocked(unsuspendPubkey).mockClear().mockResolvedValue({ success: true });

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -23,6 +23,19 @@ vi.mock('./keycast-client', () => ({
   createMinorAccount: vi.fn().mockResolvedValue({ success: true, pubkey: 'a'.repeat(64), claim_url: 'https://login.test/claim/abc' }),
 }));
 
+// Isolate the handler from the relay: these tests exercise state transitions +
+// Keycast wiring, not bulk content moderation. By default the bulk leg succeeds;
+// individual tests can override to assert C5 failure-surfacing.
+vi.mock('./bulk-moderate', () => ({
+  // mockImplementation (not mockResolvedValue) so each call gets a FRESH Response
+  // -- a Response body can only be read once, and triggerBulkModerate consumes it.
+  handleBulkModerate: vi.fn().mockImplementation(() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ success: true, eventsProcessed: 0, mediaProcessed: 0, failures: [] }), { status: 200 }),
+    ),
+  ),
+}));
+
 const corsHeaders = { 'Access-Control-Allow-Origin': '*' };
 
 function makeEnv(db?: unknown, overrides: Partial<AgeReviewEnv> = {}): AgeReviewEnv {
@@ -57,6 +70,7 @@ function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
     claim_link_expires_at: null,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
+    version: 0,
     ...overrides,
   };
 }
@@ -567,16 +581,20 @@ describe('Keycast suspension wiring', () => {
     const updatedCase = { ...restrictedCase, state: 'denied_closed' as const };
 
     let selectCount = 0;
+    // The denied path also reads age_review_config via prepare().first() (no
+    // bind), so the mock exposes a top-level first() as well as bind().first().
+    const firstFor = (sql: string) => async () => {
+      if (sql.includes('WHERE id = ?')) {
+        selectCount += 1;
+        return selectCount === 1 ? restrictedCase : updatedCase;
+      }
+      return null; // age_review_config -> default config
+    };
     const db = {
       prepare: vi.fn().mockImplementation((sql: string) => ({
+        first: vi.fn().mockImplementation(firstFor(sql)),
         bind: vi.fn().mockReturnValue({
-          first: vi.fn().mockImplementation(async () => {
-            if (sql.includes('WHERE id = ?')) {
-              selectCount += 1;
-              return selectCount === 1 ? restrictedCase : updatedCase;
-            }
-            return null;
-          }),
+          first: vi.fn().mockImplementation(firstFor(sql)),
           run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
         }),
       })),
@@ -596,7 +614,7 @@ describe('Keycast suspension wiring', () => {
     expect(banUser).toHaveBeenCalledWith(restrictedCase.pubkey, 'age_review_denied', expect.objectContaining({ DB: expect.anything() }));
   });
 
-  it('does not block state transition when Keycast fails', async () => {
+  it('surfaces a Keycast failure (success:false / 207) but still applies the state transition', async () => {
     vi.mocked(suspendUser).mockResolvedValue({ success: false, error: 'Connection refused' });
 
     const reviewCase = makeCase({ state: 'under_moderator_review' });
@@ -623,30 +641,40 @@ describe('Keycast suspension wiring', () => {
       body: JSON.stringify({ state: 'restricted_pending_user_response' }),
     });
     const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db), corsHeaders);
-    const body = await res.json() as { success: boolean; keycastUpdated: boolean };
+    const body = await res.json() as {
+      success: boolean; keycastUpdated: boolean;
+      enforcement: { keycast: string }; case: { state: string };
+    };
 
-    expect(res.status).toBe(200);
-    expect(body.success).toBe(true);
+    // C5: the failure is surfaced, not masked as success...
+    expect(res.status).toBe(207);
+    expect(body.success).toBe(false);
     expect(body.keycastUpdated).toBe(false);
+    expect(body.enforcement.keycast).toBe('failed');
+    // ...but the DB state transition still persisted (enforcement is best-effort,
+    // retryable; it does not roll back the case state).
+    expect(body.case.state).toBe('restricted_pending_user_response');
   });
 
-  it('does not block state transition when Keycast throws', async () => {
+  it('surfaces a thrown Keycast error (success:false / 207) but still applies the state transition', async () => {
     vi.mocked(banUser).mockRejectedValue(new Error('Network error'));
 
     const restrictedCase = makeCase({ state: 'restricted_pending_user_response' });
     const updatedCase = { ...restrictedCase, state: 'denied_closed' as const };
 
     let selectCount = 0;
+    const firstFor = (sql: string) => async () => {
+      if (sql.includes('WHERE id = ?')) {
+        selectCount += 1;
+        return selectCount === 1 ? restrictedCase : updatedCase;
+      }
+      return null; // age_review_config -> default config
+    };
     const db = {
       prepare: vi.fn().mockImplementation((sql: string) => ({
+        first: vi.fn().mockImplementation(firstFor(sql)),
         bind: vi.fn().mockReturnValue({
-          first: vi.fn().mockImplementation(async () => {
-            if (sql.includes('WHERE id = ?')) {
-              selectCount += 1;
-              return selectCount === 1 ? restrictedCase : updatedCase;
-            }
-            return null;
-          }),
+          first: vi.fn().mockImplementation(firstFor(sql)),
           run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
         }),
       })),
@@ -657,10 +685,14 @@ describe('Keycast suspension wiring', () => {
       body: JSON.stringify({ state: 'denied_closed' }),
     });
     const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(db), corsHeaders);
-    const body = await res.json() as { success: boolean };
+    const body = await res.json() as {
+      success: boolean; enforcement: { keycast: string }; case: { state: string };
+    };
 
-    expect(res.status).toBe(200);
-    expect(body.success).toBe(true);
+    expect(res.status).toBe(207);
+    expect(body.success).toBe(false);
+    expect(body.enforcement.keycast).toBe('failed');
+    expect(body.case.state).toBe('denied_closed');
   });
 });
 

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -886,7 +886,7 @@ describe('checkAgeReviewDeadlines', () => {
       prepare: vi.fn().mockImplementation((sql: string) => ({
         bind: vi.fn().mockReturnValue({
           all: vi.fn().mockResolvedValue({
-            results: sql.includes('deadline_at > datetime') ? [] : [expiredCase],
+            results: sql.includes('+2 days') ? [] : [expiredCase],
           }),
           first: vi.fn().mockResolvedValue(
             sql.includes('zendesk_ticket_id') ? { zendesk_ticket_id: 55 } : null
@@ -935,7 +935,7 @@ describe('checkAgeReviewDeadlines', () => {
       prepare: vi.fn().mockImplementation((sql: string) => ({
         bind: vi.fn().mockReturnValue({
           all: vi.fn().mockResolvedValue({
-            results: sql.includes('deadline_at > datetime') ? [] : [expiredCase],
+            results: sql.includes('+2 days') ? [] : [expiredCase],
           }),
           first: vi.fn().mockResolvedValue(null),
           run: runMock,
@@ -964,7 +964,7 @@ describe('checkAgeReviewDeadlines', () => {
       prepare: vi.fn().mockImplementation((sql: string) => ({
         bind: vi.fn().mockReturnValue({
           all: vi.fn().mockResolvedValue({
-            results: sql.includes('deadline_at > datetime') ? [approachingCase] : [],
+            results: sql.includes('+2 days') ? [approachingCase] : [],
           }),
           run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
         }),
@@ -998,7 +998,7 @@ describe('checkAgeReviewDeadlines', () => {
       prepare: vi.fn().mockImplementation((sql: string) => ({
         bind: vi.fn().mockReturnValue({
           all: vi.fn().mockResolvedValue({
-            results: sql.includes('deadline_at > datetime') ? [approachingCase] : [],
+            results: sql.includes('+2 days') ? [approachingCase] : [],
           }),
           run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
         }),
@@ -1028,7 +1028,7 @@ describe('checkAgeReviewDeadlines', () => {
       prepare: vi.fn().mockImplementation((sql: string) => ({
         bind: vi.fn().mockReturnValue({
           all: vi.fn().mockResolvedValue({
-            results: sql.includes('deadline_at > datetime') ? [approachingCase] : [],
+            results: sql.includes('+2 days') ? [approachingCase] : [],
           }),
           run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
         }),

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -184,24 +184,27 @@ export async function handleUpdateAgeReviewCase(
     return json({ success: false, error: 'No valid fields to update' }, 400, corsHeaders);
   }
 
-  // C7: optimistic locking. Reject a stale client write up front (the UI may
-  // send the version it last read) ...
-  if (
-    body.expected_version !== undefined &&
-    (typeof body.expected_version !== 'number' || body.expected_version !== existing.version)
-  ) {
-    return json({
-      success: false,
-      error: 'Case was modified by another request',
-      code: 'version_conflict',
-      current_version: existing.version,
-    }, 409, corsHeaders);
+  // optimistic locking. Validate expected_version's type like every other
+  // field (a bad type is a 400, not a conflict), then reject a stale client
+  // write up front; the server-read CAS below is the real guard.
+  const versionConflict = () => json({
+    success: false,
+    error: 'Case was modified by another request',
+    code: 'version_conflict',
+    current_version: existing.version,
+  }, 409, corsHeaders);
+
+  if (body.expected_version !== undefined && typeof body.expected_version !== 'number') {
+    return json({ success: false, error: 'expected_version must be a number' }, 400, corsHeaders);
+  }
+  if (body.expected_version !== undefined && body.expected_version !== existing.version) {
+    return versionConflict();
   }
 
   updates.push("updated_at = datetime('now')");
   updates.push('version = version + 1');
 
-  // C7: ... and compare-and-swap on the version we read. If a concurrent
+  // ... and compare-and-swap on the version we read. If a concurrent
   // writer (another moderator, or the deadline cron) committed between our
   // read and this write, changes === 0 and we abort BEFORE running any
   // enforcement -- the loser must not apply side effects for a state it no
@@ -211,12 +214,7 @@ export async function handleUpdateAgeReviewCase(
   ).bind(...binds, caseId, existing.version).run();
 
   if (updateResult.meta?.changes !== 1) {
-    return json({
-      success: false,
-      error: 'Case was modified by another request',
-      code: 'version_conflict',
-      current_version: existing.version,
-    }, 409, corsHeaders);
+    return versionConflict();
   }
 
   let updated = await env.DB.prepare('SELECT * FROM age_review_cases WHERE id = ?')
@@ -266,49 +264,53 @@ export async function handleUpdateAgeReviewCase(
     }
   }
 
-  // C5: enforcement legs are SAFETY-CRITICAL, not "non-critical". Track each
-  // leg's real outcome and surface failure -- the API must not report success
-  // when a minor's content was not actually restricted or their account not
-  // actually suspended. (Zendesk above stays non-critical and swallowed.)
+  // Enforcement legs are safety-critical: track each leg's real outcome and
+  // surface failure -- the API must not report success when a minor's content
+  // was not actually restricted or their account not suspended. (Zendesk above
+  // stays non-critical and swallowed.)
   type LegStatus = 'not_attempted' | 'ok' | 'failed';
   let bulk: LegStatus = 'not_attempted';
   let bulkError: string | undefined;
   let bulkActionTriggered: string | undefined;
-  let keycast: LegStatus = 'not_attempted';
-  let keycastError: string | undefined;
   let relay: LegStatus = 'not_attempted';
   let relayError: string | undefined;
+  let keycast: LegStatus = 'not_attempted';
+  let keycastError: string | undefined;
+
+  // Shared wrapper for the relay and Keycast legs (both resolve to
+  // { success, error }). Returns not_attempted when no call applies.
+  const runStatusLeg = async (
+    label: string,
+    call: () => Promise<{ success: boolean; error?: string }> | undefined,
+  ): Promise<{ status: LegStatus; error?: string }> => {
+    try {
+      const result = await call();
+      if (!result) return { status: 'not_attempted' };
+      if (result.success) return { status: 'ok' };
+      console.error(`[age-review] ${label} ${requestedState} failed for case ${caseId}: ${result.error}`);
+      return { status: 'failed', error: result.error };
+    } catch (error) {
+      console.error(`[age-review] ${label} action failed for case ${caseId}:`, error);
+      return { status: 'failed', error: error instanceof Error ? error.message : String(error) };
+    }
+  };
 
   if (requestedState !== undefined) {
-    // C1/C9: relay-level pubkey enforcement. suspendpubkey (reversible) hides
-    // the user's existing events AND blocks new writes at the relay -- the only
-    // layer that does so regardless of key custody (Keycast suspend does not
-    // stop a self-custody / local-key signer). Reversed by unsuspendpubkey on
-    // clear (existing content reappears on the ~5-min MV refresh). On
-    // deny/expiry, banpubkey purges (one-way) per the closure outcome.
-    try {
-      let relayResult;
-      if (enteredRestrictedState) {
-        relayResult = await suspendPubkey(existing.pubkey, 'age_review', env);
-      } else if (clearedCase) {
-        relayResult = await unsuspendPubkey(existing.pubkey, env);
-      } else if (deniedCase) {
-        relayResult = await banPubkey(existing.pubkey, 'age_review_denied', env);
-      }
-      if (relayResult) {
-        relay = relayResult.success ? 'ok' : 'failed';
-        if (!relayResult.success) {
-          relayError = relayResult.error;
-          console.error(`[age-review] Relay ${requestedState} failed for case ${caseId}: ${relayResult.error}`);
-        }
-      }
-    } catch (error) {
-      relay = 'failed';
-      relayError = error instanceof Error ? error.message : String(error);
-      console.error(`[age-review] Relay action failed for case ${caseId}:`, error);
-    }
+    // Relay-level pubkey enforcement: suspendpubkey (reversible) hides the user's
+    // existing events AND blocks new writes regardless of key custody (Keycast
+    // suspend does not stop a self-custody / local-key signer); unsuspendpubkey
+    // reverses it on clear (existing content reappears on the ~5-min MV refresh);
+    // banpubkey purges (one-way) on deny/expiry.
+    const relayLeg = await runStatusLeg('Relay', () =>
+      enteredRestrictedState ? suspendPubkey(existing.pubkey, 'age_review', env)
+      : clearedCase ? unsuspendPubkey(existing.pubkey, env)
+      : deniedCase ? banPubkey(existing.pubkey, 'age_review_denied', env)
+      : undefined);
+    relay = relayLeg.status;
+    relayError = relayLeg.error;
 
-    // Relay/media bulk content action
+    // Relay/media bulk content action (own shape: throws on failure, and deny
+    // only deletes when auto_delete_on_deny is set).
     try {
       if (enteredRestrictedState) {
         await triggerBulkModerate(existing.pubkey, 'age-restrict-all', 'Age review restriction', env);
@@ -332,31 +334,17 @@ export async function handleUpdateAgeReviewCase(
       console.error(`[age-review] Bulk action failed for case ${caseId}:`, error);
     }
 
-    // Keycast account status
-    try {
-      let keycastResult;
-      if (enteredRestrictedState) {
-        keycastResult = await suspendUser(existing.pubkey, 'age_review', env);
-      } else if (clearedCase) {
-        keycastResult = await unsuspendUser(existing.pubkey, env);
-      } else if (deniedCase) {
-        keycastResult = await banUser(existing.pubkey, 'age_review_denied', env);
-      }
-      if (keycastResult) {
-        keycast = keycastResult.success ? 'ok' : 'failed';
-        if (!keycastResult.success) {
-          keycastError = keycastResult.error;
-          console.error(`[age-review] Keycast ${requestedState} failed for case ${caseId}: ${keycastResult.error}`);
-        }
-      }
-    } catch (error) {
-      keycast = 'failed';
-      keycastError = error instanceof Error ? error.message : String(error);
-      console.error(`[age-review] Keycast call failed for case ${caseId}:`, error);
-    }
+    // Keycast account status.
+    const keycastLeg = await runStatusLeg('Keycast', () =>
+      enteredRestrictedState ? suspendUser(existing.pubkey, 'age_review', env)
+      : clearedCase ? unsuspendUser(existing.pubkey, env)
+      : deniedCase ? banUser(existing.pubkey, 'age_review_denied', env)
+      : undefined);
+    keycast = keycastLeg.status;
+    keycastError = keycastLeg.error;
   }
 
-  // C5: a failed critical leg is reported (success:false, HTTP 207) so the
+  // a failed critical leg is reported (success:false, HTTP 207) so the
   // moderator/UI sees enforcement is incomplete and can retry. The DB state
   // change persisted; re-issuing the PATCH (with the new version) is a safe,
   // CAS-guarded retry of the enforcement.
@@ -930,7 +918,12 @@ export async function handleAgeReviewReplyWebhook(
 export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> {
   if (!env.DB) return;
 
-  // Alert on cases approaching deadline (within 2 days), skip if alerted in last 12h
+  // Alert on cases approaching deadline (within 2 days), skip if alerted in last 12h.
+  // Note the deliberate asymmetry: this alert window covers ALL non-terminal cases,
+  // whereas auto-close (below) only fires for the restricted set. An expired case in
+  // a non-restricted state would therefore be neither auto-closed nor in this window
+  // (its deadline is in the past) -- the expired-needs-action alert further down closes
+  // that blind spot so such cases still reach a moderator.
   const approaching = await env.DB.prepare(`
     SELECT * FROM age_review_cases
     WHERE state NOT IN (${TERMINAL_STATES.map(() => '?').join(',')})
@@ -954,13 +947,13 @@ export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> 
   }
 
   // Auto-close expired cases and ban via Keycast.
-  // C6: only auto-close cases the moderator actually RESTRICTED and that are
+  // only auto-close cases the moderator actually RESTRICTED and that are
   // still awaiting a user/parent response. This deliberately excludes
   // open_reported / under_moderator_review (never restricted -- a single
   // unsolicited report must not auto-ban an account no human confirmed) and
   // submitted_for_review / needs_follow_up (the user already responded -- a
   // moderator must act, the clock must not auto-deny them).
-  // C8: compare via datetime() so the ISO-8601 (`...T...Z`) deadline_at is
+  // compare via datetime() so the ISO-8601 (`...T...Z`) deadline_at is
   // parsed rather than lexically compared against datetime('now') (space form),
   // which otherwise delays expiry until the next UTC midnight.
   const expired = await env.DB.prepare(`
@@ -972,7 +965,7 @@ export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> 
   `).bind(...ACCOUNT_RESTRICTED_AGE_REVIEW_STATES).all<AgeReviewCase>();
 
   for (const row of expired.results) {
-    // C7: CAS on the version we read so the cron doesn't auto-close (and then
+    // CAS on the version we read so the cron doesn't auto-close (and then
     // ban/delete) a case a moderator is concurrently acting on. If the row
     // changed since the SELECT above, skip it -- the moderator's action wins and
     // the next tick re-evaluates. This prevents the cron from clobbering a
@@ -1014,7 +1007,7 @@ export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> 
       console.error(`[age-review] Keycast ban failed for expired case ${row.id}:`, error);
     }
 
-    // C9: purge the user's events at the relay (one-way) -- the case is closed
+    // purge the user's events at the relay (one-way) -- the case is closed
     // by deadline, matching the deny outcome. Best-effort; logged on failure.
     try {
       const relayBan = await banPubkey(row.pubkey, 'age_review_expired', env);
@@ -1031,17 +1024,47 @@ export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> 
   if (expired.results.length > 0 && env.SLACK_WEBHOOK_URL) {
     await sendSlackAlert(env.SLACK_WEBHOOK_URL, 'expired', expired.results);
   }
+
+  // Expired but NOT auto-closable: non-terminal cases the cron deliberately does
+  // not auto-close (never restricted, e.g. open_reported / under_moderator_review,
+  // or the user already responded, e.g. submitted_for_review / needs_follow_up).
+  // Without this they would silently sit past deadline -- out of the approaching
+  // window and out of the auto-close set -- so alert (throttled to 12h) to keep a
+  // human in the loop.
+  const expiredNeedsAction = await env.DB.prepare(`
+    SELECT * FROM age_review_cases
+    WHERE state NOT IN (${TERMINAL_STATES.map(() => '?').join(',')})
+      AND state NOT IN (${ACCOUNT_RESTRICTED_AGE_REVIEW_STATES.map(() => '?').join(',')})
+      AND clock_paused = 0
+      AND deadline_at IS NOT NULL
+      AND datetime(deadline_at) < datetime('now')
+      AND (last_alerted_at IS NULL OR last_alerted_at < datetime('now', '-12 hours'))
+    ORDER BY deadline_at ASC
+  `).bind(...TERMINAL_STATES, ...ACCOUNT_RESTRICTED_AGE_REVIEW_STATES).all<AgeReviewCase>();
+
+  if (expiredNeedsAction.results.length > 0 && env.SLACK_WEBHOOK_URL) {
+    const sent = await sendSlackAlert(env.SLACK_WEBHOOK_URL, 'expired_needs_action', expiredNeedsAction.results);
+    if (sent) {
+      for (const row of expiredNeedsAction.results) {
+        await env.DB.prepare(
+          `UPDATE age_review_cases SET last_alerted_at = datetime('now') WHERE id = ?`
+        ).bind(row.id).run();
+      }
+    }
+  }
 }
 
 async function sendSlackAlert(
   webhookUrl: string,
-  alertType: 'approaching' | 'expired',
+  alertType: 'approaching' | 'expired' | 'expired_needs_action',
   cases: AgeReviewCase[],
 ): Promise<boolean> {
-  const emoji = alertType === 'expired' ? ':rotating_light:' : ':warning:';
-  const header = alertType === 'expired'
-    ? `${emoji} ${cases.length} age review case(s) expired`
-    : `${emoji} ${cases.length} age review case(s) approaching deadline`;
+  const emoji = alertType === 'approaching' ? ':warning:' : ':rotating_light:';
+  const header = alertType === 'approaching'
+    ? `${emoji} ${cases.length} age review case(s) approaching deadline`
+    : alertType === 'expired'
+      ? `${emoji} ${cases.length} age review case(s) expired`
+      : `${emoji} ${cases.length} age review case(s) past deadline awaiting moderator action`;
 
   const lines = cases.map(c => {
     const deadline = c.deadline_at ? new Date(c.deadline_at).toISOString().split('T')[0] : 'no deadline';

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -942,11 +942,20 @@ export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> 
   `).bind(...ACCOUNT_RESTRICTED_AGE_REVIEW_STATES).all<AgeReviewCase>();
 
   for (const row of expired.results) {
-    await env.DB.prepare(`
+    // C7: CAS on the version we read so the cron doesn't auto-close (and then
+    // ban/delete) a case a moderator is concurrently acting on. If the row
+    // changed since the SELECT above, skip it -- the moderator's action wins and
+    // the next tick re-evaluates. This prevents the cron from clobbering a
+    // just-cleared case or double-firing enforcement.
+    const closeResult = await env.DB.prepare(`
       UPDATE age_review_cases
-      SET state = 'denied_closed', resolution_note = 'Auto-closed: deadline expired with no response', updated_at = datetime('now')
-      WHERE id = ?
-    `).bind(row.id).run();
+      SET state = 'denied_closed', resolution_note = 'Auto-closed: deadline expired with no response', updated_at = datetime('now'), version = version + 1
+      WHERE id = ? AND version = ?
+    `).bind(row.id, row.version).run();
+    if (closeResult.meta?.changes !== 1) {
+      console.log(`[age-review] Skipped expired case ${row.id} (modified concurrently)`);
+      continue;
+    }
     console.log(`[age-review] Auto-closed expired case ${row.id} for ${row.pubkey}`);
     try {
       await syncAgeReviewTicketResolution(row.id, 'denied_closed', 'Auto-closed: deadline expired with no response', env);

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -5,6 +5,7 @@ import {
   AGE_BANDS,
   AGE_REVIEW_STATES,
   TERMINAL_STATES,
+  ACCOUNT_RESTRICTED_AGE_REVIEW_STATES,
   VALID_TRANSITIONS,
   isAccountRestrictedAgeReviewState,
   DEADLINE_DAYS,
@@ -850,8 +851,8 @@ export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> 
     WHERE state NOT IN (${TERMINAL_STATES.map(() => '?').join(',')})
       AND clock_paused = 0
       AND deadline_at IS NOT NULL
-      AND deadline_at < datetime('now', '+2 days')
-      AND deadline_at > datetime('now')
+      AND datetime(deadline_at) < datetime('now', '+2 days')
+      AND datetime(deadline_at) > datetime('now')
       AND (last_alerted_at IS NULL OR last_alerted_at < datetime('now', '-12 hours'))
     ORDER BY deadline_at ASC
   `).bind(...TERMINAL_STATES).all<AgeReviewCase>();
@@ -868,13 +869,22 @@ export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> 
   }
 
   // Auto-close expired cases and ban via Keycast.
+  // C6: only auto-close cases the moderator actually RESTRICTED and that are
+  // still awaiting a user/parent response. This deliberately excludes
+  // open_reported / under_moderator_review (never restricted -- a single
+  // unsolicited report must not auto-ban an account no human confirmed) and
+  // submitted_for_review / needs_follow_up (the user already responded -- a
+  // moderator must act, the clock must not auto-deny them).
+  // C8: compare via datetime() so the ISO-8601 (`...T...Z`) deadline_at is
+  // parsed rather than lexically compared against datetime('now') (space form),
+  // which otherwise delays expiry until the next UTC midnight.
   const expired = await env.DB.prepare(`
     SELECT * FROM age_review_cases
-    WHERE state NOT IN (${TERMINAL_STATES.map(() => '?').join(',')})
+    WHERE state IN (${ACCOUNT_RESTRICTED_AGE_REVIEW_STATES.map(() => '?').join(',')})
       AND clock_paused = 0
       AND deadline_at IS NOT NULL
-      AND deadline_at < datetime('now')
-  `).bind(...TERMINAL_STATES).all<AgeReviewCase>();
+      AND datetime(deadline_at) < datetime('now')
+  `).bind(...ACCOUNT_RESTRICTED_AGE_REVIEW_STATES).all<AgeReviewCase>();
 
   for (const row of expired.results) {
     await env.DB.prepare(`

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -350,10 +350,10 @@ export async function handleUpdateAgeReviewCase(
     keycastError = keycastLeg.error;
   }
 
-  // a failed critical leg is reported (success:false, HTTP 207) so the
-  // moderator/UI sees enforcement is incomplete and can retry. The DB state
-  // change persisted; re-issuing the PATCH (with the new version) is a safe,
-  // CAS-guarded retry of the enforcement.
+  // A failed critical leg is reported (success:false, HTTP 207) so the
+  // moderator/UI sees enforcement is incomplete. The DB state change persists;
+  // remediation must re-run the failed downstream enforcement outside this
+  // state-transition handler.
   const enforcementComplete = relay !== 'failed' && bulk !== 'failed' && keycast !== 'failed';
   return json({
     success: enforcementComplete,

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -184,12 +184,40 @@ export async function handleUpdateAgeReviewCase(
     return json({ success: false, error: 'No valid fields to update' }, 400, corsHeaders);
   }
 
-  updates.push("updated_at = datetime('now')");
-  binds.push(caseId);
+  // C7: optimistic locking. Reject a stale client write up front (the UI may
+  // send the version it last read) ...
+  if (
+    body.expected_version !== undefined &&
+    (typeof body.expected_version !== 'number' || body.expected_version !== existing.version)
+  ) {
+    return json({
+      success: false,
+      error: 'Case was modified by another request',
+      code: 'version_conflict',
+      current_version: existing.version,
+    }, 409, corsHeaders);
+  }
 
-  await env.DB.prepare(
-    `UPDATE age_review_cases SET ${updates.join(', ')} WHERE id = ?`
-  ).bind(...binds).run();
+  updates.push("updated_at = datetime('now')");
+  updates.push('version = version + 1');
+
+  // C7: ... and compare-and-swap on the version we read. If a concurrent
+  // writer (another moderator, or the deadline cron) committed between our
+  // read and this write, changes === 0 and we abort BEFORE running any
+  // enforcement -- the loser must not apply side effects for a state it no
+  // longer owns.
+  const updateResult = await env.DB.prepare(
+    `UPDATE age_review_cases SET ${updates.join(', ')} WHERE id = ? AND version = ?`
+  ).bind(...binds, caseId, existing.version).run();
+
+  if (updateResult.meta?.changes !== 1) {
+    return json({
+      success: false,
+      error: 'Case was modified by another request',
+      code: 'version_conflict',
+      current_version: existing.version,
+    }, 409, corsHeaders);
+  }
 
   let updated = await env.DB.prepare('SELECT * FROM age_review_cases WHERE id = ?')
     .bind(caseId).first<AgeReviewCase>();
@@ -238,31 +266,43 @@ export async function handleUpdateAgeReviewCase(
     }
   }
 
-  // Non-critical: fire bulk content actions on state transitions
+  // C5: enforcement legs are SAFETY-CRITICAL, not "non-critical". Track each
+  // leg's real outcome and surface failure -- the API must not report success
+  // when a minor's content was not actually restricted or their account not
+  // actually suspended. (Zendesk above stays non-critical and swallowed.)
+  type LegStatus = 'not_attempted' | 'ok' | 'failed';
+  let bulk: LegStatus = 'not_attempted';
+  let bulkError: string | undefined;
   let bulkActionTriggered: string | undefined;
+  let keycast: LegStatus = 'not_attempted';
+  let keycastError: string | undefined;
+
   if (requestedState !== undefined) {
+    // Relay/media bulk content action
     try {
       if (enteredRestrictedState) {
         await triggerBulkModerate(existing.pubkey, 'age-restrict-all', 'Age review restriction', env);
+        bulk = 'ok';
         bulkActionTriggered = 'age-restrict-all';
       } else if (clearedCase) {
         await triggerBulkModerate(existing.pubkey, 'un-age-restrict-all', 'Age review cleared', env);
+        bulk = 'ok';
         bulkActionTriggered = 'un-age-restrict-all';
       } else if (deniedCase) {
         const config = await getAgeReviewConfig(env.DB!);
         if (config.auto_delete_on_deny) {
           await triggerBulkModerate(existing.pubkey, 'delete-all', 'Age review denied', env);
+          bulk = 'ok';
           bulkActionTriggered = 'delete-all';
         }
       }
     } catch (error) {
+      bulk = 'failed';
+      bulkError = error instanceof Error ? error.message : String(error);
       console.error(`[age-review] Bulk action failed for case ${caseId}:`, error);
     }
-  }
 
-  // Non-critical: sync account status with Keycast
-  let keycastUpdated = false;
-  if (requestedState !== undefined) {
+    // Keycast account status
     try {
       let keycastResult;
       if (enteredRestrictedState) {
@@ -273,17 +313,32 @@ export async function handleUpdateAgeReviewCase(
         keycastResult = await banUser(existing.pubkey, 'age_review_denied', env);
       }
       if (keycastResult) {
-        keycastUpdated = keycastResult.success;
+        keycast = keycastResult.success ? 'ok' : 'failed';
         if (!keycastResult.success) {
+          keycastError = keycastResult.error;
           console.error(`[age-review] Keycast ${requestedState} failed for case ${caseId}: ${keycastResult.error}`);
         }
       }
     } catch (error) {
+      keycast = 'failed';
+      keycastError = error instanceof Error ? error.message : String(error);
       console.error(`[age-review] Keycast call failed for case ${caseId}:`, error);
     }
   }
 
-  return json({ success: true, case: updated, bulkActionTriggered, keycastUpdated }, 200, corsHeaders);
+  // C5: a failed critical leg is reported (success:false, HTTP 207) so the
+  // moderator/UI sees enforcement is incomplete and can retry. The DB state
+  // change persisted; re-issuing the PATCH (with the new version) is a safe,
+  // CAS-guarded retry of the enforcement.
+  const enforcementComplete = bulk !== 'failed' && keycast !== 'failed';
+  return json({
+    success: enforcementComplete,
+    case: updated,
+    bulkActionTriggered,
+    keycastUpdated: keycast === 'ok',
+    enforcementComplete,
+    enforcement: { bulk, bulkError, keycast, keycastError },
+  }, enforcementComplete ? 200 : 207, corsHeaders);
 }
 
 // ---------------------------------------------------------------------------

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -187,11 +187,11 @@ export async function handleUpdateAgeReviewCase(
   // optimistic locking. Validate expected_version's type like every other
   // field (a bad type is a 400, not a conflict), then reject a stale client
   // write up front; the server-read CAS below is the real guard.
-  const versionConflict = () => json({
+  const versionConflict = (currentVersion: number = existing.version) => json({
     success: false,
     error: 'Case was modified by another request',
     code: 'version_conflict',
-    current_version: existing.version,
+    current_version: currentVersion,
   }, 409, corsHeaders);
 
   if (body.expected_version !== undefined && typeof body.expected_version !== 'number') {
@@ -214,7 +214,13 @@ export async function handleUpdateAgeReviewCase(
   ).bind(...binds, caseId, existing.version).run();
 
   if (updateResult.meta?.changes !== 1) {
-    return versionConflict();
+    // A concurrent writer bumped the version between our read and this write, so
+    // existing.version is now stale. Re-read the row to report the TRUE current
+    // version. (The up-front check above can safely return existing.version
+    // because no write has happened yet; on a CAS miss one has.)
+    const fresh = await env.DB.prepare('SELECT version FROM age_review_cases WHERE id = ?')
+      .bind(caseId).first<{ version: number }>();
+    return versionConflict(fresh?.version ?? existing.version);
   }
 
   let updated = await env.DB.prepare('SELECT * FROM age_review_cases WHERE id = ?')

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -15,7 +15,7 @@ import { handleBulkModerate, type BulkModerateEnv } from './bulk-moderate';
 import { resolveZendeskCreds } from './zendesk-sync';
 import type { BulkAction, BulkModerateResult } from '../../shared/bulk-moderation';
 import { suspendUser, unsuspendUser, banUser, createMinorAccount, type KeycastEnv } from './keycast-client';
-import type { SecretStoreSecret } from './nip86';
+import { suspendPubkey, unsuspendPubkey, banPubkey, type SecretStoreSecret } from './nip86';
 
 export interface AgeReviewEnv extends BulkModerateEnv, KeycastEnv {
   SLACK_WEBHOOK_URL?: string;
@@ -276,8 +276,38 @@ export async function handleUpdateAgeReviewCase(
   let bulkActionTriggered: string | undefined;
   let keycast: LegStatus = 'not_attempted';
   let keycastError: string | undefined;
+  let relay: LegStatus = 'not_attempted';
+  let relayError: string | undefined;
 
   if (requestedState !== undefined) {
+    // C1/C9: relay-level pubkey enforcement. suspendpubkey (reversible) hides
+    // the user's existing events AND blocks new writes at the relay -- the only
+    // layer that does so regardless of key custody (Keycast suspend does not
+    // stop a self-custody / local-key signer). Reversed by unsuspendpubkey on
+    // clear (existing content reappears on the ~5-min MV refresh). On
+    // deny/expiry, banpubkey purges (one-way) per the closure outcome.
+    try {
+      let relayResult;
+      if (enteredRestrictedState) {
+        relayResult = await suspendPubkey(existing.pubkey, 'age_review', env);
+      } else if (clearedCase) {
+        relayResult = await unsuspendPubkey(existing.pubkey, env);
+      } else if (deniedCase) {
+        relayResult = await banPubkey(existing.pubkey, 'age_review_denied', env);
+      }
+      if (relayResult) {
+        relay = relayResult.success ? 'ok' : 'failed';
+        if (!relayResult.success) {
+          relayError = relayResult.error;
+          console.error(`[age-review] Relay ${requestedState} failed for case ${caseId}: ${relayResult.error}`);
+        }
+      }
+    } catch (error) {
+      relay = 'failed';
+      relayError = error instanceof Error ? error.message : String(error);
+      console.error(`[age-review] Relay action failed for case ${caseId}:`, error);
+    }
+
     // Relay/media bulk content action
     try {
       if (enteredRestrictedState) {
@@ -330,14 +360,14 @@ export async function handleUpdateAgeReviewCase(
   // moderator/UI sees enforcement is incomplete and can retry. The DB state
   // change persisted; re-issuing the PATCH (with the new version) is a safe,
   // CAS-guarded retry of the enforcement.
-  const enforcementComplete = bulk !== 'failed' && keycast !== 'failed';
+  const enforcementComplete = relay !== 'failed' && bulk !== 'failed' && keycast !== 'failed';
   return json({
     success: enforcementComplete,
     case: updated,
     bulkActionTriggered,
     keycastUpdated: keycast === 'ok',
     enforcementComplete,
-    enforcement: { bulk, bulkError, keycast, keycastError },
+    enforcement: { relay, relayError, bulk, bulkError, keycast, keycastError },
   }, enforcementComplete ? 200 : 207, corsHeaders);
 }
 
@@ -982,6 +1012,19 @@ export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> 
       }
     } catch (error) {
       console.error(`[age-review] Keycast ban failed for expired case ${row.id}:`, error);
+    }
+
+    // C9: purge the user's events at the relay (one-way) -- the case is closed
+    // by deadline, matching the deny outcome. Best-effort; logged on failure.
+    try {
+      const relayBan = await banPubkey(row.pubkey, 'age_review_expired', env);
+      if (relayBan.success) {
+        console.log(`[age-review] Relay banpubkey sent for expired case ${row.id}`);
+      } else {
+        console.error(`[age-review] Relay banpubkey failed for expired case ${row.id}: ${relayBan.error}`);
+      }
+    } catch (error) {
+      console.error(`[age-review] Relay banpubkey failed for expired case ${row.id}:`, error);
     }
   }
 

--- a/worker/src/db.ts
+++ b/worker/src/db.ts
@@ -73,7 +73,8 @@ export async function ensureSchema(db: D1Database): Promise<void> {
       claim_link_url TEXT,
       claim_link_expires_at TEXT,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      version INTEGER NOT NULL DEFAULT 0
     )
   `).run();
 
@@ -98,6 +99,12 @@ export async function ensureSchema(db: D1Database): Promise<void> {
 
   try {
     await db.prepare(`ALTER TABLE age_review_cases ADD COLUMN claim_link_expires_at TEXT`).run();
+  } catch {
+    // Column already exists
+  }
+
+  try {
+    await db.prepare(`ALTER TABLE age_review_cases ADD COLUMN version INTEGER NOT NULL DEFAULT 0`).run();
   } catch {
     // Column already exists
   }

--- a/worker/src/nip86.test.ts
+++ b/worker/src/nip86.test.ts
@@ -11,6 +11,8 @@ import {
   allowEvent,
   banPubkey,
   unbanPubkey,
+  suspendPubkey,
+  unsuspendPubkey,
   publishKind5Deletion,
   type Nip86Env,
 } from './nip86';
@@ -212,6 +214,24 @@ describe('convenience methods', () => {
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
     expect(body.method).toBe('unbanpubkey');
+    expect(body.params).toEqual(['pubkey123']);
+  });
+
+  it('suspendPubkey should call suspendpubkey RPC with [pubkey, reason]', async () => {
+    const result = await suspendPubkey('pubkey123', 'age_review', mockEnv);
+    expect(result.success).toBe(true);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.method).toBe('suspendpubkey');
+    expect(body.params).toEqual(['pubkey123', 'age_review']);
+  });
+
+  it('unsuspendPubkey should call unsuspendpubkey RPC with [pubkey]', async () => {
+    const result = await unsuspendPubkey('pubkey123', mockEnv);
+    expect(result.success).toBe(true);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.method).toBe('unsuspendpubkey');
     expect(body.params).toEqual(['pubkey123']);
   });
 });

--- a/worker/src/nip86.ts
+++ b/worker/src/nip86.ts
@@ -192,6 +192,32 @@ export async function unbanPubkey(
   return callNip86Rpc('unbanpubkey', [pubkey], env);
 }
 
+/**
+ * Suspend a pubkey on the relay (REVERSIBLE). Funnelcake hides the pubkey's
+ * existing events at serve time and rejects new writes, without the destructive
+ * purge that banpubkey performs. Use for age-review restriction; reverse with
+ * unsuspendPubkey on clear. Params mirror banpubkey: [pubkey, reason].
+ */
+export async function suspendPubkey(
+  pubkey: string,
+  reason: string,
+  env: Nip86Env
+): Promise<Nip86RpcResult> {
+  return callNip86Rpc('suspendpubkey', [pubkey, reason], env);
+}
+
+/**
+ * Un-suspend a pubkey on the relay. Existing content becomes visible again once
+ * Funnelcake's suspended-pubkeys materialized view refreshes (~5 min); new
+ * writes are re-allowed immediately.
+ */
+export async function unsuspendPubkey(
+  pubkey: string,
+  env: Nip86Env
+): Promise<Nip86RpcResult> {
+  return callNip86Rpc('unsuspendpubkey', [pubkey], env);
+}
+
 const KIND5_PUBLISH_TIMEOUT_MS = 10_000;
 
 /**

--- a/worker/test/age-review-cron.d1.test.ts
+++ b/worker/test/age-review-cron.d1.test.ts
@@ -12,10 +12,8 @@ import { ensureSchema } from '../src/db';
 import { checkAgeReviewDeadlines } from '../src/age-review';
 
 let mf: Miniflare;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let DB: any;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let cronEnv: any;
+let DB: D1Database;
+let cronEnv: Parameters<typeof checkAgeReviewDeadlines>[0];
 
 beforeAll(async () => {
   mf = new Miniflare({
@@ -25,7 +23,7 @@ beforeAll(async () => {
     compatibilityFlags: ['nodejs_compat'],
     d1Databases: ['DB'],
   });
-  DB = await mf.getD1Database('DB');
+  DB = (await mf.getD1Database('DB')) as unknown as D1Database;
   // Minimal env: no Keycast/Slack/Zendesk/moderation bindings. The cron's
   // downstream calls (banUser, Slack, Zendesk, bulk-delete) then no-op / early
   // out / are swallowed; the DB state transition we assert happens first.
@@ -56,7 +54,7 @@ async function insertCase(id: string, state: string, deadlineIso: string) {
 
 async function stateOf(id: string): Promise<string | undefined> {
   const row = await DB.prepare('SELECT state FROM age_review_cases WHERE id = ?')
-    .bind(id).first();
+    .bind(id).first<{ state: string }>();
   return row?.state;
 }
 
@@ -69,9 +67,9 @@ describe('age-review cron on real D1 (C6 + C8)', () => {
     const r = await DB.prepare(
       `SELECT ('2026-06-22T08:00:00.000Z' < '2026-06-22 12:00:00')           AS lexical,
               (datetime('2026-06-22T08:00:00.000Z') < '2026-06-22 12:00:00') AS fixed`,
-    ).first();
-    expect(r.lexical).toBe(0); // the bug: appears NOT-yet-expired
-    expect(r.fixed).toBe(1);   // the fix: correct temporal comparison
+    ).first<{ lexical: number; fixed: number }>();
+    expect(r!.lexical).toBe(0); // the bug: appears NOT-yet-expired
+    expect(r!.fixed).toBe(1);   // the fix: correct temporal comparison
   });
 
   it('C8: a restricted case that expired earlier TODAY (same UTC day) is auto-closed', async () => {
@@ -116,8 +114,8 @@ describe('age-review cron on real D1 (C6 + C8)', () => {
     await insertCase('c7-cron', 'restricted_pending_user_response', '2020-01-01T00:00:00.000Z');
     await checkAgeReviewDeadlines(cronEnv);
     const row = await DB.prepare('SELECT state, version FROM age_review_cases WHERE id = ?')
-      .bind('c7-cron').first();
-    expect(row.state).toBe('denied_closed');
-    expect(row.version).toBe(1); // CAS UPDATE applied
+      .bind('c7-cron').first<{ state: string; version: number }>();
+    expect(row!.state).toBe('denied_closed');
+    expect(row!.version).toBe(1); // CAS UPDATE applied
   });
 });

--- a/worker/test/age-review-cron.d1.test.ts
+++ b/worker/test/age-review-cron.d1.test.ts
@@ -111,4 +111,13 @@ describe('age-review cron on real D1 (C6 + C8)', () => {
     await checkAgeReviewDeadlines(cronEnv);
     expect(await stateOf('c6-paused')).toBe('restricted_pending_user_response');
   });
+
+  it('C7: cron auto-close uses CAS and bumps the version', async () => {
+    await insertCase('c7-cron', 'restricted_pending_user_response', '2020-01-01T00:00:00.000Z');
+    await checkAgeReviewDeadlines(cronEnv);
+    const row = await DB.prepare('SELECT state, version FROM age_review_cases WHERE id = ?')
+      .bind('c7-cron').first();
+    expect(row.state).toBe('denied_closed');
+    expect(row.version).toBe(1); // CAS UPDATE applied
+  });
 });

--- a/worker/test/age-review-cron.d1.test.ts
+++ b/worker/test/age-review-cron.d1.test.ts
@@ -1,0 +1,114 @@
+// Real-D1 (Miniflare SQLite) validation for the age-review cron fixes:
+//   C8 -- deadline comparison must use datetime(deadline_at), not a lexical
+//         TEXT compare of an ISO-8601 (`...T...Z`) value against datetime('now').
+//   C6 -- the auto-close cron must only act on cases that were actually
+//         RESTRICTED and are still awaiting a response.
+// The existing vitest.config.ts runs on node with a MOCKED DB, so it never
+// exercised SQLite and could not have caught the C8 bug. This suite runs the
+// real checkAgeReviewDeadlines against a real Miniflare-backed D1.
+import { Miniflare } from 'miniflare';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { ensureSchema } from '../src/db';
+import { checkAgeReviewDeadlines } from '../src/age-review';
+
+let mf: Miniflare;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let DB: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let cronEnv: any;
+
+beforeAll(async () => {
+  mf = new Miniflare({
+    modules: true,
+    script: 'export default { fetch() { return new Response("ok"); } };',
+    compatibilityDate: '2024-12-01',
+    compatibilityFlags: ['nodejs_compat'],
+    d1Databases: ['DB'],
+  });
+  DB = await mf.getD1Database('DB');
+  // Minimal env: no Keycast/Slack/Zendesk/moderation bindings. The cron's
+  // downstream calls (banUser, Slack, Zendesk, bulk-delete) then no-op / early
+  // out / are swallowed; the DB state transition we assert happens first.
+  cronEnv = { DB };
+});
+
+afterAll(async () => {
+  await mf?.dispose();
+});
+
+async function reset() {
+  await ensureSchema(DB);
+  await DB.prepare('DELETE FROM age_review_cases').run();
+  await DB.prepare('DELETE FROM age_review_config').run();
+  // Skip the auto-delete bulk-moderate path (which would open a relay WebSocket)
+  // so the test stays hermetic; we validate the state machine, not delete.
+  await DB.prepare(
+    "INSERT OR REPLACE INTO age_review_config (key, value) VALUES ('auto_delete_on_deny', 'false')",
+  ).run();
+}
+
+async function insertCase(id: string, state: string, deadlineIso: string) {
+  await DB.prepare(
+    `INSERT INTO age_review_cases (id, pubkey, state, deadline_at, clock_paused)
+     VALUES (?, ?, ?, ?, 0)`,
+  ).bind(id, `pk_${id}`, state, deadlineIso).run();
+}
+
+async function stateOf(id: string): Promise<string | undefined> {
+  const row = await DB.prepare('SELECT state FROM age_review_cases WHERE id = ?')
+    .bind(id).first();
+  return row?.state;
+}
+
+describe('age-review cron on real D1 (C6 + C8)', () => {
+  beforeEach(reset);
+
+  it('C8 mechanism: lexical TEXT compare misfires where datetime() is correct', async () => {
+    // 08:00 is clearly before 12:00 on the same day, but the ISO string sorts
+    // AFTER the space-form because 'T'(0x54) > ' '(0x20).
+    const r = await DB.prepare(
+      `SELECT ('2026-06-22T08:00:00.000Z' < '2026-06-22 12:00:00')           AS lexical,
+              (datetime('2026-06-22T08:00:00.000Z') < '2026-06-22 12:00:00') AS fixed`,
+    ).first();
+    expect(r.lexical).toBe(0); // the bug: appears NOT-yet-expired
+    expect(r.fixed).toBe(1);   // the fix: correct temporal comparison
+  });
+
+  it('C8: a restricted case that expired earlier TODAY (same UTC day) is auto-closed', async () => {
+    const deadline = new Date(Date.now() - 60_000).toISOString(); // 1 min ago
+    await insertCase('c8-today', 'restricted_pending_user_response', deadline);
+    await checkAgeReviewDeadlines(cronEnv);
+    expect(await stateOf('c8-today')).toBe('denied_closed');
+  });
+
+  it('C6: a never-restricted (open_reported) expired case is NOT auto-closed/banned', async () => {
+    await insertCase('c6-open', 'open_reported', '2020-01-01T00:00:00.000Z');
+    await checkAgeReviewDeadlines(cronEnv);
+    expect(await stateOf('c6-open')).toBe('open_reported');
+  });
+
+  it('C6: a never-restricted (under_moderator_review) expired case is NOT auto-closed', async () => {
+    await insertCase('c6-umr', 'under_moderator_review', '2020-01-01T00:00:00.000Z');
+    await checkAgeReviewDeadlines(cronEnv);
+    expect(await stateOf('c6-umr')).toBe('under_moderator_review');
+  });
+
+  it('C6: an already-responded (submitted_for_review) expired case is NOT auto-closed', async () => {
+    await insertCase('c6-sub', 'submitted_for_review', '2020-01-01T00:00:00.000Z');
+    await checkAgeReviewDeadlines(cronEnv);
+    expect(await stateOf('c6-sub')).toBe('submitted_for_review');
+  });
+
+  it('C6: a restricted + pending expired case IS auto-closed', async () => {
+    await insertCase('c6-restricted', 'restricted_pending_parental_consent', '2020-01-01T00:00:00.000Z');
+    await checkAgeReviewDeadlines(cronEnv);
+    expect(await stateOf('c6-restricted')).toBe('denied_closed');
+  });
+
+  it('a paused restricted case is NOT auto-closed even if expired', async () => {
+    await insertCase('c6-paused', 'restricted_pending_user_response', '2020-01-01T00:00:00.000Z');
+    await DB.prepare('UPDATE age_review_cases SET clock_paused = 1 WHERE id = ?').bind('c6-paused').run();
+    await checkAgeReviewDeadlines(cronEnv);
+    expect(await stateOf('c6-paused')).toBe('restricted_pending_user_response');
+  });
+});

--- a/worker/test/age-review-cron.d1.test.ts
+++ b/worker/test/age-review-cron.d1.test.ts
@@ -1,13 +1,13 @@
 // Real-D1 (Miniflare SQLite) validation for the age-review cron fixes:
-//   C8 -- deadline comparison must use datetime(deadline_at), not a lexical
+//   deadline comparison must use datetime(deadline_at), not a lexical
 //         TEXT compare of an ISO-8601 (`...T...Z`) value against datetime('now').
-//   C6 -- the auto-close cron must only act on cases that were actually
+//   the auto-close cron must only act on cases that were actually
 //         RESTRICTED and are still awaiting a response.
 // The existing vitest.config.ts runs on node with a MOCKED DB, so it never
-// exercised SQLite and could not have caught the C8 bug. This suite runs the
+// exercised SQLite and could not have caught the bug. This suite runs the
 // real checkAgeReviewDeadlines against a real Miniflare-backed D1.
 import { Miniflare } from 'miniflare';
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
 import { ensureSchema } from '../src/db';
 import { checkAgeReviewDeadlines } from '../src/age-review';
 
@@ -58,10 +58,11 @@ async function stateOf(id: string): Promise<string | undefined> {
   return row?.state;
 }
 
-describe('age-review cron on real D1 (C6 + C8)', () => {
+describe('age-review cron on real D1', () => {
   beforeEach(reset);
+  afterEach(() => vi.restoreAllMocks());
 
-  it('C8 mechanism: lexical TEXT compare misfires where datetime() is correct', async () => {
+  it('mechanism: lexical TEXT compare misfires where datetime() is correct', async () => {
     // 08:00 is clearly before 12:00 on the same day, but the ISO string sorts
     // AFTER the space-form because 'T'(0x54) > ' '(0x20).
     const r = await DB.prepare(
@@ -72,32 +73,32 @@ describe('age-review cron on real D1 (C6 + C8)', () => {
     expect(r!.fixed).toBe(1);   // the fix: correct temporal comparison
   });
 
-  it('C8: a restricted case that expired earlier TODAY (same UTC day) is auto-closed', async () => {
+  it('a restricted case that expired earlier TODAY (same UTC day) is auto-closed', async () => {
     const deadline = new Date(Date.now() - 60_000).toISOString(); // 1 min ago
     await insertCase('c8-today', 'restricted_pending_user_response', deadline);
     await checkAgeReviewDeadlines(cronEnv);
     expect(await stateOf('c8-today')).toBe('denied_closed');
   });
 
-  it('C6: a never-restricted (open_reported) expired case is NOT auto-closed/banned', async () => {
+  it('a never-restricted (open_reported) expired case is NOT auto-closed/banned', async () => {
     await insertCase('c6-open', 'open_reported', '2020-01-01T00:00:00.000Z');
     await checkAgeReviewDeadlines(cronEnv);
     expect(await stateOf('c6-open')).toBe('open_reported');
   });
 
-  it('C6: a never-restricted (under_moderator_review) expired case is NOT auto-closed', async () => {
+  it('a never-restricted (under_moderator_review) expired case is NOT auto-closed', async () => {
     await insertCase('c6-umr', 'under_moderator_review', '2020-01-01T00:00:00.000Z');
     await checkAgeReviewDeadlines(cronEnv);
     expect(await stateOf('c6-umr')).toBe('under_moderator_review');
   });
 
-  it('C6: an already-responded (submitted_for_review) expired case is NOT auto-closed', async () => {
+  it('an already-responded (submitted_for_review) expired case is NOT auto-closed', async () => {
     await insertCase('c6-sub', 'submitted_for_review', '2020-01-01T00:00:00.000Z');
     await checkAgeReviewDeadlines(cronEnv);
     expect(await stateOf('c6-sub')).toBe('submitted_for_review');
   });
 
-  it('C6: a restricted + pending expired case IS auto-closed', async () => {
+  it('a restricted + pending expired case IS auto-closed', async () => {
     await insertCase('c6-restricted', 'restricted_pending_parental_consent', '2020-01-01T00:00:00.000Z');
     await checkAgeReviewDeadlines(cronEnv);
     expect(await stateOf('c6-restricted')).toBe('denied_closed');
@@ -110,7 +111,28 @@ describe('age-review cron on real D1 (C6 + C8)', () => {
     expect(await stateOf('c6-paused')).toBe('restricted_pending_user_response');
   });
 
-  it('C7: cron auto-close uses CAS and bumps the version', async () => {
+  it('an expired non-restricted case is surfaced via the awaiting-moderator-action alert', async () => {
+    // submitted_for_review is past deadline: the cron must NOT auto-close it (the
+    // user responded; a moderator must decide) but must still alert so it does not
+    // sit in the blind spot between the approaching window and the auto-close set.
+    const bodies: string[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation((_input, init) => {
+      bodies.push(String(init?.body ?? ''));
+      return Promise.resolve(new Response('ok', { status: 200 }));
+    });
+    await insertCase('na-sub', 'submitted_for_review', '2020-01-01T00:00:00.000Z');
+    await checkAgeReviewDeadlines({ ...cronEnv, SLACK_WEBHOOK_URL: 'https://hooks.test/x' });
+
+    expect(await stateOf('na-sub')).toBe('submitted_for_review'); // not auto-closed
+    const alert = bodies.find((b) => b.includes('awaiting moderator action'));
+    expect(alert).toBeTruthy();
+    expect(alert).toContain('pk_na-sub');
+    const row = await DB.prepare('SELECT last_alerted_at FROM age_review_cases WHERE id = ?')
+      .bind('na-sub').first<{ last_alerted_at: string | null }>();
+    expect(row!.last_alerted_at).not.toBeNull(); // 12h throttle stamp written
+  });
+
+  it('cron auto-close uses CAS and bumps the version', async () => {
     await insertCase('c7-cron', 'restricted_pending_user_response', '2020-01-01T00:00:00.000Z');
     await checkAgeReviewDeadlines(cronEnv);
     const row = await DB.prepare('SELECT state, version FROM age_review_cases WHERE id = ?')

--- a/worker/test/age-review-handler.d1.test.ts
+++ b/worker/test/age-review-handler.d1.test.ts
@@ -9,11 +9,9 @@ import { ensureSchema } from '../src/db';
 import { handleUpdateAgeReviewCase } from '../src/age-review';
 
 let mf: Miniflare;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let DB: any;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let env: any;
-const cors = {};
+let DB: D1Database;
+let env: Parameters<typeof handleUpdateAgeReviewCase>[2];
+const cors: Record<string, string> = {};
 
 beforeAll(async () => {
   mf = new Miniflare({
@@ -23,7 +21,7 @@ beforeAll(async () => {
     compatibilityFlags: ['nodejs_compat'],
     d1Databases: ['DB'],
   });
-  DB = await mf.getD1Database('DB');
+  DB = (await mf.getD1Database('DB')) as unknown as D1Database;
   // No KEYCAST_URL / RELAY_URL / MODERATION bindings: enforcement legs fail,
   // which is what we want for the C5 surfacing test.
   env = { DB };
@@ -54,7 +52,10 @@ function patch(id: string, patchBody: Record<string, unknown>) {
 }
 
 async function rowOf(id: string) {
-  return DB.prepare('SELECT state, version FROM age_review_cases WHERE id = ?').bind(id).first();
+  const row = await DB.prepare('SELECT state, version FROM age_review_cases WHERE id = ?')
+    .bind(id).first<{ state: string; version: number }>();
+  if (!row) throw new Error(`row not found: ${id}`);
+  return row;
 }
 
 describe('age-review handler on real D1 (C7 + C5)', () => {

--- a/worker/test/age-review-handler.d1.test.ts
+++ b/worker/test/age-review-handler.d1.test.ts
@@ -1,7 +1,7 @@
 // Real-D1 (Miniflare SQLite) validation for the age-review handler fixes:
-//   C7 -- optimistic concurrency: a compare-and-swap on a version column so two
+//   optimistic concurrency: a compare-and-swap on a version column so two
 //         racing writers can't clobber each other / double-fire enforcement.
-//   C5 -- enforcement failures are surfaced (success:false / HTTP 207), not
+//   enforcement failures are surfaced (success:false / HTTP 207), not
 //         masked as success, while the state transition still persists.
 import { Miniflare } from 'miniflare';
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
@@ -23,7 +23,7 @@ beforeAll(async () => {
   });
   DB = (await mf.getD1Database('DB')) as unknown as D1Database;
   // No KEYCAST_URL / RELAY_URL / MODERATION bindings: enforcement legs fail,
-  // which is what we want for the C5 surfacing test.
+  // which is what we want for the surfacing test.
   env = { DB };
 });
 afterAll(async () => { await mf?.dispose(); });
@@ -58,10 +58,10 @@ async function rowOf(id: string) {
   return row;
 }
 
-describe('age-review handler on real D1 (C7 + C5)', () => {
+describe('age-review handler on real D1', () => {
   beforeEach(reset);
 
-  it('C7: a stale expected_version is rejected with 409 and the state is unchanged', async () => {
+  it('a stale expected_version is rejected with 409 and the state is unchanged', async () => {
     await insertCase('c7-stale', 'open_reported');
     const res = await patch('c7-stale', { state: 'under_moderator_review', expected_version: 999 });
     expect(res.status).toBe(409);
@@ -72,7 +72,7 @@ describe('age-review handler on real D1 (C7 + C5)', () => {
     expect(row.version).toBe(0);
   });
 
-  it('C7: a matching version succeeds and increments version', async () => {
+  it('a matching version succeeds and increments version', async () => {
     await insertCase('c7-ok', 'open_reported');
     const res = await patch('c7-ok', { state: 'under_moderator_review', expected_version: 0 });
     expect(res.status).toBe(200);
@@ -81,7 +81,17 @@ describe('age-review handler on real D1 (C7 + C5)', () => {
     expect(row.version).toBe(1);
   });
 
-  it('C7: re-using a now-stale version (CAS) is rejected', async () => {
+  it('a non-number expected_version is a 400, not a 409 version_conflict', async () => {
+    await insertCase('ev-type', 'open_reported');
+    const res = await patch('ev-type', { state: 'under_moderator_review', expected_version: '0' });
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/expected_version must be a number/);
+    // bad input must not transition the case
+    expect((await rowOf('ev-type')).state).toBe('open_reported');
+  });
+
+  it('re-using a now-stale version (CAS) is rejected', async () => {
     await insertCase('c7-cas', 'open_reported');
     const first = await patch('c7-cas', { state: 'under_moderator_review', expected_version: 0 });
     expect(first.status).toBe(200);
@@ -91,7 +101,7 @@ describe('age-review handler on real D1 (C7 + C5)', () => {
     expect((await rowOf('c7-cas')).state).toBe('under_moderator_review');
   });
 
-  it('C7: server-read CAS path (no client expected_version) applies and bumps version', async () => {
+  it('server-read CAS path (no client expected_version) applies and bumps version', async () => {
     // When the client omits expected_version, the handler still compares-and-swaps
     // on the version it read (WHERE version = <read>). The lost-update REJECTION
     // for that same WHERE clause is proven deterministically by the
@@ -103,7 +113,7 @@ describe('age-review handler on real D1 (C7 + C5)', () => {
     expect((await rowOf('c7-serverread')).version).toBe(1);
   });
 
-  it('C5: a failed enforcement leg is surfaced (success:false / 207) but the transition persists', async () => {
+  it('a failed enforcement leg is surfaced (success:false / 207) but the transition persists', async () => {
     await insertCase('c5', 'under_moderator_review');
     const res = await patch('c5', { state: 'restricted_pending_user_response' });
     // No relay/keycast configured -> both legs fail; the API must NOT claim success.
@@ -114,7 +124,7 @@ describe('age-review handler on real D1 (C7 + C5)', () => {
     };
     expect(body.success).toBe(false);
     expect(body.enforcementComplete).toBe(false);
-    expect(body.enforcement.relay).toBe('failed'); // C1: relay suspend attempted, no relay configured
+    expect(body.enforcement.relay).toBe('failed'); // relay suspend attempted, no relay configured
     expect(body.enforcement.bulk).toBe('failed');
     // ...but the DB state transition still applied (best-effort, retryable).
     expect(body.case.state).toBe('restricted_pending_user_response');

--- a/worker/test/age-review-handler.d1.test.ts
+++ b/worker/test/age-review-handler.d1.test.ts
@@ -109,10 +109,11 @@ describe('age-review handler on real D1 (C7 + C5)', () => {
     expect(res.status).toBe(207);
     const body = await res.json() as {
       success: boolean; enforcementComplete: boolean;
-      enforcement: { bulk: string; keycast: string }; case: { state: string };
+      enforcement: { relay: string; bulk: string; keycast: string }; case: { state: string };
     };
     expect(body.success).toBe(false);
     expect(body.enforcementComplete).toBe(false);
+    expect(body.enforcement.relay).toBe('failed'); // C1: relay suspend attempted, no relay configured
     expect(body.enforcement.bulk).toBe('failed');
     // ...but the DB state transition still applied (best-effort, retryable).
     expect(body.case.state).toBe('restricted_pending_user_response');

--- a/worker/test/age-review-handler.d1.test.ts
+++ b/worker/test/age-review-handler.d1.test.ts
@@ -1,0 +1,121 @@
+// Real-D1 (Miniflare SQLite) validation for the age-review handler fixes:
+//   C7 -- optimistic concurrency: a compare-and-swap on a version column so two
+//         racing writers can't clobber each other / double-fire enforcement.
+//   C5 -- enforcement failures are surfaced (success:false / HTTP 207), not
+//         masked as success, while the state transition still persists.
+import { Miniflare } from 'miniflare';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { ensureSchema } from '../src/db';
+import { handleUpdateAgeReviewCase } from '../src/age-review';
+
+let mf: Miniflare;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let DB: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let env: any;
+const cors = {};
+
+beforeAll(async () => {
+  mf = new Miniflare({
+    modules: true,
+    script: 'export default { fetch() { return new Response("ok"); } };',
+    compatibilityDate: '2024-12-01',
+    compatibilityFlags: ['nodejs_compat'],
+    d1Databases: ['DB'],
+  });
+  DB = await mf.getD1Database('DB');
+  // No KEYCAST_URL / RELAY_URL / MODERATION bindings: enforcement legs fail,
+  // which is what we want for the C5 surfacing test.
+  env = { DB };
+});
+afterAll(async () => { await mf?.dispose(); });
+
+async function reset() {
+  await ensureSchema(DB);
+  await DB.prepare('DELETE FROM age_review_cases').run();
+  await DB.prepare(
+    "INSERT OR REPLACE INTO age_review_config (key, value) VALUES ('auto_delete_on_deny', 'false')",
+  ).run();
+}
+
+async function insertCase(id: string, state: string) {
+  await DB.prepare(
+    `INSERT INTO age_review_cases (id, pubkey, state, deadline_at, clock_paused, version)
+     VALUES (?, ?, ?, ?, 0, 0)`,
+  ).bind(id, `pk_${id}`, state, new Date(Date.now() + 9 * 864e5).toISOString()).run();
+}
+
+function patch(id: string, patchBody: Record<string, unknown>) {
+  const req = new Request(`https://api.test/api/age-review/cases/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(patchBody),
+  });
+  return handleUpdateAgeReviewCase(req, id, env, cors);
+}
+
+async function rowOf(id: string) {
+  return DB.prepare('SELECT state, version FROM age_review_cases WHERE id = ?').bind(id).first();
+}
+
+describe('age-review handler on real D1 (C7 + C5)', () => {
+  beforeEach(reset);
+
+  it('C7: a stale expected_version is rejected with 409 and the state is unchanged', async () => {
+    await insertCase('c7-stale', 'open_reported');
+    const res = await patch('c7-stale', { state: 'under_moderator_review', expected_version: 999 });
+    expect(res.status).toBe(409);
+    const body = await res.json() as { code: string };
+    expect(body.code).toBe('version_conflict');
+    const row = await rowOf('c7-stale');
+    expect(row.state).toBe('open_reported'); // unchanged
+    expect(row.version).toBe(0);
+  });
+
+  it('C7: a matching version succeeds and increments version', async () => {
+    await insertCase('c7-ok', 'open_reported');
+    const res = await patch('c7-ok', { state: 'under_moderator_review', expected_version: 0 });
+    expect(res.status).toBe(200);
+    const row = await rowOf('c7-ok');
+    expect(row.state).toBe('under_moderator_review');
+    expect(row.version).toBe(1);
+  });
+
+  it('C7: re-using a now-stale version (CAS) is rejected', async () => {
+    await insertCase('c7-cas', 'open_reported');
+    const first = await patch('c7-cas', { state: 'under_moderator_review', expected_version: 0 });
+    expect(first.status).toBe(200);
+    // version is now 1; a second writer still holding version 0 must lose.
+    const second = await patch('c7-cas', { state: 'needs_follow_up', expected_version: 0 });
+    expect(second.status).toBe(409);
+    expect((await rowOf('c7-cas')).state).toBe('under_moderator_review');
+  });
+
+  it('C7: server-read CAS path (no client expected_version) applies and bumps version', async () => {
+    // When the client omits expected_version, the handler still compares-and-swaps
+    // on the version it read (WHERE version = <read>). The lost-update REJECTION
+    // for that same WHERE clause is proven deterministically by the
+    // "re-using a now-stale version" test above; a true read-read-write-write
+    // interleave can't be reproduced here because Miniflare D1 serializes ops.
+    await insertCase('c7-serverread', 'open_reported');
+    const res = await patch('c7-serverread', { state: 'under_moderator_review' });
+    expect(res.status).toBe(200);
+    expect((await rowOf('c7-serverread')).version).toBe(1);
+  });
+
+  it('C5: a failed enforcement leg is surfaced (success:false / 207) but the transition persists', async () => {
+    await insertCase('c5', 'under_moderator_review');
+    const res = await patch('c5', { state: 'restricted_pending_user_response' });
+    // No relay/keycast configured -> both legs fail; the API must NOT claim success.
+    expect(res.status).toBe(207);
+    const body = await res.json() as {
+      success: boolean; enforcementComplete: boolean;
+      enforcement: { bulk: string; keycast: string }; case: { state: string };
+    };
+    expect(body.success).toBe(false);
+    expect(body.enforcementComplete).toBe(false);
+    expect(body.enforcement.bulk).toBe('failed');
+    // ...but the DB state transition still applied (best-effort, retryable).
+    expect(body.case.state).toBe('restricted_pending_user_response');
+    expect((await rowOf('c5')).state).toBe('restricted_pending_user_response');
+  });
+});

--- a/worker/test/relay-suspend.e2e.test.ts
+++ b/worker/test/relay-suspend.e2e.test.ts
@@ -1,0 +1,98 @@
+// END-TO-END: relay-manager's REAL NIP-86 client (suspendPubkey/unsuspendPubkey/
+// banPubkey) against a LIVE funnelcake (cake relay + funnel management) backed by
+// real ClickHouse. Proves the downstream effect C1/C9 depend on:
+//   - suspendpubkey actually HIDES the user's existing events at the relay (C1)
+//   - banpubkey actually purges/hides them (C9)
+// This is the cross-system validation that worker-only tests can't give.
+//
+// Prereqs (started out-of-band):
+//   cake   :7777  (BIND_ADDR=127.0.0.1:7777, CLICKHOUSE_URL=...:18123)
+//   funnel :8080  (ADMIN_PUBKEYS=<pubkey of TEST_NSEC>, RELAY_URL=http://127.0.0.1:8080)
+import { describe, it, expect } from 'vitest';
+import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure';
+import { suspendPubkey, banPubkey, type Nip86Env } from '../src/nip86';
+
+const CAKE_WS = 'ws://127.0.0.1:7777';
+// Admin nsec whose pubkey is funnel's ADMIN_PUBKEYS (same key as nip86.test.ts).
+const TEST_NSEC = 'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5';
+const env = { NOSTR_NSEC: TEST_NSEC, RELAY_URL: 'http://127.0.0.1:8080' } as Nip86Env;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function publish(signed: object): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(CAKE_WS);
+    const timer = setTimeout(() => { ws.close(); reject(new Error('publish timeout')); }, 8000);
+    ws.onopen = () => ws.send(JSON.stringify(['EVENT', signed]));
+    ws.onmessage = (e) => {
+      const msg = JSON.parse(e.data as string);
+      if (msg[0] === 'OK') {
+        clearTimeout(timer); ws.close();
+        msg[2] ? resolve() : reject(new Error(`relay rejected EVENT: ${msg[3]}`));
+      }
+    };
+    ws.onerror = () => { clearTimeout(timer); reject(new Error('ws error (publish)')); };
+  });
+}
+
+function reqAuthorIds(pubkey: string): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(CAKE_WS);
+    const ids: string[] = [];
+    const sub = `s${Math.floor(performance.now())}`;
+    const timer = setTimeout(() => { ws.close(); reject(new Error('req timeout')); }, 8000);
+    ws.onopen = () => ws.send(JSON.stringify(['REQ', sub, { authors: [pubkey], kinds: [1] }]));
+    ws.onmessage = (e) => {
+      const msg = JSON.parse(e.data as string);
+      if (msg[0] === 'EVENT' && msg[1] === sub) ids.push(msg[2].id);
+      else if (msg[0] === 'EOSE' && msg[1] === sub) { clearTimeout(timer); ws.close(); resolve(ids); }
+    };
+    ws.onerror = () => { clearTimeout(timer); reject(new Error('ws error (req)')); };
+  });
+}
+
+// Poll until predicate holds (relay ingest + MV are async/batched).
+async function waitFor(fn: () => Promise<boolean>, label: string, ms = 12000) {
+  const start = performance.now();
+  while (performance.now() - start < ms) {
+    if (await fn()) return;
+    await sleep(500);
+  }
+  throw new Error(`timeout waiting for: ${label}`);
+}
+
+async function makeAuthorWithEvent() {
+  const sk = generateSecretKey();
+  const pk = getPublicKey(sk);
+  const ev = finalizeEvent(
+    { kind: 1, content: `age-review e2e ${pk.slice(0, 8)}`, tags: [], created_at: Math.floor(Date.now() / 1000) },
+    sk,
+  );
+  await publish(ev);
+  await waitFor(async () => (await reqAuthorIds(pk)).includes(ev.id), `event ${ev.id.slice(0, 8)} visible`);
+  return { pk, id: ev.id };
+}
+
+describe('C1/C9 e2e: relay-manager NIP-86 -> live funnelcake', () => {
+  it('C1: suspendPubkey hides the author\'s existing events at the relay', async () => {
+    const { pk, id } = await makeAuthorWithEvent();
+    expect((await reqAuthorIds(pk))).toContain(id); // visible before
+
+    const res = await suspendPubkey(pk, 'age_review', env);
+    expect(res.success).toBe(true); // funnel accepted the real NIP-98 request
+
+    await waitFor(async () => !(await reqAuthorIds(pk)).includes(id), 'event hidden after suspend');
+    expect((await reqAuthorIds(pk))).not.toContain(id); // hidden after
+  });
+
+  it('C9: banPubkey hides/purges the author\'s events at the relay', async () => {
+    const { pk, id } = await makeAuthorWithEvent();
+    expect((await reqAuthorIds(pk))).toContain(id);
+
+    const res = await banPubkey(pk, 'age_review_denied', env);
+    expect(res.success).toBe(true);
+
+    await waitFor(async () => !(await reqAuthorIds(pk)).includes(id), 'event gone after ban');
+    expect((await reqAuthorIds(pk))).not.toContain(id);
+  });
+});

--- a/worker/test/relay-suspend.e2e.test.ts
+++ b/worker/test/relay-suspend.e2e.test.ts
@@ -28,7 +28,7 @@ function publish(signed: object): Promise<void> {
       const msg = JSON.parse(e.data as string);
       if (msg[0] === 'OK') {
         clearTimeout(timer); ws.close();
-        msg[2] ? resolve() : reject(new Error(`relay rejected EVENT: ${msg[3]}`));
+        if (msg[2]) resolve(); else reject(new Error(`relay rejected EVENT: ${msg[3]}`));
       }
     };
     ws.onerror = () => { clearTimeout(timer); reject(new Error('ws error (publish)')); };

--- a/worker/test/relay-suspend.e2e.test.ts
+++ b/worker/test/relay-suspend.e2e.test.ts
@@ -1,8 +1,8 @@
 // END-TO-END: relay-manager's REAL NIP-86 client (suspendPubkey/unsuspendPubkey/
 // banPubkey) against a LIVE funnelcake (cake relay + funnel management) backed by
-// real ClickHouse. Proves the downstream effect C1/C9 depend on:
-//   - suspendpubkey actually HIDES the user's existing events at the relay (C1)
-//   - banpubkey actually purges/hides them (C9)
+// real ClickHouse. Proves the downstream effects the relay enforcement depends on:
+//   - suspendpubkey actually HIDES the user's existing events at the relay
+//   - banpubkey actually purges/hides them
 // This is the cross-system validation that worker-only tests can't give.
 //
 // Prereqs (started out-of-band):
@@ -73,8 +73,8 @@ async function makeAuthorWithEvent() {
   return { pk, id: ev.id };
 }
 
-describe('C1/C9 e2e: relay-manager NIP-86 -> live funnelcake', () => {
-  it('C1: suspendPubkey hides the author\'s existing events at the relay', async () => {
+describe('e2e: relay-manager NIP-86 -> live funnelcake', () => {
+  it('suspendPubkey hides the author\'s existing events at the relay', async () => {
     const { pk, id } = await makeAuthorWithEvent();
     expect((await reqAuthorIds(pk))).toContain(id); // visible before
 
@@ -85,7 +85,7 @@ describe('C1/C9 e2e: relay-manager NIP-86 -> live funnelcake', () => {
     expect((await reqAuthorIds(pk))).not.toContain(id); // hidden after
   });
 
-  it('C9: banPubkey hides/purges the author\'s events at the relay', async () => {
+  it('banPubkey hides/purges the author\'s events at the relay', async () => {
     const { pk, id } = await makeAuthorWithEvent();
     expect((await reqAuthorIds(pk))).toContain(id);
 

--- a/worker/vitest.config.ts
+++ b/worker/vitest.config.ts
@@ -1,8 +1,13 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 
 export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    // The d1 (Miniflare) and e2e (live local relay) suites are opt-in via
+    // `npm run test:d1` and `npm run test:e2e`. Keep the default `npm test` a
+    // fast, self-contained node suite so CI and contributors are not gated on
+    // Miniflare/workerd or a running local relay.
+    exclude: [...configDefaults.exclude, 'test/**/*.d1.test.ts', 'test/**/*.e2e.test.ts'],
   },
 });

--- a/worker/vitest.d1.config.ts
+++ b/worker/vitest.d1.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+// Separate from vitest.config.ts (which mocks the DB) so the existing suite is
+// untouched. These tests drive a real Miniflare D1 (real SQLite) directly, which
+// is the only faithful way to validate SQL/datetime semantics like the
+// age-review deadline comparison (C8) and the cron state-set guard (C6).
+// (We use Miniflare directly rather than @cloudflare/vitest-pool-workers because
+// that pool runner is not yet compatible with Vitest 4.)
+// See .context/under16-remediation-plan.md.
+export default defineConfig({
+  test: {
+    include: ['test/**/*.d1.test.ts'],
+    environment: 'node',
+    testTimeout: 30000,
+    hookTimeout: 30000,
+  },
+});

--- a/worker/vitest.d1.config.ts
+++ b/worker/vitest.d1.config.ts
@@ -3,10 +3,10 @@ import { defineConfig } from 'vitest/config';
 // Separate from vitest.config.ts (which mocks the DB) so the existing suite is
 // untouched. These tests drive a real Miniflare D1 (real SQLite) directly, which
 // is the only faithful way to validate SQL/datetime semantics like the
-// age-review deadline comparison (C8) and the cron state-set guard (C6).
+// age-review deadline comparison and the cron state-set guard.
 // (We use Miniflare directly rather than @cloudflare/vitest-pool-workers because
 // that pool runner is not yet compatible with Vitest 4.)
-// See .context/under16-remediation-plan.md.
+// Opt-in: excluded from the default suite; run with `npm run test:d1`.
 export default defineConfig({
   test: {
     include: ['test/**/*.d1.test.ts'],

--- a/worker/vitest.e2e.config.ts
+++ b/worker/vitest.e2e.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+// End-to-end integration against a LIVE local funnelcake (cake relay :7777 +
+// funnel management :8080) backed by real ClickHouse. Run manually:
+//   npm run test:e2e
+// Requires the relays to be running with ADMIN_PUBKEYS set to the test nsec's
+// pubkey. Not part of the default suite (needs live services).
+export default defineConfig({
+  test: {
+    include: ['test/**/*.e2e.test.ts'],
+    environment: 'node',
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    retry: 0,
+  },
+});


### PR DESCRIPTION
Part of #110.

Hardens the Age Review case state machine, the 15 day clock, the deadline cron, and
the restrict/clear/deny actions so that an action's effect is verified and its status
reported accurately.

In Divine's apps a restricted account already appears blank (the clients honor the
account's moderation status and labels). Part of this PR closes the remaining path
where the same events were still reachable by querying the relay directly, outside
the apps.

What changed:
- Deadline auto-close acts only on cases that were actually restricted and are
  awaiting a response, not cases that were only reported or already responded (#111).
- Deadlines are evaluated as timestamps, so expiry is determined correctly (#112).
- Case updates and the cron use an optimistic version check (new version column,
  migration 0011), so concurrent actions cannot overwrite each other or double-fire (#113).
- Each enforcement step's real outcome is reported; a failed required step returns a
  non-success result with per-step detail instead of a blanket success (#114).
- Restriction applies the relay's reversible pubkey suspension (hides existing events,
  blocks new writes) and clear reverses it (#115).
- Denial and expiry remove the user's events at the relay at the pubkey level (#116).

Validation (local):
- Default suite: `npm test` (node, self-contained).
- Real D1 (Miniflare): `npm run test:d1` -- before/after coverage of the cron scope,
  deadline comparison, and the version check.
- Live relay (local funnelcake + ClickHouse): `npm run test:e2e` -- publishes an event,
  suspends/bans the pubkey, confirms the relay no longer serves it.
The d1 and e2e suites are opt-in (excluded from the default run) so CI is not gated on
Miniflare or a running relay.

Closes #111, closes #112, closes #113, closes #114, closes #115, closes #116.
