### PR TITLE
refactor(age-review): hoist enforcement/response contract types into shared

### DIFF
--- a/shared/age-review.ts
+++ b/shared/age-review.ts
@@ -98,3 +98,30 @@ export interface AgeReviewCase {
   updated_at: string;
   version: number;
 }
+
+// --- Case-update enforcement contract (shared by the worker API and the admin client) ---
+
+export type EnforcementLegStatus = 'not_attempted' | 'ok' | 'failed';
+
+// Per-leg outcome of the enforcement a case update triggers: relay suspend/ban,
+// bulk media/content action, and Keycast account status.
+export interface AgeReviewEnforcement {
+  relay: EnforcementLegStatus;
+  relayError?: string;
+  bulk: EnforcementLegStatus;
+  bulkError?: string;
+  keycast: EnforcementLegStatus;
+  keycastError?: string;
+}
+
+// Response body for a case GET/PATCH. On a partial-enforcement PATCH the worker
+// returns HTTP 207 with `enforcementComplete: false`. `enforcement` is optional
+// so an older client still works against a worker that predates this contract.
+export interface AgeReviewCaseResponse {
+  success: boolean;
+  case: AgeReviewCase;
+  keycastUpdated?: boolean;
+  bulkActionTriggered?: string;
+  enforcementComplete?: boolean;
+  enforcement?: AgeReviewEnforcement;
+}

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -9,6 +9,7 @@ import {
   type BulkModerateResult,
 } from "../../shared/bulk-moderation";
 import { extractMediaHashes as extractSharedMediaHashes } from "../../shared/media-hashes";
+import type { AgeReviewCaseResponse } from "../../shared/age-review";
 
 // Build headers with CF Access service token for cross-origin API requests.
 // The service token authenticates the frontend to CF Access policies on api-relay-* domains.
@@ -922,35 +923,20 @@ function extractBreakdown(
 // Age Review
 // ---------------------------------------------------------------------------
 
-export type { AgeReviewCase, AgeReviewState, AgeBand } from '../../shared/age-review';
+// Enforcement/response contract types live in shared/age-review.ts so the
+// worker API and this client use one definition instead of duplicating it.
+export type {
+  AgeReviewCase,
+  AgeReviewState,
+  AgeBand,
+  EnforcementLegStatus,
+  AgeReviewEnforcement,
+  AgeReviewCaseResponse,
+} from '../../shared/age-review';
 
 interface AgeReviewCasesResponse {
   success: boolean;
   cases: import('../../shared/age-review').AgeReviewCase[];
-}
-
-export type EnforcementLegStatus = 'not_attempted' | 'ok' | 'failed';
-
-// Per-leg outcome of the enforcement the case update triggers (relay
-// suspend/ban, bulk media/content action, Keycast account status). Optional so
-// the client still works against a worker that predates the enforcement contract.
-export interface AgeReviewEnforcement {
-  relay: EnforcementLegStatus;
-  relayError?: string;
-  bulk: EnforcementLegStatus;
-  bulkError?: string;
-  keycast: EnforcementLegStatus;
-  keycastError?: string;
-}
-
-export interface AgeReviewCaseResponse {
-  success: boolean;
-  case: import('../../shared/age-review').AgeReviewCase;
-  keycastUpdated?: boolean;
-  bulkActionTriggered?: string;
-  // false when any enforcement leg failed (the server returns HTTP 207 then).
-  enforcementComplete?: boolean;
-  enforcement?: AgeReviewEnforcement;
 }
 
 export async function getAgeReviewCases(

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -12,6 +12,7 @@ import {
   defaultResolutionForBand,
   type EnforcementLegStatus,
   type AgeReviewEnforcement,
+  type AgeReviewCaseResponse,
 } from '../../shared/age-review';
 import { handleBulkModerate, type BulkModerateEnv } from './bulk-moderate';
 import { resolveZendeskCreds } from './zendesk-sync';
@@ -355,16 +356,23 @@ export async function handleUpdateAgeReviewCase(
   // moderator/UI sees enforcement is incomplete. The DB state change persists;
   // remediation must re-run the failed downstream enforcement outside this
   // state-transition handler.
+  // `updated` is the row re-read after the CAS succeeded, so it must exist;
+  // guard for the type system and surface the impossible case rather than
+  // emitting case:null.
+  if (!updated) {
+    return json({ success: false, error: 'Case not found after update' }, 500, corsHeaders);
+  }
   const enforcement: AgeReviewEnforcement = { relay, relayError, bulk, bulkError, keycast, keycastError };
   const enforcementComplete = relay !== 'failed' && bulk !== 'failed' && keycast !== 'failed';
-  return json({
+  const response: AgeReviewCaseResponse = {
     success: enforcementComplete,
     case: updated,
     bulkActionTriggered,
     keycastUpdated: keycast === 'ok',
     enforcementComplete,
     enforcement,
-  }, enforcementComplete ? 200 : 207, corsHeaders);
+  };
+  return json(response, enforcementComplete ? 200 : 207, corsHeaders);
 }
 
 // ---------------------------------------------------------------------------

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -10,6 +10,8 @@ import {
   isAccountRestrictedAgeReviewState,
   DEADLINE_DAYS,
   defaultResolutionForBand,
+  type EnforcementLegStatus,
+  type AgeReviewEnforcement,
 } from '../../shared/age-review';
 import { handleBulkModerate, type BulkModerateEnv } from './bulk-moderate';
 import { resolveZendeskCreds } from './zendesk-sync';
@@ -274,13 +276,12 @@ export async function handleUpdateAgeReviewCase(
   // surface failure -- the API must not report success when a minor's content
   // was not actually restricted or their account not suspended. (Zendesk above
   // stays non-critical and swallowed.)
-  type LegStatus = 'not_attempted' | 'ok' | 'failed';
-  let bulk: LegStatus = 'not_attempted';
+  let bulk: EnforcementLegStatus = 'not_attempted';
   let bulkError: string | undefined;
   let bulkActionTriggered: string | undefined;
-  let relay: LegStatus = 'not_attempted';
+  let relay: EnforcementLegStatus = 'not_attempted';
   let relayError: string | undefined;
-  let keycast: LegStatus = 'not_attempted';
+  let keycast: EnforcementLegStatus = 'not_attempted';
   let keycastError: string | undefined;
 
   // Shared wrapper for the relay and Keycast legs (both resolve to
@@ -288,7 +289,7 @@ export async function handleUpdateAgeReviewCase(
   const runStatusLeg = async (
     label: string,
     call: () => Promise<{ success: boolean; error?: string }> | undefined,
-  ): Promise<{ status: LegStatus; error?: string }> => {
+  ): Promise<{ status: EnforcementLegStatus; error?: string }> => {
     try {
       const result = await call();
       if (!result) return { status: 'not_attempted' };
@@ -354,6 +355,7 @@ export async function handleUpdateAgeReviewCase(
   // moderator/UI sees enforcement is incomplete. The DB state change persists;
   // remediation must re-run the failed downstream enforcement outside this
   // state-transition handler.
+  const enforcement: AgeReviewEnforcement = { relay, relayError, bulk, bulkError, keycast, keycastError };
   const enforcementComplete = relay !== 'failed' && bulk !== 'failed' && keycast !== 'failed';
   return json({
     success: enforcementComplete,
@@ -361,7 +363,7 @@ export async function handleUpdateAgeReviewCase(
     bulkActionTriggered,
     keycastUpdated: keycast === 'ok',
     enforcementComplete,
-    enforcement: { relay, relayError, bulk, bulkError, keycast, keycastError },
+    enforcement,
   }, enforcementComplete ? 200 : 207, corsHeaders);
 }
 


### PR DESCRIPTION
## Summary

The case-update enforcement contract — `EnforcementLegStatus`, `AgeReviewEnforcement`, and the case-response shape — was defined in two places: inline in the worker (`worker/src/age-review.ts`) and again in the admin client (`src/lib/adminApi.ts`). This hoists the canonical definitions into `shared/age-review.ts` so the worker and client share one source of truth and cannot drift.

Type-only, no behavior change. The worker now uses the shared `EnforcementLegStatus` + `AgeReviewEnforcement`; the client re-exports the shared types.

## Validation

- worker `tsc`
- frontend `tsc -p tsconfig.app.json`
- eslint
- worker default + D1 suites
- frontend adminApi/component tests

## Linked Issue

Closes #130

Surfaced in the #122 review. Related to #110. Independent of #127 (touches different regions of `age-review.ts`).