### PR TITLE
Age Review: reversible withhold for restricted media

### DIFF
--- a/docs/api-webhooks.md
+++ b/docs/api-webhooks.md
@@ -99,7 +99,7 @@ Moderate media content (images/videos) by SHA-256 hash.
 ```json
 {
   "sha256": "abc123...",
-  "action": "PERMANENT_BAN" | "SAFE" | "AGE_RESTRICTED" | "REVIEW",
+  "action": "SAFE" | "REVIEW" | "QUARANTINE" | "AGE_RESTRICTED" | "PERMANENT_BAN" | "DELETE",
   "reason": "CSAM content"
 }
 ```
@@ -118,8 +118,10 @@ Moderate media content (images/videos) by SHA-256 hash.
 |--------|-------------|
 | `PERMANENT_BAN` | Block this media hash permanently |
 | `SAFE` | Mark as safe, allow serving |
+| `QUARANTINE` | Withhold this media hash while preserving reversibility |
 | `AGE_RESTRICTED` | Allow but flag as adult content |
 | `REVIEW` | Queue for manual review |
+| `DELETE` | Delete this media hash |
 
 ---
 

--- a/src/lib/adminApi.test.ts
+++ b/src/lib/adminApi.test.ts
@@ -738,7 +738,7 @@ describe('adminApi', () => {
         json: async () => ({ success: true }),
       });
 
-      const actions: ModerationAction[] = ['SAFE', 'REVIEW', 'AGE_RESTRICTED', 'PERMANENT_BAN'];
+      const actions: ModerationAction[] = ['SAFE', 'REVIEW', 'QUARANTINE', 'AGE_RESTRICTED', 'PERMANENT_BAN', 'DELETE'];
 
       for (const action of actions) {
         await moderateMedia(API_URL, 'hash123', action);

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -317,9 +317,9 @@ export async function markAsReviewed(
 }
 
 // Media moderation request actions
-export type ModerationAction = 'SAFE' | 'REVIEW' | 'AGE_RESTRICTED' | 'PERMANENT_BAN' | 'DELETE';
+export type ModerationAction = 'SAFE' | 'REVIEW' | 'QUARANTINE' | 'AGE_RESTRICTED' | 'PERMANENT_BAN' | 'DELETE';
 // Media moderation status values returned by /api/check-result/:sha256
-export type MediaStatusAction = ModerationAction | 'QUARANTINE';
+export type MediaStatusAction = ModerationAction;
 
 export interface MediaStatus {
   sha256: string;

--- a/worker/src/bulk-moderate.test.ts
+++ b/worker/src/bulk-moderate.test.ts
@@ -117,7 +117,7 @@ describe('handleBulkModerate', () => {
     return undefined;
   }
 
-  it('C3: age-restrict-all sends QUARANTINE (reversible withhold) for media', async () => {
+  it('age-restrict-all sends QUARANTINE (reversible withhold) for media', async () => {
     mockRelay([{ id: 'e'.repeat(64), kind: 34235, content: '', tags: [['x', hashA]] }]);
     const request = new Request('https://test/api/bulk-moderate', {
       method: 'POST',
@@ -129,7 +129,7 @@ describe('handleBulkModerate', () => {
     expect(moderationActionFor(hashA)).toBe('QUARANTINE');
   });
 
-  it('C3: un-age-restrict-all sends SAFE (restore) for media', async () => {
+  it('un-age-restrict-all sends SAFE (restore) for media', async () => {
     mockRelay([{ id: 'e'.repeat(64), kind: 34235, content: '', tags: [['x', hashA]] }]);
     const request = new Request('https://test/api/bulk-moderate', {
       method: 'POST',

--- a/worker/src/bulk-moderate.test.ts
+++ b/worker/src/bulk-moderate.test.ts
@@ -108,6 +108,37 @@ describe('handleBulkModerate', () => {
     }
   });
 
+  function moderationActionFor(sha256: string): string | undefined {
+    const fetchMock = vi.mocked((mockEnv.MODERATION_API as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch);
+    for (const call of fetchMock.mock.calls) {
+      const body = JSON.parse((call[1] as RequestInit).body as string);
+      if (body.sha256 === sha256) return body.action;
+    }
+    return undefined;
+  }
+
+  it('C3: age-restrict-all sends QUARANTINE (reversible withhold) for media', async () => {
+    mockRelay([{ id: 'e'.repeat(64), kind: 34235, content: '', tags: [['x', hashA]] }]);
+    const request = new Request('https://test/api/bulk-moderate', {
+      method: 'POST',
+      body: JSON.stringify({ pubkey: 'a'.repeat(64), action: 'age-restrict-all' }),
+    });
+    const response = await handleBulkModerate(request, mockEnv, {});
+    expect(response.status).toBe(200);
+    // NOT 'AGE_RESTRICTED' (which would serve bytes to any signed-in viewer).
+    expect(moderationActionFor(hashA)).toBe('QUARANTINE');
+  });
+
+  it('C3: un-age-restrict-all sends SAFE (restore) for media', async () => {
+    mockRelay([{ id: 'e'.repeat(64), kind: 34235, content: '', tags: [['x', hashA]] }]);
+    const request = new Request('https://test/api/bulk-moderate', {
+      method: 'POST',
+      body: JSON.stringify({ pubkey: 'a'.repeat(64), action: 'un-age-restrict-all' }),
+    });
+    await handleBulkModerate(request, mockEnv, {});
+    expect(moderationActionFor(hashA)).toBe('SAFE');
+  });
+
   it('marks bulk delete as failed when relay deletion returns success false', async () => {
     const { banEvent } = await import('./nip86');
     vi.mocked(banEvent).mockResolvedValueOnce({ success: false, error: 'relay refused' });

--- a/worker/src/bulk-moderate.ts
+++ b/worker/src/bulk-moderate.ts
@@ -99,7 +99,7 @@ export async function handleBulkModerate(
     });
   } else {
     result.eventsProcessed = events.length;
-    // C3: age-review restriction must WITHHOLD the media, not adult-gate it.
+    // Age-review restriction must WITHHOLD the media, not adult-gate it.
     // QUARANTINE -> (moderation-service) RESTRICT -> blossom BlobStatus::Restricted,
     // which 404s to everyone except the owner and is reversible to Active. The
     // old 'AGE_RESTRICTED' -> BlobStatus::AgeRestricted serves full bytes to ANY

--- a/worker/src/bulk-moderate.ts
+++ b/worker/src/bulk-moderate.ts
@@ -99,7 +99,13 @@ export async function handleBulkModerate(
     });
   } else {
     result.eventsProcessed = events.length;
-    const mediaAction = action === 'age-restrict-all' ? 'AGE_RESTRICTED' : 'SAFE';
+    // C3: age-review restriction must WITHHOLD the media, not adult-gate it.
+    // QUARANTINE -> (moderation-service) RESTRICT -> blossom BlobStatus::Restricted,
+    // which 404s to everyone except the owner and is reversible to Active. The
+    // old 'AGE_RESTRICTED' -> BlobStatus::AgeRestricted serves full bytes to ANY
+    // signed-in viewer (a throwaway key), so it does not hide a minor's content.
+    // Clear ('un-age-restrict-all') sends 'SAFE' -> Active to restore.
+    const mediaAction = action === 'age-restrict-all' ? 'QUARANTINE' : 'SAFE';
     await runWithConcurrency(mediaHashes, BULK_ACTION_CONCURRENCY, async (sha256) => {
       try {
         await callModerateMedia(sha256, mediaAction, reason, env);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1353,7 +1353,7 @@ async function handleModerateMedia(
   try {
     const body = await request.json() as {
       sha256: string;
-      action: 'SAFE' | 'REVIEW' | 'AGE_RESTRICTED' | 'PERMANENT_BAN' | 'DELETE';
+      action: 'SAFE' | 'REVIEW' | 'QUARANTINE' | 'AGE_RESTRICTED' | 'PERMANENT_BAN' | 'DELETE';
       reason?: string;
     };
 


### PR DESCRIPTION
Part of #110.

Restricting an account's media used an age-gate state that still serves the bytes to
any signed-in request made directly to the media server (the apps already hide it).
This uses the reversible withhold state instead.

What changed:
- Restriction sends the withhold action, which maps (via the moderation service) to the
  media server's Restricted state: not served to anyone but the owner, and reversible.
- Clear restores the media; denial still deletes.

Companion: a comment correction in divine-moderation-service (separate small PR).

Validation (local): the emitted media action is asserted for restrict and clear; the
media server's own tests confirm the withhold state returns not-found to non-owners
while the age-gate state does not.

Closes #117.
