### PR TITLE
Fix Ban User modal hanging on "Banning…"

### DIFF
--- a/src/components/UserActions.test.tsx
+++ b/src/components/UserActions.test.tsx
@@ -101,4 +101,48 @@ describe('UserActions', () => {
     expect(api.banPubkey).toHaveBeenCalledWith('a'.repeat(64), 'Banned by moderator');
     expect(api.logDecision).toHaveBeenCalledTimes(1); // fired, but not awaited
   });
+
+  it('closes the ban dialog on success (the alertdialog is removed)', async () => {
+    // The real symptom of the hang bug is the dialog never closing; assert it's gone.
+    renderWithProvider(<UserActions pubkey={'a'.repeat(64)} />);
+    fireEvent.click(screen.getByRole('button', { name: /Ban User/i }));
+    const dialog = screen.getByRole('alertdialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Ban User' }));
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument());
+  });
+
+  it('surfaces a ban timeout as an error toast and keeps the dialog open for retry', async () => {
+    api.banPubkey.mockRejectedValue(
+      new Error("Relay RPC 'banpubkey' timed out after 30s. The action may still have applied. Re-check before retrying."),
+    );
+    renderWithProvider(<UserActions pubkey={'a'.repeat(64)} />);
+    fireEvent.click(screen.getByRole('button', { name: /Ban User/i }));
+    const dialog = screen.getByRole('alertdialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Ban User' }));
+
+    await waitFor(() =>
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Failed to ban user', variant: 'destructive' }),
+      ),
+    );
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+  });
+
+  it('shows a non-blocking toast when the audit log fails but still completes the ban', async () => {
+    // Audit-log loss should be visible to the moderator, but must never block the
+    // action or the dialog close.
+    api.logDecision.mockRejectedValue(new Error('audit down'));
+    renderWithProvider(<UserActions pubkey={'a'.repeat(64)} />);
+    fireEvent.click(screen.getByRole('button', { name: /Ban User/i }));
+    const dialog = screen.getByRole('alertdialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Ban User' }));
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: expect.stringMatching(/audit log not recorded/i) }),
+      ),
+    );
+  });
 });

--- a/src/components/UserActions.test.tsx
+++ b/src/components/UserActions.test.tsx
@@ -102,6 +102,36 @@ describe('UserActions', () => {
     expect(api.logDecision).toHaveBeenCalledTimes(1); // fired, but not awaited
   });
 
+  it('invalidates the decision log after the detached audit write lands (report converges without manual refresh)', async () => {
+    // Suspend/age-restrict resolution comes only from the D1 decision row, and the
+    // onSuccess refetch races the fire-and-forget write. The invalidation must fire
+    // AFTER the write resolves (not before), so the report converges on its own.
+    let resolveWrite!: () => void;
+    api.logDecision.mockReturnValue(new Promise<void>((r) => { resolveWrite = () => r(undefined); }));
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+    const decisionsInvalidations = () => invalidateSpy.mock.calls.filter(
+      ([arg]) => (arg as { queryKey?: unknown[] })?.queryKey?.[0] === 'decisions',
+    ).length;
+
+    render(
+      <QueryClientProvider client={qc}>
+        <TooltipProvider><UserActions pubkey={'a'.repeat(64)} /></TooltipProvider>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Suspend User/i }));
+
+    await waitFor(() => expect(api.logDecision).toHaveBeenCalledTimes(1));
+    expect(decisionsInvalidations()).toBe(0); // write hasn't landed yet — report stays unresolved
+
+    resolveWrite();
+
+    await waitFor(() => expect(decisionsInvalidations()).toBe(1));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['decisions'] });
+  });
+
   it('closes the ban dialog on success (the alertdialog is removed)', async () => {
     // The real symptom of the hang bug is the dialog never closing; assert it's gone.
     renderWithProvider(<UserActions pubkey={'a'.repeat(64)} />);

--- a/src/components/UserActions.test.tsx
+++ b/src/components/UserActions.test.tsx
@@ -1,23 +1,38 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { TooltipProvider } from '@/components/ui/tooltip';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { UserActions } from './UserActions';
 
+// Stable mock so individual tests can control resolution timing (e.g. make the
+// audit log hang) and assert on the same fn instances.
+const api = vi.hoisted(() => ({
+  bulkModerate: vi.fn(),
+  banPubkey: vi.fn(),
+  unbanPubkey: vi.fn(),
+  suspendPubkey: vi.fn(),
+  unsuspendPubkey: vi.fn(),
+  logDecision: vi.fn(),
+}));
+const toast = vi.hoisted(() => vi.fn());
+
 vi.mock('@/hooks/useAdminApi', () => ({
-  useAdminApi: () => ({
-    bulkModerate: vi.fn().mockResolvedValue({ success: true, eventsProcessed: 3, mediaProcessed: 2, failures: [] }),
-    banPubkey: vi.fn().mockResolvedValue({ success: true }),
-    unbanPubkey: vi.fn().mockResolvedValue({ success: true }),
-    suspendPubkey: vi.fn().mockResolvedValue({ success: true }),
-    unsuspendPubkey: vi.fn().mockResolvedValue({ success: true }),
-    logDecision: vi.fn().mockResolvedValue(undefined),
-  }),
+  useAdminApi: () => api,
 }));
 
 vi.mock('@/hooks/useToast', () => ({
-  useToast: () => ({ toast: vi.fn() }),
+  useToast: () => ({ toast }),
 }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.bulkModerate.mockResolvedValue({ success: true, eventsProcessed: 3, mediaProcessed: 2, failures: [] });
+  api.banPubkey.mockResolvedValue({ success: true });
+  api.unbanPubkey.mockResolvedValue({ success: true });
+  api.suspendPubkey.mockResolvedValue({ success: true });
+  api.unsuspendPubkey.mockResolvedValue({ success: true });
+  api.logDecision.mockResolvedValue(undefined);
+});
 
 function renderWithProvider(ui: React.ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
@@ -65,5 +80,25 @@ describe('UserActions', () => {
     expect(screen.getByRole('button', { name: /Ban User/i })).toBeInTheDocument();
     expect(screen.queryByText(/Age Restrict All/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Delete All Content/i)).not.toBeInTheDocument();
+  });
+
+  it('completes the ban (closing the modal) even when the audit log never resolves', async () => {
+    // Regression: logDecision used to be awaited in the mutation critical path, so a
+    // hung /api/decisions write left the confirm dialog stuck on "Banning…". The audit
+    // log is now fire-and-forget, so the ban must still settle when it never resolves.
+    api.logDecision.mockReturnValue(new Promise(() => {})); // never settles
+    const onActionComplete = vi.fn();
+
+    renderWithProvider(
+      <UserActions pubkey={'a'.repeat(64)} onActionComplete={onActionComplete} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Ban User/i })); // open confirm dialog
+    const dialog = screen.getByRole('alertdialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Ban User' })); // confirm
+
+    await waitFor(() => expect(onActionComplete).toHaveBeenCalledTimes(1));
+    expect(api.banPubkey).toHaveBeenCalledWith('a'.repeat(64), 'Banned by moderator');
+    expect(api.logDecision).toHaveBeenCalledTimes(1); // fired, but not awaited
   });
 });

--- a/src/components/UserActions.tsx
+++ b/src/components/UserActions.tsx
@@ -27,9 +27,14 @@ export function UserActions({
 
   // Audit logging is a non-critical side effect. Fire-and-forget so a slow or
   // hung /api/decisions write can never stall the moderation action or leave the
-  // confirm dialog stuck on "Banning…". The relay action is the source of truth.
+  // confirm dialog stuck on "Banning…". The relay action is the source of truth;
+  // on failure we surface a non-blocking toast so the moderator knows the decision
+  // log lagged, without blocking the action or the dialog close.
   const logAudit = (params: Parameters<typeof api.logDecision>[0]) =>
-    void api.logDecision(params).catch((e) => console.warn('[UserActions] audit log failed', e));
+    void api.logDecision(params).catch((e) => {
+      console.warn('[UserActions] audit log failed', e);
+      toast({ title: 'Action applied; audit log not recorded' });
+    });
 
   const suspendUserMutation = useMutation({
     mutationFn: async () => {

--- a/src/components/UserActions.tsx
+++ b/src/components/UserActions.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useToast } from '@/hooks/useToast';
@@ -23,6 +23,7 @@ export function UserActions({
 }: UserActionsProps) {
   const { toast } = useToast();
   const api = useAdminApi();
+  const queryClient = useQueryClient();
   const showBulkActions = context !== 'age-review';
 
   // Audit logging is a non-critical side effect. Fire-and-forget so a slow or
@@ -30,11 +31,24 @@ export function UserActions({
   // confirm dialog stuck on "Banning…". The relay action is the source of truth;
   // on failure we surface a non-blocking toast so the moderator knows the decision
   // log lagged, without blocking the action or the dialog close.
+  //
+  // When the write SUCCEEDS, re-invalidate the decision log. Suspend and bulk
+  // age-restrict derive resolved-state ONLY from the D1 decision row (unlike
+  // ban/delete, which read live relay state), and onActionComplete refetches
+  // decisions synchronously in onSuccess — racing this detached write. Without a
+  // post-write invalidation the report reads back before the row exists and stays
+  // "pending" until a manual refresh. The ['decisions'] prefix covers
+  // useDecisionLog's ['decisions', targetId]. A report legitimately stays
+  // unresolved when no row was written (the .catch path), which is correct.
   const logAudit = (params: Parameters<typeof api.logDecision>[0]) =>
-    void api.logDecision(params).catch((e) => {
-      console.warn('[UserActions] audit log failed', e);
-      toast({ title: 'Action applied; audit log not recorded' });
-    });
+    void api.logDecision(params)
+      .then(() => {
+        queryClient.invalidateQueries({ queryKey: ['decisions'] });
+      })
+      .catch((e) => {
+        console.warn('[UserActions] audit log failed', e);
+        toast({ title: 'Action applied; audit log not recorded' });
+      });
 
   const suspendUserMutation = useMutation({
     mutationFn: async () => {

--- a/src/components/UserActions.tsx
+++ b/src/components/UserActions.tsx
@@ -25,10 +25,16 @@ export function UserActions({
   const api = useAdminApi();
   const showBulkActions = context !== 'age-review';
 
+  // Audit logging is a non-critical side effect. Fire-and-forget so a slow or
+  // hung /api/decisions write can never stall the moderation action or leave the
+  // confirm dialog stuck on "Banning…". The relay action is the source of truth.
+  const logAudit = (params: Parameters<typeof api.logDecision>[0]) =>
+    void api.logDecision(params).catch((e) => console.warn('[UserActions] audit log failed', e));
+
   const suspendUserMutation = useMutation({
     mutationFn: async () => {
       await api.suspendPubkey(pubkey, 'Suspended by moderator');
-      await api.logDecision({
+      logAudit({
         targetType: 'pubkey',
         targetId: pubkey,
         action: 'suspend_user',
@@ -47,7 +53,7 @@ export function UserActions({
   const unsuspendUserMutation = useMutation({
     mutationFn: async () => {
       await api.unsuspendPubkey(pubkey);
-      await api.logDecision({
+      logAudit({
         targetType: 'pubkey',
         targetId: pubkey,
         action: 'unsuspend_user',
@@ -66,7 +72,7 @@ export function UserActions({
   const banUserMutation = useMutation({
     mutationFn: async () => {
       await api.banPubkey(pubkey, 'Banned by moderator');
-      await api.logDecision({
+      logAudit({
         targetType: 'pubkey',
         targetId: pubkey,
         action: 'ban_user',
@@ -85,7 +91,7 @@ export function UserActions({
   const unbanUserMutation = useMutation({
     mutationFn: async () => {
       await api.unbanPubkey(pubkey);
-      await api.logDecision({
+      logAudit({
         targetType: 'pubkey',
         targetId: pubkey,
         action: 'unban_user',
@@ -104,7 +110,7 @@ export function UserActions({
   const bulkAgeRestrictMutation = useMutation({
     mutationFn: async () => {
       const result = await api.bulkModerate(pubkey, 'age-restrict-all', 'Bulk age-restricted by moderator');
-      await api.logDecision({
+      logAudit({
         targetType: 'pubkey',
         targetId: pubkey,
         action: 'bulk_age_restrict',
@@ -124,7 +130,7 @@ export function UserActions({
   const bulkDeleteMutation = useMutation({
     mutationFn: async () => {
       const result = await api.bulkModerate(pubkey, 'delete-all', 'Bulk deleted by moderator');
-      await api.logDecision({
+      logAudit({
         targetType: 'pubkey',
         targetId: pubkey,
         action: 'bulk_delete',

--- a/src/lib/adminApi.test.ts
+++ b/src/lib/adminApi.test.ts
@@ -28,6 +28,7 @@ import {
   extractMediaHashes,
   isBlockedMediaAction,
   updateAgeReviewCase,
+  bulkModerate,
   ApiError,
   type UnsignedEvent,
   type ApiResponse,
@@ -108,14 +109,43 @@ describe('adminApi', () => {
       expect(result).toEqual(mockData);
     });
 
-    it('throws an actionable ApiError when an HTTP request times out', async () => {
-      // Regression: apiRequest had no timeout, so a hung relay could leave the
-      // "Deleting…" / "Restricting…" bulk modals spinning forever.
+    it('a read (GET) timeout says could-not-reach, not may-have-applied', async () => {
+      // A timed-out read mutated nothing, so "may have applied" would be wrong;
+      // the moderator should just retry.
       mockFetch.mockRejectedValueOnce(new DOMException('timed out', 'TimeoutError'));
 
       await expect(getWorkerInfo(API_URL)).rejects.toThrow(
-        /Request to \/api\/info timed out after 30s\. The action may still have applied\. Re-check before retrying\./,
+        /Request to \/api\/info timed out after 30s\. Could not reach the relay\. Try again\./,
       );
+    });
+
+    it('a write (POST) timeout says the action may still have applied', async () => {
+      // A timed-out write can still land on the relay even though we stopped
+      // waiting, so the moderator must re-check rather than blindly retry.
+      mockFetch.mockRejectedValueOnce(new DOMException('timed out', 'TimeoutError'));
+
+      await expect(
+        moderateAction(API_URL, { action: 'ban_pubkey', pubkey: 'p'.repeat(64) }),
+      ).rejects.toThrow(
+        /Request to \/api\/moderate timed out after 30s\. The action may still have applied\. Re-check before retrying\./,
+      );
+    });
+
+    it('bulkModerate is bounded by the longer BULK timeout; other calls by the 30s default', async () => {
+      // bulk is a server-side O(N/5) loop that can legitimately exceed 30s; it
+      // must not false-timeout on the primary path.
+      const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, eventsProcessed: 0, mediaProcessed: 0, failures: [] }),
+      });
+      await bulkModerate(API_URL, 'a'.repeat(64), 'age-restrict-all');
+      expect(timeoutSpy).toHaveBeenLastCalledWith(180_000);
+
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) });
+      await getWorkerInfo(API_URL);
+      expect(timeoutSpy).toHaveBeenLastCalledWith(30_000);
+      timeoutSpy.mockRestore();
     });
 
     it('surfaces a JSON error body (409 version_conflict) as structured ApiError fields', async () => {
@@ -403,6 +433,15 @@ describe('adminApi', () => {
       mockFetch.mockRejectedValueOnce(networkError);
 
       await expect(callRelayRpc(API_URL, 'banpubkey')).rejects.toBe(networkError);
+    });
+
+    it('an RPC list read timeout says could-not-reach (no may-have-applied)', async () => {
+      // list* RPC methods are reads; a timeout there mutated nothing.
+      mockFetch.mockRejectedValueOnce(new DOMException('timed out', 'TimeoutError'));
+
+      await expect(listBannedPubkeys(API_URL)).rejects.toThrow(
+        /Relay RPC 'listbannedpubkeys' timed out after 30s\. Could not reach the relay\. Try again\./,
+      );
     });
   });
 

--- a/src/lib/adminApi.test.ts
+++ b/src/lib/adminApi.test.ts
@@ -443,6 +443,16 @@ describe('adminApi', () => {
         /Relay RPC 'listbannedpubkeys' timed out after 30s\. Could not reach the relay\. Try again\./,
       );
     });
+
+    it('a non-list read RPC (getbannedevent) timeout says could-not-reach, not may-have-applied', async () => {
+      // getbannedevent / supportedmethods are reads that do NOT start with 'list';
+      // they must still get the read copy, not the write "may have applied".
+      mockFetch.mockRejectedValueOnce(new DOMException('timed out', 'TimeoutError'));
+
+      await expect(callRelayRpc(API_URL, 'getbannedevent', ['eventid'])).rejects.toThrow(
+        /Relay RPC 'getbannedevent' timed out after 30s\. Could not reach the relay\. Try again\./,
+      );
+    });
   });
 
   describe('banPubkey', () => {

--- a/src/lib/adminApi.test.ts
+++ b/src/lib/adminApi.test.ts
@@ -131,6 +131,22 @@ describe('adminApi', () => {
       );
     });
 
+    it('a stalled response BODY (headers sent, body never finishes) still maps to the friendly timeout copy', async () => {
+      // A relay that sends headers then stalls the body aborts during
+      // response.json(), AFTER fetch() resolved. Without bounding the read this
+      // surfaced as a raw TimeoutError that skipped the "may have applied" copy.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => { throw new DOMException('timed out', 'TimeoutError'); },
+      });
+
+      await expect(
+        moderateAction(API_URL, { action: 'ban_pubkey', pubkey: 'p'.repeat(64) }),
+      ).rejects.toThrow(
+        /Request to \/api\/moderate timed out after 30s\. The action may still have applied\. Re-check before retrying\./,
+      );
+    });
+
     it('bulkModerate is bounded by the longer BULK timeout; other calls by the 30s default', async () => {
       // bulk is a server-side O(N/5) loop that can legitimately exceed 30s; it
       // must not false-timeout on the primary path.

--- a/src/lib/adminApi.test.ts
+++ b/src/lib/adminApi.test.ts
@@ -108,6 +108,16 @@ describe('adminApi', () => {
       expect(result).toEqual(mockData);
     });
 
+    it('throws an actionable ApiError when an HTTP request times out', async () => {
+      // Regression: apiRequest had no timeout, so a hung relay could leave the
+      // "Deleting…" / "Restricting…" bulk modals spinning forever.
+      mockFetch.mockRejectedValueOnce(new DOMException('timed out', 'TimeoutError'));
+
+      await expect(getWorkerInfo(API_URL)).rejects.toThrow(
+        /Request to \/api\/info timed out after 30s\. The action may still have applied\. Re-check before retrying\./,
+      );
+    });
+
     it('surfaces a JSON error body (409 version_conflict) as structured ApiError fields', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
@@ -376,6 +386,23 @@ describe('adminApi', () => {
       const result = await callRelayRpc<string[]>(API_URL, 'listbannedpubkeys');
 
       expect(result).toEqual(['pubkey1', 'pubkey2']);
+    });
+
+    it('throws an actionable ApiError naming the method when the RPC times out', async () => {
+      // Regression: callRelayRpc had no timeout, so a hung banpubkey purge left
+      // the "Banning…" modal spinning forever.
+      mockFetch.mockRejectedValueOnce(new DOMException('timed out', 'TimeoutError'));
+
+      await expect(callRelayRpc(API_URL, 'banpubkey', ['npub'])).rejects.toThrow(
+        /Relay RPC 'banpubkey' timed out after 30s\. The action may still have applied\. Re-check before retrying\./,
+      );
+    });
+
+    it('re-throws non-timeout fetch errors unchanged', async () => {
+      const networkError = new TypeError('Failed to fetch');
+      mockFetch.mockRejectedValueOnce(networkError);
+
+      await expect(callRelayRpc(API_URL, 'banpubkey')).rejects.toBe(networkError);
     });
   });
 

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -87,8 +87,10 @@ export class ApiError extends Error {
 // Bound every relay-bound HTTP call so a slow or hung relay can't leave the UI
 // spinning forever (the "Banning…" / "Deleting…" confirm modals). Generous
 // because some actions purge across 16+ tables; if legitimate operations exceed
-// this, fix the relay-side latency rather than raise the bound. Covers every
-// caller of apiRequest and callRelayRpc, not just bans.
+// this, fix the relay-side latency rather than raise the bound. Covers callers of
+// apiRequest and callRelayRpc (connection AND body read, via readJsonBounded) plus
+// the standalone check-result / check-classifier / realness fetches — every
+// relay-bound fetch routes through fetchWithTimeout.
 const API_TIMEOUT_MS = 30_000;
 
 // Bulk moderation is a server-side O(N/5) loop that can legitimately run for
@@ -121,6 +123,29 @@ const READ_RPC_METHODS = new Set<string>([
 // even though we stopped waiting (re-check before retrying), but a timed-out
 // read applied nothing (just retry). Emitting "may have applied" on a read would
 // mislead the moderator.
+// Map an AbortSignal.timeout abort to the friendly ApiError copy. Shared by
+// fetchWithTimeout (bounds the connection) and readJsonBounded (the body read): a
+// relay that sends headers then stalls the body aborts during response.json(),
+// AFTER fetch() resolves, so the same mapping has to wrap the read too — otherwise
+// a body stall surfaces as a raw TimeoutError and skips the "may have applied" copy.
+function asTimeoutApiError(err: unknown, label: string, mutates: boolean, timeoutMs: number): unknown {
+  if (err instanceof DOMException && err.name === 'TimeoutError') {
+    const tail = mutates
+      ? 'The action may still have applied. Re-check before retrying.'
+      : 'Could not reach the relay. Try again.';
+    return new ApiError(`${label} timed out after ${timeoutMs / 1000}s. ${tail}`);
+  }
+  return err;
+}
+
+async function readJsonBounded<T>(response: Response, label: string, mutates: boolean, timeoutMs: number): Promise<T> {
+  try {
+    return await response.json() as T;
+  } catch (err) {
+    throw asTimeoutApiError(err, label, mutates, timeoutMs);
+  }
+}
+
 async function fetchWithTimeout(
   url: string,
   init: RequestInit,
@@ -131,13 +156,7 @@ async function fetchWithTimeout(
   try {
     return await fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
   } catch (err) {
-    if (err instanceof DOMException && err.name === 'TimeoutError') {
-      const tail = opts.mutates
-        ? 'The action may still have applied. Re-check before retrying.'
-        : 'Could not reach the relay. Try again.';
-      throw new ApiError(`${label} timed out after ${timeoutMs / 1000}s. ${tail}`);
-    }
-    throw err;
+    throw asTimeoutApiError(err, label, opts.mutates, timeoutMs);
   }
 }
 
@@ -151,11 +170,14 @@ async function apiRequest<T>(
   if (!apiUrl) {
     throw new ApiError('No relay selected. Go to Settings to choose an environment.');
   }
+  const label = `Request to ${endpoint}`;
+  const mutates = method !== 'GET';
+  const timeoutMs = opts?.timeoutMs ?? API_TIMEOUT_MS;
   const response = await fetchWithTimeout(`${apiUrl}${endpoint}`, {
     method,
     headers: getApiHeaders(),
     body: body ? JSON.stringify(body) : undefined,
-  }, `Request to ${endpoint}`, { mutates: method !== 'GET', timeoutMs: opts?.timeoutMs });
+  }, label, { mutates, timeoutMs });
 
   if (!response.ok) {
     // Read the JSON error body if there is one so callers can act on structured
@@ -176,7 +198,7 @@ async function apiRequest<T>(
     );
   }
 
-  const data = await response.json() as T;
+  const data = await readJsonBounded<T>(response, label, mutates, timeoutMs);
   return data;
 }
 
@@ -239,11 +261,13 @@ export async function callRelayRpc<T = unknown>(
   if (!apiUrl) {
     throw new ApiError('No relay selected. Go to Settings to choose an environment.');
   }
+  const label = `Relay RPC '${method}'`;
+  const mutates = !READ_RPC_METHODS.has(method);
   const response = await fetchWithTimeout(`${apiUrl}/api/relay-rpc`, {
     method: 'POST',
     headers: getApiHeaders(),
     body: JSON.stringify({ method, params }),
-  }, `Relay RPC '${method}'`, { mutates: !READ_RPC_METHODS.has(method) });
+  }, label, { mutates });
 
   if (!response.ok) {
     throw new ApiError(
@@ -253,7 +277,7 @@ export async function callRelayRpc<T = unknown>(
     );
   }
 
-  const data = await response.json() as ApiResponse<T>;
+  const data = await readJsonBounded<ApiResponse<T>>(response, label, mutates, API_TIMEOUT_MS);
 
   if (!data.success) {
     throw new ApiError(data.error || 'RPC call failed');
@@ -429,10 +453,10 @@ export async function moderateMedia(
 // Check media moderation status
 export async function checkMediaStatus(apiUrl: string, sha256: string): Promise<MediaStatus | null> {
   try {
-    const response = await fetch(`${apiUrl}/api/check-result/${sha256}`, {
+    const response = await fetchWithTimeout(`${apiUrl}/api/check-result/${sha256}`, {
       method: 'GET',
       headers: getApiHeaders(),
-    });
+    }, 'Media status check', { mutates: false });
 
     if (!response.ok) {
       if (response.status === 404) return null;
@@ -685,10 +709,10 @@ export interface ClassifierData {
 // Fetch classifier data (scene classification + topic profile)
 export async function getClassifierData(apiUrl: string, sha256: string): Promise<ClassifierData | null> {
   try {
-    const response = await fetch(`${apiUrl}/api/check-classifier/${sha256}`, {
+    const response = await fetchWithTimeout(`${apiUrl}/api/check-classifier/${sha256}`, {
       method: 'GET',
       headers: getApiHeaders(),
-    });
+    }, 'Classifier data', { mutates: false });
 
     if (!response.ok) {
       if (response.status === 404) return null;
@@ -772,10 +796,10 @@ export interface AIDetectionResult {
 // Fetch AI detection results by event ID (via worker proxy)
 export async function getAIDetectionResult(apiUrl: string, eventId: string): Promise<AIDetectionResult | null> {
   try {
-    const response = await fetch(`${apiUrl}/api/realness/jobs/${eventId}`, {
+    const response = await fetchWithTimeout(`${apiUrl}/api/realness/jobs/${eventId}`, {
       method: 'GET',
       headers: { ...getApiHeaders(''), 'Accept': 'application/json' },
-    });
+    }, 'AI detection result', { mutates: false });
 
     if (!response.ok) {
       if (response.status === 404) return null;
@@ -800,7 +824,7 @@ export async function submitAIDetection(
   eventId?: string
 ): Promise<{ jobId: string; status: string } | null> {
   try {
-    const response = await fetch(`${apiUrl}/api/realness/analyze`, {
+    const response = await fetchWithTimeout(`${apiUrl}/api/realness/analyze`, {
       method: 'POST',
       headers: getApiHeaders(),
       body: JSON.stringify({
@@ -808,7 +832,7 @@ export async function submitAIDetection(
         mediaHash: sha256,
         ...(eventId && { eventId }),
       }),
-    });
+    }, 'AI detection submit', { mutates: true });
 
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -99,6 +99,23 @@ const API_TIMEOUT_MS = 30_000;
 // model (feat/bulk-moderate-async-job), after which bulk reverts to the default.
 const BULK_API_TIMEOUT_MS = 180_000;
 
+// NIP-86 read methods are a closed, known set, so derive read-vs-write from
+// membership rather than a name prefix: `getbannedevent` and `supportedmethods`
+// are reads that do NOT start with `list`, and inferring from the prefix would
+// label them as writes (wrongly telling a moderator a read "may have applied").
+const READ_RPC_METHODS = new Set<string>([
+  'listbannedpubkeys',
+  'listallowedpubkeys',
+  'listsuspendedpubkeys',
+  'listbannedevents',
+  'listbannedtags',
+  'listblockedips',
+  'listallowedkinds',
+  'listeventsneedingmoderation',
+  'getbannedevent',
+  'supportedmethods',
+]);
+
 // fetch wrapper that aborts after the chosen bound. The timeout message depends
 // on whether the call mutates relay state: a timed-out write may have landed
 // even though we stopped waiting (re-check before retrying), but a timed-out
@@ -226,8 +243,7 @@ export async function callRelayRpc<T = unknown>(
     method: 'POST',
     headers: getApiHeaders(),
     body: JSON.stringify({ method, params }),
-    // The only read RPCs are the list* methods; everything else mutates relay state.
-  }, `Relay RPC '${method}'`, { mutates: !method.startsWith('list') });
+  }, `Relay RPC '${method}'`, { mutates: !READ_RPC_METHODS.has(method) });
 
   if (!response.ok) {
     throw new ApiError(

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -84,6 +84,29 @@ export class ApiError extends Error {
   }
 }
 
+// Bound every relay-bound HTTP call so a slow or hung relay can't leave the UI
+// spinning forever (the "Banning…" / "Deleting…" confirm modals). Generous
+// because some actions purge across 16+ tables; if legitimate operations exceed
+// this, fix the relay-side latency rather than raise the bound. Covers every
+// caller of apiRequest and callRelayRpc, not just bans.
+const API_TIMEOUT_MS = 30_000;
+
+// fetch wrapper that aborts after API_TIMEOUT_MS. On timeout it throws an
+// actionable ApiError: the relay may have applied the action even though we
+// stopped waiting, so the moderator should re-check rather than blindly retry.
+async function fetchWithTimeout(url: string, init: RequestInit, label: string): Promise<Response> {
+  try {
+    return await fetch(url, { ...init, signal: AbortSignal.timeout(API_TIMEOUT_MS) });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'TimeoutError') {
+      throw new ApiError(
+        `${label} timed out after ${API_TIMEOUT_MS / 1000}s. The action may still have applied. Re-check before retrying.`,
+      );
+    }
+    throw err;
+  }
+}
+
 async function apiRequest<T>(
   apiUrl: string,
   endpoint: string,
@@ -93,11 +116,11 @@ async function apiRequest<T>(
   if (!apiUrl) {
     throw new ApiError('No relay selected. Go to Settings to choose an environment.');
   }
-  const response = await fetch(`${apiUrl}${endpoint}`, {
+  const response = await fetchWithTimeout(`${apiUrl}${endpoint}`, {
     method,
     headers: getApiHeaders(),
     body: body ? JSON.stringify(body) : undefined,
-  });
+  }, `Request to ${endpoint}`);
 
   if (!response.ok) {
     // Read the JSON error body if there is one so callers can act on structured
@@ -172,11 +195,6 @@ export async function allowPubkey(apiUrl: string, pubkey: string): Promise<ApiRe
   return moderateAction(apiUrl, { action: 'allow_pubkey', pubkey });
 }
 
-// Bound relay RPC calls so a slow/hung relay can't leave the UI spinning forever
-// (e.g. the "Banning…" modal). Generous because banpubkey purges across 16+ tables;
-// if legitimate purges exceed this, fix the relay-side latency rather than raise this.
-const RELAY_RPC_TIMEOUT_MS = 30_000;
-
 // NIP-86 Relay RPC endpoint - for direct relay management
 export async function callRelayRpc<T = unknown>(
   apiUrl: string,
@@ -186,24 +204,11 @@ export async function callRelayRpc<T = unknown>(
   if (!apiUrl) {
     throw new ApiError('No relay selected. Go to Settings to choose an environment.');
   }
-  let response: Response;
-  try {
-    response = await fetch(`${apiUrl}/api/relay-rpc`, {
-      method: 'POST',
-      headers: getApiHeaders(),
-      body: JSON.stringify({ method, params }),
-      signal: AbortSignal.timeout(RELAY_RPC_TIMEOUT_MS),
-    });
-  } catch (err) {
-    if (err instanceof DOMException && err.name === 'TimeoutError') {
-      // The relay may still have applied the action even though we stopped waiting,
-      // so tell the moderator to re-check rather than blindly retry.
-      throw new ApiError(
-        `Relay RPC '${method}' timed out after ${RELAY_RPC_TIMEOUT_MS / 1000}s. The action may still have applied. Re-check before retrying.`,
-      );
-    }
-    throw err;
-  }
+  const response = await fetchWithTimeout(`${apiUrl}/api/relay-rpc`, {
+    method: 'POST',
+    headers: getApiHeaders(),
+    body: JSON.stringify({ method, params }),
+  }, `Relay RPC '${method}'`);
 
   if (!response.ok) {
     throw new ApiError(

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -87,10 +87,12 @@ export class ApiError extends Error {
 // Bound every relay-bound HTTP call so a slow or hung relay can't leave the UI
 // spinning forever (the "Banning…" / "Deleting…" confirm modals). Generous
 // because some actions purge across 16+ tables; if legitimate operations exceed
-// this, fix the relay-side latency rather than raise the bound. Covers callers of
-// apiRequest and callRelayRpc (connection AND body read, via readJsonBounded) plus
-// the standalone check-result / check-classifier / realness fetches — every
-// relay-bound fetch routes through fetchWithTimeout.
+// this, fix the relay-side latency rather than raise the bound. Every relay-bound
+// fetch routes through fetchWithTimeout (bounds the connection). apiRequest and
+// callRelayRpc additionally map a stalled body read to the friendly copy via
+// readJsonBounded (they surface the message to a moderator); the standalone
+// check-result / check-classifier / realness fetches rely on the same AbortSignal
+// aborting the body and degrade to null, so they need no copy mapping.
 const API_TIMEOUT_MS = 30_000;
 
 // Bulk moderation is a server-side O(N/5) loop that can legitimately run for

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -199,7 +199,7 @@ export async function callRelayRpc<T = unknown>(
       // The relay may still have applied the action even though we stopped waiting,
       // so tell the moderator to re-check rather than blindly retry.
       throw new ApiError(
-        `Relay RPC '${method}' timed out after ${RELAY_RPC_TIMEOUT_MS / 1000}s. The action may still have applied — re-check before retrying.`,
+        `Relay RPC '${method}' timed out after ${RELAY_RPC_TIMEOUT_MS / 1000}s. The action may still have applied. Re-check before retrying.`,
       );
     }
     throw err;

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -91,17 +91,34 @@ export class ApiError extends Error {
 // caller of apiRequest and callRelayRpc, not just bans.
 const API_TIMEOUT_MS = 30_000;
 
-// fetch wrapper that aborts after API_TIMEOUT_MS. On timeout it throws an
-// actionable ApiError: the relay may have applied the action even though we
-// stopped waiting, so the moderator should re-check rather than blindly retry.
-async function fetchWithTimeout(url: string, init: RequestInit, label: string): Promise<Response> {
+// Bulk moderation is a server-side O(N/5) loop that can legitimately run for
+// minutes on a prolific account (especially once REST enumeration processes ALL
+// of an author's videos). Give it a far larger client bound than the default so
+// it doesn't false-timeout on the primary destructive path, while still
+// guaranteeing no fetch hangs forever. Tracked for replacement by the async job
+// model (feat/bulk-moderate-async-job), after which bulk reverts to the default.
+const BULK_API_TIMEOUT_MS = 180_000;
+
+// fetch wrapper that aborts after the chosen bound. The timeout message depends
+// on whether the call mutates relay state: a timed-out write may have landed
+// even though we stopped waiting (re-check before retrying), but a timed-out
+// read applied nothing (just retry). Emitting "may have applied" on a read would
+// mislead the moderator.
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  label: string,
+  opts: { mutates: boolean; timeoutMs?: number },
+): Promise<Response> {
+  const timeoutMs = opts.timeoutMs ?? API_TIMEOUT_MS;
   try {
-    return await fetch(url, { ...init, signal: AbortSignal.timeout(API_TIMEOUT_MS) });
+    return await fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
   } catch (err) {
     if (err instanceof DOMException && err.name === 'TimeoutError') {
-      throw new ApiError(
-        `${label} timed out after ${API_TIMEOUT_MS / 1000}s. The action may still have applied. Re-check before retrying.`,
-      );
+      const tail = opts.mutates
+        ? 'The action may still have applied. Re-check before retrying.'
+        : 'Could not reach the relay. Try again.';
+      throw new ApiError(`${label} timed out after ${timeoutMs / 1000}s. ${tail}`);
     }
     throw err;
   }
@@ -111,7 +128,8 @@ async function apiRequest<T>(
   apiUrl: string,
   endpoint: string,
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
-  body?: object
+  body?: object,
+  opts?: { timeoutMs?: number }
 ): Promise<T> {
   if (!apiUrl) {
     throw new ApiError('No relay selected. Go to Settings to choose an environment.');
@@ -120,7 +138,7 @@ async function apiRequest<T>(
     method,
     headers: getApiHeaders(),
     body: body ? JSON.stringify(body) : undefined,
-  }, `Request to ${endpoint}`);
+  }, `Request to ${endpoint}`, { mutates: method !== 'GET', timeoutMs: opts?.timeoutMs });
 
   if (!response.ok) {
     // Read the JSON error body if there is one so callers can act on structured
@@ -208,7 +226,8 @@ export async function callRelayRpc<T = unknown>(
     method: 'POST',
     headers: getApiHeaders(),
     body: JSON.stringify({ method, params }),
-  }, `Relay RPC '${method}'`);
+    // The only read RPCs are the list* methods; everything else mutates relay state.
+  }, `Relay RPC '${method}'`, { mutates: !method.startsWith('list') });
 
   if (!response.ok) {
     throw new ApiError(
@@ -1019,7 +1038,10 @@ export async function bulkModerate(
   action: BulkAction,
   reason?: string,
 ): Promise<BulkModerateResult> {
-  const result = await apiRequest<BulkModerateResult>(apiUrl, '/api/bulk-moderate', 'POST', { pubkey, action, reason });
+  const result = await apiRequest<BulkModerateResult>(
+    apiUrl, '/api/bulk-moderate', 'POST', { pubkey, action, reason },
+    { timeoutMs: BULK_API_TIMEOUT_MS },
+  );
   if (!result.success) {
     const summary = result.failures.slice(0, 3).join('; ');
     throw new ApiError(summary ? `Bulk moderation failed: ${summary}` : 'Bulk moderation failed');

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -172,6 +172,11 @@ export async function allowPubkey(apiUrl: string, pubkey: string): Promise<ApiRe
   return moderateAction(apiUrl, { action: 'allow_pubkey', pubkey });
 }
 
+// Bound relay RPC calls so a slow/hung relay can't leave the UI spinning forever
+// (e.g. the "Banning…" modal). Generous because banpubkey purges across 16+ tables;
+// if legitimate purges exceed this, fix the relay-side latency rather than raise this.
+const RELAY_RPC_TIMEOUT_MS = 30_000;
+
 // NIP-86 Relay RPC endpoint - for direct relay management
 export async function callRelayRpc<T = unknown>(
   apiUrl: string,
@@ -181,11 +186,24 @@ export async function callRelayRpc<T = unknown>(
   if (!apiUrl) {
     throw new ApiError('No relay selected. Go to Settings to choose an environment.');
   }
-  const response = await fetch(`${apiUrl}/api/relay-rpc`, {
-    method: 'POST',
-    headers: getApiHeaders(),
-    body: JSON.stringify({ method, params }),
-  });
+  let response: Response;
+  try {
+    response = await fetch(`${apiUrl}/api/relay-rpc`, {
+      method: 'POST',
+      headers: getApiHeaders(),
+      body: JSON.stringify({ method, params }),
+      signal: AbortSignal.timeout(RELAY_RPC_TIMEOUT_MS),
+    });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'TimeoutError') {
+      // The relay may still have applied the action even though we stopped waiting,
+      // so tell the moderator to re-check rather than blindly retry.
+      throw new ApiError(
+        `Relay RPC '${method}' timed out after ${RELAY_RPC_TIMEOUT_MS / 1000}s. The action may still have applied — re-check before retrying.`,
+      );
+    }
+    throw err;
+  }
 
   if (!response.ok) {
     throw new ApiError(


### PR DESCRIPTION
## What

The **Ban User** confirm modal could hang on **"Banning…"** indefinitely while the ban itself succeeded on the relay (reported by Charlie). Two independent defects, both fixed here.

### 1. Audit log no longer blocks the moderation action (`UserActions.tsx`)

The ban mutation awaited `logDecision` (a D1 audit write to `/api/decisions`) in its critical path, so a slow or hung audit write kept the mutation pending and the `ConfirmDialog` could never close. Audit logging is a non-critical side effect, so it's now fire-and-forget via a small `logAudit` helper (with a `.catch`). Applied consistently to all the mutations in this component (ban, suspend, unsuspend, unban, bulk age-restrict, bulk delete). The relay action remains the source of truth and stays awaited.

### 2. Every relay-bound HTTP call now times out (`adminApi.ts`)

`callRelayRpc` was a plain `fetch` with no timeout, so a slow/hung relay (`banpubkey` purges across 16+ tables) left an infinite spinner. I added a shared `fetchWithTimeout` helper with a 30s `AbortSignal.timeout` and applied it to both `callRelayRpc` and `apiRequest`. That second path matters: `bulkModerate` (the "Delete All Content" and "Age Restrict All" actions) routes through `apiRequest`, so without this those destructive modals retained the identical "spins forever" failure mode the ban fix was meant to kill. On timeout it rejects with an actionable message ("The action may still have applied. Re-check before retrying.") that matches the observed reality (the action lands even when the UI gives up). This now protects every RPC and HTTP caller, not just `UserActions`.

## Why this is safe without a reproduction

Both are unambiguous defects in the code path, independent of which call was hanging in the field:
- A non-critical side effect blocking the primary UX violates our graceful-degradation rule.
- No network call should be able to hang forever.
- `UserManagement.tsx` already surfaces relay success immediately and verifies in the background; this brings `UserActions` in line.
- Audit logging is now best-effort: a failed `logDecision` is logged to the console and swallowed, so the decision log can lag the relay with no operator-visible signal. This is the intended graceful-degradation tradeoff (the relay is source of truth); surfacing true state on timeout is tracked in #133.

## Test / checks

- `tsc -p tsconfig.app.json --noEmit` clean
- `eslint` clean
- `vitest run` green (120 passed, 1 skipped; `App.test.tsx` excluded as a pre-existing scaffold smoke test that holds the node process open via the app's relay WebSocket)
- New regression tests: HTTP-path and RPC-path timeouts throw the actionable message and non-timeout errors re-throw unchanged (`adminApi.test.ts`); the ban completes and closes the modal even when `logDecision` never resolves (`UserActions.test.tsx`).

## Out of scope (tracked in #133)

- Same `await logDecision(...)`-in-critical-path pattern in `UserManagement.tsx`, `EventDetail.tsx`, `Labels.tsx`, `EventActions.tsx`.
- Relay-side latency of the purge itself (a queued/async purge if legitimate operations start approaching the 30s client timeout).
- Surfacing true state on timeout via `verifyPubkeyBanned`.

Refs #133


---

## Update — bulk timeout decoupling + accurate read/write copy

Two follow-ups from review, on top of the original ban-modal fix:

- **Decoupled the bulk-moderate timeout from the global 30s.** A large/multi-video account legitimately exceeds 30s, so the flat bound surfaced a false "timed out" on the primary destructive path. `apiRequest` now takes a per-call timeout override; `bulkModerate` uses `BULK_API_TIMEOUT_MS = 180_000`, everything else keeps the 30s default. (This bound is interim — the async job model in #135 removes it.)
- **Read-vs-write timeout copy.** The "may still have applied. Re-check" message now only fires on mutating calls. Reads (`getWorkerInfo`, `list*`, `getbannedevent`, `supportedmethods`) say "Could not reach the relay. Try again." Read-ness is derived from an explicit `READ_RPC_METHODS` set (a `list*` prefix heuristic mislabeled `getbannedevent`/`supportedmethods` as writes).
- Audit-log failure now raises a non-blocking toast; regression tests assert the dialog closes and that a timeout surfaces as the error toast.

Validated locally end-to-end against a real funnelcake relay (ban + delete modals close on success; ban confirmed applied on the relay).
