### PR TITLE
Age Review: page through all events when actioning

### DIFF
--- a/worker/src/bulk-moderate.test.ts
+++ b/worker/src/bulk-moderate.test.ts
@@ -155,7 +155,7 @@ function mockPaginatedRelay(all: Array<{ id: string; kind: number; content: stri
   } as unknown as typeof WebSocket));
 }
 
-describe('queryRelayEvents pagination (C4)', () => {
+describe('queryRelayEvents pagination', () => {
   beforeEach(() => vi.restoreAllMocks());
 
   it('pages through >500 events via until cursor instead of rejecting', async () => {

--- a/worker/src/bulk-moderate.test.ts
+++ b/worker/src/bulk-moderate.test.ts
@@ -164,8 +164,22 @@ describe('queryRelayEvents pagination (C4)', () => {
       id: `e${i}`, kind: 1, content: '', tags: [] as string[][], created_at: 1200 - i,
     }));
     mockPaginatedRelay(all);
-    const events = await queryRelayEvents('a'.repeat(64), { RELAY_URL: 'wss://relay.test' });
+    const { events, complete } = await queryRelayEvents('a'.repeat(64), { RELAY_URL: 'wss://relay.test' });
     expect(events).toHaveLength(1200); // all collected, deduped across page boundaries; no throw
+    expect(complete).toBe(true);
+  });
+
+  it('terminates and reports incomplete when >1 page of events share one created_at', async () => {
+    // 600 events all at the same second: an inclusive `until` cursor cannot
+    // subdivide a second, so it must not loop forever or silently report success.
+    const all = Array.from({ length: 600 }, (_, i) => ({
+      id: `e${i}`, kind: 1, content: '', tags: [] as string[][], created_at: 1000,
+    }));
+    mockPaginatedRelay(all);
+    const { events, complete } = await queryRelayEvents('a'.repeat(64), { RELAY_URL: 'wss://relay.test' });
+    expect(complete).toBe(false);            // surfaced, not a silent success
+    expect(events.length).toBe(500);         // escaped the saturated second after one page
+    expect(events.length).toBeLessThan(600); // the excess at that second was not silently claimed as done
   });
 });
 

--- a/worker/src/bulk-moderate.test.ts
+++ b/worker/src/bulk-moderate.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { handleBulkModerate, extractMediaHashes, type BulkModerateEnv } from './bulk-moderate';
+import { handleBulkModerate, extractMediaHashes, queryRelayEvents, type BulkModerateEnv } from './bulk-moderate';
 
 vi.mock('./nip86', () => ({
   getAdminPubkey: vi.fn().mockResolvedValue('moderator-pubkey'),
@@ -123,6 +123,49 @@ describe('handleBulkModerate', () => {
     expect(body.success).toBe(false);
     expect(body.eventsProcessed).toBe(0);
     expect(body.failures[0]).toContain('relay refused');
+  });
+});
+
+// Paginating mock relay: responds to each REQ with up to `limit` events whose
+// created_at <= filter.until (descending), then EOSE for that sub. Models a
+// relay that supports until-cursoring.
+function mockPaginatedRelay(all: Array<{ id: string; kind: number; content: string; tags: string[][]; created_at: number }>) {
+  const sorted = [...all].sort((a, b) => b.created_at - a.created_at);
+  vi.spyOn(globalThis, 'WebSocket').mockImplementation((function () {
+    const listeners = new Map<string, Array<(value?: unknown) => void>>();
+    const emit = (type: string, value?: unknown) => listeners.get(type)?.forEach((h) => h(value));
+    const sock = {
+      addEventListener: (t: string, h: (value?: unknown) => void) => listeners.set(t, [...(listeners.get(t) || []), h]),
+      send: (payload: string) => {
+        const data = JSON.parse(payload);
+        if (data[0] !== 'REQ') return; // ignore CLOSE
+        const sub = data[1];
+        const until = data[2].until ?? Infinity;
+        const limit = data[2].limit ?? 500;
+        const page = sorted.filter((e) => e.created_at <= until).slice(0, limit);
+        queueMicrotask(() => {
+          for (const ev of page) emit('message', { data: JSON.stringify(['EVENT', sub, ev]) });
+          emit('message', { data: JSON.stringify(['EOSE', sub]) });
+        });
+      },
+      close: vi.fn(),
+    };
+    queueMicrotask(() => emit('open'));
+    return sock;
+  } as unknown as typeof WebSocket));
+}
+
+describe('queryRelayEvents pagination (C4)', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('pages through >500 events via until cursor instead of rejecting', async () => {
+    // 1200 events with distinct descending created_at -> 3 pages (500/500/200).
+    const all = Array.from({ length: 1200 }, (_, i) => ({
+      id: `e${i}`, kind: 1, content: '', tags: [] as string[][], created_at: 1200 - i,
+    }));
+    mockPaginatedRelay(all);
+    const events = await queryRelayEvents('a'.repeat(64), { RELAY_URL: 'wss://relay.test' });
+    expect(events).toHaveLength(1200); // all collected, deduped across page boundaries; no throw
   });
 });
 

--- a/worker/src/bulk-moderate.ts
+++ b/worker/src/bulk-moderate.ts
@@ -4,9 +4,12 @@ import { VALID_BULK_ACTIONS, type BulkAction, type BulkModerateResult } from '..
 import { extractMediaHashes as extractSharedMediaHashes } from '../../shared/media-hashes';
 
 const BULK_ACTION_CONCURRENCY = 5;
-const RELAY_QUERY_LIMIT = 500;
-const RELAY_QUERY_FETCH_LIMIT = RELAY_QUERY_LIMIT + 1;
-const RELAY_QUERY_TIMEOUT_MS = 10000;
+// C4: page through ALL of an author's events via `until` cursoring instead of
+// rejecting accounts with more than one page. The old reject left prolific
+// accounts entirely un-enforced (the throw was swallowed upstream).
+const RELAY_QUERY_PAGE_SIZE = 500;
+const RELAY_QUERY_MAX_PAGES = 100; // safety bound (~50k events); logged if hit, never silent
+const RELAY_QUERY_TIMEOUT_MS = 10000; // per-page (reset each page)
 
 export interface BulkModerateEnv extends Nip86Env, ZendeskSyncEnv {
   DB?: D1Database;
@@ -122,16 +125,14 @@ export async function queryRelayEvents(
     try {
       const ws = new WebSocket(env.RELAY_URL);
       let resolved = false;
-      const events: RelayEventSummary[] = [];
-      const subId = `bulk-${Date.now()}`;
+      const byId = new Map<string, RelayEventSummary>(); // dedup across pages (until boundary overlaps)
+      let page = 0;
+      let currentSub = '';
+      let pageEvents = 0;        // events seen in the current page
+      let pageOldest = Infinity; // min created_at in the current page -> next `until`
+      let timeout: ReturnType<typeof setTimeout>;
 
-      // `resolve` expects RelayEventSummary[]; `reject` expects an Error. The helper
-      // accepts whichever terminator and its matching value as a single union, so the
-      // settle path (close socket, clear timeout, guard against double-settle) is shared.
-      type Settle =
-        | { fn: typeof resolve; value: RelayEventSummary[] }
-        | { fn: typeof reject; value: Error };
-      const finish = (fn: Settle['fn'], value: RelayEventSummary[] | Error) => {
+      const finish = (fn: typeof resolve | typeof reject, value: RelayEventSummary[] | Error) => {
         if (resolved) return;
         resolved = true;
         clearTimeout(timeout);
@@ -139,26 +140,52 @@ export async function queryRelayEvents(
         (fn as (value: RelayEventSummary[] | Error) => void)(value);
       };
 
-      const timeout = setTimeout(() => {
-        finish(reject, new Error('Relay query timed out before EOSE'));
-      }, RELAY_QUERY_TIMEOUT_MS);
+      const armTimeout = () => {
+        clearTimeout(timeout);
+        // Per-page: a prolific account legitimately needs many pages; only a
+        // stalled page (no EOSE within the window) is a failure.
+        timeout = setTimeout(() => finish(reject, new Error('Relay query timed out before EOSE')), RELAY_QUERY_TIMEOUT_MS);
+      };
 
-      ws.addEventListener('open', () => {
-        ws.send(JSON.stringify(['REQ', subId, { authors: [pubkey], limit: RELAY_QUERY_FETCH_LIMIT }]));
-      });
+      const sendPage = (until?: number) => {
+        page += 1;
+        currentSub = `bulk-${Date.now()}-${page}`;
+        pageEvents = 0;
+        pageOldest = Infinity;
+        const filter: { authors: string[]; limit: number; until?: number } = { authors: [pubkey], limit: RELAY_QUERY_PAGE_SIZE };
+        if (until !== undefined) filter.until = until;
+        armTimeout();
+        ws.send(JSON.stringify(['REQ', currentSub, filter]));
+      };
+
+      ws.addEventListener('open', () => sendPage());
 
       ws.addEventListener('message', (msg) => {
         try {
           const data = JSON.parse(msg.data as string);
-          if (data[0] === 'EVENT' && data[1] === subId) {
-            const event = data[2] as { id: string; kind: number; content?: string; tags: string[][] };
-            events.push({ id: event.id, kind: event.kind, content: event.content || '', tags: event.tags });
-          } else if (data[0] === 'EOSE' && data[1] === subId) {
-            if (events.length > RELAY_QUERY_LIMIT) {
-              finish(reject, new Error(`Bulk moderation matched more than ${RELAY_QUERY_LIMIT} events; narrow the scope or add pagination`));
+          if (data[0] === 'EVENT' && data[1] === currentSub) {
+            const event = data[2] as { id: string; kind: number; content?: string; tags: string[][]; created_at?: number };
+            pageEvents += 1;
+            if (!byId.has(event.id)) {
+              byId.set(event.id, { id: event.id, kind: event.kind, content: event.content || '', tags: event.tags });
+            }
+            if (typeof event.created_at === 'number' && event.created_at < pageOldest) pageOldest = event.created_at;
+          } else if (data[0] === 'EOSE' && data[1] === currentSub) {
+            ws.send(JSON.stringify(['CLOSE', currentSub]));
+            // Last page reached: a partial page means the relay has no more events.
+            if (pageEvents < RELAY_QUERY_PAGE_SIZE) {
+              finish(resolve, Array.from(byId.values()));
               return;
             }
-            finish(resolve, events);
+            if (page >= RELAY_QUERY_MAX_PAGES) {
+              // Never silently truncate: surface that we bounded coverage.
+              console.warn(`[bulk-moderate] hit RELAY_QUERY_MAX_PAGES (${RELAY_QUERY_MAX_PAGES}, ~${page * RELAY_QUERY_PAGE_SIZE} events) for ${pubkey}; processing collected subset`);
+              finish(resolve, Array.from(byId.values()));
+              return;
+            }
+            // Page through older events. `until` is inclusive so the boundary
+            // timestamp may repeat; the byId map dedups it.
+            sendPage(pageOldest === Infinity ? undefined : pageOldest);
           }
         } catch {
           // Ignore malformed relay frames and continue collecting.

--- a/worker/src/bulk-moderate.ts
+++ b/worker/src/bulk-moderate.ts
@@ -4,7 +4,7 @@ import { VALID_BULK_ACTIONS, type BulkAction, type BulkModerateResult } from '..
 import { extractMediaHashes as extractSharedMediaHashes } from '../../shared/media-hashes';
 
 const BULK_ACTION_CONCURRENCY = 5;
-// C4: page through ALL of an author's events via `until` cursoring instead of
+// Page through ALL of an author's events via `until` cursoring instead of
 // rejecting accounts with more than one page. The old reject left prolific
 // accounts entirely un-enforced (the throw was swallowed upstream).
 const RELAY_QUERY_PAGE_SIZE = 500;

--- a/worker/src/bulk-moderate.ts
+++ b/worker/src/bulk-moderate.ts
@@ -49,10 +49,18 @@ export async function handleBulkModerate(
   const action = body.action as BulkAction;
   const reason = body.reason || `Bulk ${action} by moderator`;
 
-  const events = await queryRelayEvents(body.pubkey, env);
+  const { events, complete } = await queryRelayEvents(body.pubkey, env);
   const mediaHashes = extractMediaHashes(events);
   const moderatorPubkey = await getAdminPubkey(env);
   const result: BulkModerateResult = { success: true, eventsProcessed: 0, mediaProcessed: 0, failures: [] };
+
+  // If the relay could not be fully paginated (e.g. more than one page of events
+  // share a single created_at second, which an until-cursor cannot subdivide),
+  // surface it rather than silently enforcing over a partial set. The events we
+  // did gather are still actioned below (best effort).
+  if (!complete) {
+    result.failures.push(`enumeration:${body.pubkey}:relay could not be fully paginated; actioned a partial set`);
+  }
 
   if (action === 'delete-all') {
     const successfulEventIds: string[] = [];
@@ -120,7 +128,8 @@ export async function handleBulkModerate(
 export async function queryRelayEvents(
   pubkey: string,
   env: Pick<BulkModerateEnv, 'RELAY_URL'>,
-): Promise<RelayEventSummary[]> {
+): Promise<{ events: RelayEventSummary[]; complete: boolean }> {
+  type Result = { events: RelayEventSummary[]; complete: boolean };
   return new Promise((resolve, reject) => {
     try {
       const ws = new WebSocket(env.RELAY_URL);
@@ -129,16 +138,19 @@ export async function queryRelayEvents(
       let page = 0;
       let currentSub = '';
       let pageEvents = 0;        // events seen in the current page
+      let pageStartSize = 0;     // byId.size at page start -> detects whether the page added anything new
       let pageOldest = Infinity; // min created_at in the current page -> next `until`
+      let incomplete = false;    // true if the relay could not be fully paginated (surfaced to caller)
       let timeout: ReturnType<typeof setTimeout>;
 
-      const finish = (fn: typeof resolve | typeof reject, value: RelayEventSummary[] | Error) => {
+      const finish = (fn: ((v: Result) => void) | ((e: Error) => void), value: Result | Error) => {
         if (resolved) return;
         resolved = true;
         clearTimeout(timeout);
         ws.close();
-        (fn as (value: RelayEventSummary[] | Error) => void)(value);
+        (fn as (value: Result | Error) => void)(value);
       };
+      const done = () => finish(resolve, { events: Array.from(byId.values()), complete: !incomplete });
 
       const armTimeout = () => {
         clearTimeout(timeout);
@@ -152,6 +164,7 @@ export async function queryRelayEvents(
         currentSub = `bulk-${Date.now()}-${page}`;
         pageEvents = 0;
         pageOldest = Infinity;
+        pageStartSize = byId.size;
         const filter: { authors: string[]; limit: number; until?: number } = { authors: [pubkey], limit: RELAY_QUERY_PAGE_SIZE };
         if (until !== undefined) filter.until = until;
         armTimeout();
@@ -174,13 +187,31 @@ export async function queryRelayEvents(
             ws.send(JSON.stringify(['CLOSE', currentSub]));
             // Last page reached: a partial page means the relay has no more events.
             if (pageEvents < RELAY_QUERY_PAGE_SIZE) {
-              finish(resolve, Array.from(byId.values()));
+              done();
               return;
             }
             if (page >= RELAY_QUERY_MAX_PAGES) {
-              // Never silently truncate: surface that we bounded coverage.
-              console.warn(`[bulk-moderate] hit RELAY_QUERY_MAX_PAGES (${RELAY_QUERY_MAX_PAGES}, ~${page * RELAY_QUERY_PAGE_SIZE} events) for ${pubkey}; processing collected subset`);
-              finish(resolve, Array.from(byId.values()));
+              // Bound coverage rather than loop forever; surface it (not silent).
+              incomplete = true;
+              console.warn(`[bulk-moderate] hit RELAY_QUERY_MAX_PAGES (${RELAY_QUERY_MAX_PAGES}, ~${page * RELAY_QUERY_PAGE_SIZE} events) for ${pubkey}; returning a partial set`);
+              done();
+              return;
+            }
+            // Progress guard: a full page that added no new ids means the `until`
+            // cursor is stuck -- more than one page of events share a single
+            // created_at second (an inclusive `until` cannot subdivide a second),
+            // or the events carry no created_at. Surface incompleteness, and where
+            // we can, step strictly past the saturated second so we still
+            // enumerate everything older instead of looping to the page bound.
+            if (byId.size === pageStartSize) {
+              incomplete = true;
+              if (pageOldest === Infinity) {
+                console.warn(`[bulk-moderate] relay events lack created_at; cannot paginate further for ${pubkey}; returning a partial set`);
+                done();
+                return;
+              }
+              console.warn(`[bulk-moderate] more than one page of events share created_at=${pageOldest} for ${pubkey}; skipping past that second (some events at it may be unprocessed)`);
+              sendPage(pageOldest - 1);
               return;
             }
             // Page through older events. `until` is inclusive so the boundary


### PR DESCRIPTION
Part of #110.

Bulk actioning queried an author's events in a single page and stopped once an account
had more than one page, without surfacing the stop, so a high-volume account could be
actioned over none of its content while the case still showed restricted.

What changed:
- Page through all of the author's events with a created_at cursor (dedup across
  boundaries), with a per-page timeout and a logged (not silent) page bound.

Validation (local): a test that pages through 1200 events across three pages and
collects all of them.

Closes #118.
