### PR TITLE
Age Review: surface enforcement status and conflicts in the moderator UI

### DIFF
--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -148,6 +148,8 @@ describe('AgeReviewDetail', () => {
         variant: 'destructive',
       }));
     });
+    // the toast covers the conflict; the inline error must not also fire for it
+    expect(screen.queryByText(/Failed to update/)).not.toBeInTheDocument();
   });
 
   it('shows Deny & Close without confirmation when auto-delete is off', () => {

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -3,17 +3,23 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import { AgeReviewDetail } from './AgeReviewDetail';
+import { ApiError } from '@/lib/adminApi';
 import type { AgeReviewCase, AgeBand, AgeReviewState } from '../../shared/age-review';
 
 const updateAgeReviewCase = vi.fn().mockResolvedValue({ success: true });
 const getAgeReviewConfig = vi.fn().mockResolvedValue({ auto_delete_on_deny: false });
 const writeText = vi.fn().mockResolvedValue(undefined);
+const toast = vi.fn();
 
 vi.mock('@/hooks/useAdminApi', () => ({
   useAdminApi: () => ({
     updateAgeReviewCase,
     getAgeReviewConfig,
   }),
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ toast }),
 }));
 
 vi.mock('@/hooks/useAuthor', () => ({
@@ -65,8 +71,10 @@ function renderDetail(caseData: AgeReviewCase) {
 describe('AgeReviewDetail', () => {
   beforeEach(() => {
     updateAgeReviewCase.mockClear();
+    updateAgeReviewCase.mockResolvedValue({ success: true });
     getAgeReviewConfig.mockClear();
     getAgeReviewConfig.mockResolvedValue({ auto_delete_on_deny: false });
+    toast.mockClear();
     writeText.mockClear();
     Object.assign(navigator, {
       clipboard: {
@@ -86,6 +94,59 @@ describe('AgeReviewDetail', () => {
 
     await waitFor(() => {
       expect(updateAgeReviewCase).toHaveBeenCalledWith('case-1', { state: expectedState });
+    });
+  });
+
+  it('toasts when an enforcement leg fails (HTTP 207 partial)', async () => {
+    updateAgeReviewCase.mockResolvedValueOnce({
+      success: false,
+      case: makeCase({ state: 'restricted_pending_user_response' }),
+      enforcementComplete: false,
+      enforcement: { relay: 'failed', bulk: 'ok', keycast: 'ok' },
+    });
+    renderDetail(makeCase({ suspected_age_band: 'age_13_15' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restrict Account' }));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'Enforcement incomplete',
+        variant: 'destructive',
+      }));
+    });
+    expect(toast.mock.calls[0][0].description).toMatch(/relay/);
+  });
+
+  it('does not toast when no enforcement leg failed (ok and not_attempted)', async () => {
+    updateAgeReviewCase.mockResolvedValueOnce({
+      success: true,
+      case: makeCase({ state: 'restricted_pending_user_response' }),
+      enforcementComplete: true,
+      // not_attempted must NOT be treated as a failure (the old keycastUpdated
+      // check false-fired on restricted->restricted transitions).
+      enforcement: { relay: 'ok', bulk: 'ok', keycast: 'not_attempted' },
+    });
+    renderDetail(makeCase({ suspected_age_band: 'age_13_15' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restrict Account' }));
+
+    await waitFor(() => expect(updateAgeReviewCase).toHaveBeenCalled());
+    expect(toast).not.toHaveBeenCalled();
+  });
+
+  it('toasts a reload notice on a 409 version_conflict', async () => {
+    updateAgeReviewCase.mockRejectedValueOnce(
+      new ApiError('Case was modified by another request', 409, 'Conflict', 'version_conflict', 5),
+    );
+    renderDetail(makeCase({ suspected_age_band: 'age_13_15' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restrict Account' }));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'Case changed since you opened it',
+        variant: 'destructive',
+      }));
     });
   });
 

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -431,7 +431,7 @@ export function AgeReviewDetail({ caseData: c }: Props) {
                   Updating...
                 </div>
               )}
-              {updateCase.isError && (
+              {updateCase.isError && !(updateCase.error instanceof ApiError && updateCase.error.code === 'version_conflict') && (
                 <div className="text-xs text-red-600">
                   Failed to update: {(updateCase.error as Error).message}
                 </div>

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAdminApi } from "@/hooks/useAdminApi";
+import { ApiError } from "@/lib/adminApi";
 import { useToast } from "@/hooks/useToast";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { UserActions } from "@/components/UserActions";
@@ -113,14 +114,50 @@ export function AgeReviewDetail({ caseData: c }: Props) {
     },
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['age-review-cases'] });
-      const requestedState = pendingStateRef.current as AgeReviewState | undefined;
-      if (requestedState && KEYCAST_STATES.includes(requestedState) && data.keycastUpdated === false) {
+
+      // Surface any enforcement leg that did not apply. The case state persists
+      // even when enforcement is partial (the server returns HTTP 207), so the
+      // moderator must be told the content/account may still be reachable.
+      const enforcement = data.enforcement;
+      if (enforcement) {
+        const failed: string[] = [];
+        if (enforcement.relay === 'failed') failed.push('relay (existing posts and feed)');
+        if (enforcement.bulk === 'failed') failed.push('media and content');
+        if (enforcement.keycast === 'failed') failed.push('account sign-in');
+        if (failed.length > 0) {
+          toast({
+            title: 'Enforcement incomplete',
+            description: `Case updated, but these did not apply: ${failed.join(', ')}. The user's content or account may still be reachable. Retry the action or escalate.`,
+            variant: 'destructive',
+          });
+        }
+      } else if (
+        // Fallback for a worker that predates the per-leg enforcement contract.
+        pendingStateRef.current &&
+        KEYCAST_STATES.includes(pendingStateRef.current as AgeReviewState) &&
+        data.keycastUpdated === false
+      ) {
         toast({
           title: 'Account enforcement failed',
           description: 'Case was updated but Keycast account suspension did not apply. The user\'s account may still be active. Retry or escalate.',
           variant: 'destructive',
         });
       }
+    },
+    onError: (error) => {
+      // A concurrent writer (another moderator, or the deadline cron) changed
+      // the case between our read and this write. Reload the current state so
+      // the moderator can review it before re-applying; we deliberately do not
+      // blindly replay a possibly-stale transition.
+      if (error instanceof ApiError && error.code === 'version_conflict') {
+        queryClient.invalidateQueries({ queryKey: ['age-review-cases'] });
+        toast({
+          title: 'Case changed since you opened it',
+          description: 'Another moderator or an automated deadline action modified this case. Reloaded the latest state; review it and re-apply if still needed.',
+          variant: 'destructive',
+        });
+      }
+      // Other errors surface inline via updateCase.isError below.
     },
   });
 

--- a/src/lib/adminApi.test.ts
+++ b/src/lib/adminApi.test.ts
@@ -27,6 +27,8 @@ import {
   getDecisions,
   extractMediaHashes,
   isBlockedMediaAction,
+  updateAgeReviewCase,
+  ApiError,
   type UnsignedEvent,
   type ApiResponse,
   type LabelParams,
@@ -104,6 +106,48 @@ describe('adminApi', () => {
       const result = await getWorkerInfo(API_URL);
 
       expect(result).toEqual(mockData);
+    });
+
+    it('surfaces a JSON error body (409 version_conflict) as structured ApiError fields', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        statusText: 'Conflict',
+        json: async () => ({
+          error: 'Case was modified by another request',
+          code: 'version_conflict',
+          current_version: 3,
+        }),
+      });
+
+      expect.assertions(5);
+      try {
+        await updateAgeReviewCase(API_URL, 'case-1', { state: 'cleared' });
+      } catch (e) {
+        const err = e as ApiError;
+        expect(err).toBeInstanceOf(ApiError);
+        expect(err.message).toBe('Case was modified by another request'); // not opaque "HTTP 409:"
+        expect(err.statusCode).toBe(409);
+        expect(err.code).toBe('version_conflict');
+        expect(err.currentVersion).toBe(3);
+      }
+    });
+
+    it('returns the enforcement object (not throws) on a 207 partial-enforcement response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true, // fetch sets ok=true across the whole 2xx range, including 207
+        status: 207,
+        json: async () => ({
+          success: false,
+          case: { id: 'case-1' },
+          enforcementComplete: false,
+          enforcement: { relay: 'failed', bulk: 'ok', keycast: 'ok' },
+        }),
+      });
+
+      const res = await updateAgeReviewCase(API_URL, 'case-1', { state: 'restricted_pending_user_response' });
+      expect(res.enforcementComplete).toBe(false);
+      expect(res.enforcement?.relay).toBe('failed');
     });
   });
 

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -66,11 +66,17 @@ export interface LabelParams {
   comment?: string;
 }
 
-class ApiError extends Error {
+export class ApiError extends Error {
   constructor(
     message: string,
     public statusCode?: number,
-    public statusText?: string
+    public statusText?: string,
+    // Structured fields parsed from a JSON error body, when present. `code`
+    // lets callers branch on a machine-readable reason (e.g. 'version_conflict')
+    // rather than the message string; `currentVersion` is the server's current
+    // version returned alongside a 409 conflict.
+    public code?: string,
+    public currentVersion?: number,
   ) {
     super(message);
     this.name = 'ApiError';
@@ -93,10 +99,21 @@ async function apiRequest<T>(
   });
 
   if (!response.ok) {
+    // Read the JSON error body if there is one so callers can act on structured
+    // fields (a 409 version_conflict carries `code` + `current_version`) instead
+    // of an opaque "HTTP 409:" message. Non-JSON bodies fall back to status text.
+    let parsed: { error?: string; code?: string; current_version?: number } | undefined;
+    try {
+      parsed = await response.json() as typeof parsed;
+    } catch {
+      // body was empty or not JSON; keep the status-line fallback
+    }
     throw new ApiError(
-      `HTTP ${response.status}: ${response.statusText}`,
+      parsed?.error || `HTTP ${response.status}: ${response.statusText}`,
       response.status,
-      response.statusText
+      response.statusText,
+      parsed?.code,
+      parsed?.current_version,
     );
   }
 
@@ -912,10 +929,28 @@ interface AgeReviewCasesResponse {
   cases: import('../../shared/age-review').AgeReviewCase[];
 }
 
-interface AgeReviewCaseResponse {
+export type EnforcementLegStatus = 'not_attempted' | 'ok' | 'failed';
+
+// Per-leg outcome of the enforcement the case update triggers (relay
+// suspend/ban, bulk media/content action, Keycast account status). Optional so
+// the client still works against a worker that predates the enforcement contract.
+export interface AgeReviewEnforcement {
+  relay: EnforcementLegStatus;
+  relayError?: string;
+  bulk: EnforcementLegStatus;
+  bulkError?: string;
+  keycast: EnforcementLegStatus;
+  keycastError?: string;
+}
+
+export interface AgeReviewCaseResponse {
   success: boolean;
   case: import('../../shared/age-review').AgeReviewCase;
   keycastUpdated?: boolean;
+  bulkActionTriggered?: string;
+  // false when any enforcement leg failed (the server returns HTTP 207 then).
+  enforcementComplete?: boolean;
+  enforcement?: AgeReviewEnforcement;
 }
 
 export async function getAgeReviewCases(


### PR DESCRIPTION
The case-update API reports per-leg enforcement status (relay, media/content, account) and returns HTTP 207 when a leg did not apply, plus HTTP 409 with a machine-readable code when a case changed underneath a write. The moderator UI did not yet consume that contract, so a partial enforcement read as full success and a conflict read as an opaque error. This change makes the admin UI reflect what actually happened after an action.

- Surface each enforcement leg. When relay, media/content, or account sign-in fails, show a clear "enforcement incomplete" notice naming what did not apply, instead of treating the update as fully enforced.
- Stop a false positive: the previous account-suspension warning fired even when the account leg was simply not attempted (for example a restricted-to-restricted transition). It now keys off an actual failure.
- Handle the version conflict: a 409 reloads the current state and asks the moderator to review and re-apply, instead of showing "HTTP 409".
- Export `ApiError` with the parsed `code`/`current_version`, parse JSON error bodies in `apiRequest`, and type the enforcement fields on the response.

Independent of the worker hardening PR and back-compatible with a worker that predates the per-leg contract.

Tests: `adminApi` (409 structured fields, 207 returns rather than throws) and `AgeReviewDetail` (207 toast, no toast on ok/not-attempted, 409 reload).

Decision item, not included here: whether to relabel bulk-age-review media (withheld via QUARANTINE) in the media-status badges; the media is withheld either way. Follow-up once the worker change lands: have the client send its known case version for client-side optimistic concurrency.

Part of #110.

Closes #126.
