### PR TITLE
chore(zendesk): retire dead inbound moderation-execution path (#103)

### DIFF
--- a/docs/api-webhooks.md
+++ b/docs/api-webhooks.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Divine Relay Manager exposes several API endpoints that allow external systems to trigger moderation actions. This enables integration with customer support tools like Zendesk, automated moderation pipelines, and other external services.
+The Divine Relay Manager exposes several API endpoints for integration with external systems like Zendesk (ticket report parsing, decision sync, age-review replies). Note: Zendesk does **not** execute moderation actions. Moderation is performed in Relay Manager; Zendesk only receives decision updates back. The former inbound moderation-execution path has been retired (see the note under `POST /api/zendesk/webhook`).
 
 **Base URL:** `https://api-relay.divine.video` (or `https://relay.admin.divine.video/api`)
 
@@ -146,6 +146,8 @@ Check the moderation status of a media file.
 
 ### POST /api/zendesk/webhook
 
+> **Retired (#103).** This inbound moderation-execution endpoint has been removed from the worker. Moderation happens in Relay Manager, not Zendesk. The Zendesk-side trigger, webhook, and `action_requested`/`action_status` fields have been deactivated. The detail below is kept for historical context only.
+
 Receives webhook events from Zendesk when ticket custom fields are updated.
 
 **Headers:**
@@ -227,6 +229,8 @@ Authorization: Bearer <zendesk-jwt-token>
 ---
 
 ### POST /api/zendesk/action
+
+> **Retired (#103).** This inbound moderation-execution endpoint (Zendesk sidebar) has been removed from the worker. The detail below is kept for historical context only.
 
 Execute moderation action from Zendesk sidebar (JWT authenticated).
 
@@ -318,6 +322,8 @@ Delete all decisions for a target (reopen a dismissed report).
 ---
 
 ## Setting Up Zendesk Webhooks
+
+> **Retired (#103).** The inbound moderation-execution wiring described below (the `action_requested`/`action_status` fields, the `relay moderation action` trigger, and the `relay-management` webhook) has been deactivated in Zendesk and removed from the worker. This section is kept for historical context only. The decision-reporting direction (Relay Manager → Zendesk auto-solve + internal notes) and the still-active `parse-report` / `age-review-reply` integrations are unaffected.
 
 ### 1. Create Custom Ticket Fields
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -6,9 +6,6 @@ import {
   getSecretKey,
   getManagementUrl,
   callNip86Rpc,
-  banEvent,
-  banPubkey,
-  unbanPubkey,
   type SecretStoreSecret,
 } from './nip86';
 import { ensureSchema } from './db';
@@ -31,7 +28,7 @@ import {
 } from './age-review';
 import { handleBulkModerateEnqueue, handleBulkJobStatus, processBulkJob } from './bulk-moderate';
 import type { BulkJobMessage } from '../../shared/bulk-moderation';
-import { ensureZendeskTable, addZendeskInternalNote, syncZendeskAfterAction, resolveZendeskCreds } from './zendesk-sync';
+import { ensureZendeskTable, addZendeskInternalNote, syncZendeskAfterAction } from './zendesk-sync';
 
 let schemaReady = false;
 async function ensureSchemaOnce(db: D1Database): Promise<void> {
@@ -57,17 +54,14 @@ interface Env extends KeycastEnv {
   MODERATION_API?: Fetcher;
   // Zendesk integration
   ZENDESK_SUBDOMAIN?: string | SecretStoreSecret;
-  // These four are per-worker secrets (not Secrets Store). If migrated to SecretStoreSecret,
+  // These three are per-worker secrets (not Secrets Store). If migrated to SecretStoreSecret,
   // update the call sites — they pass these directly to crypto/TextEncoder without resolving.
   ZENDESK_JWT_SECRET?: string;
   ZENDESK_PREAUTH_SECRET?: string;
-  ZENDESK_WEBHOOK_SECRET?: string;
   ZENDESK_PARSE_REPORT_SECRET?: string;
   ZENDESK_AGE_REVIEW_WEBHOOK_SECRET?: string | SecretStoreSecret;  // For /api/zendesk/age-review-reply
   ZENDESK_API_TOKEN?: string | SecretStoreSecret;
   ZENDESK_EMAIL?: string | SecretStoreSecret;
-  ZENDESK_FIELD_ACTION_STATUS?: string;
-  ZENDESK_FIELD_ACTION_REQUESTED?: string;
   ZENDESK_FIELD_CATEGORY?: string;       // For auto-solve required fields
   ZENDESK_FIELD_ISSUE?: string;          // For auto-solve required fields
   ZENDESK_FIELD_AGE_REVIEW_DEADLINE?: string;
@@ -1776,65 +1770,6 @@ async function verifyNip98Auth(
   }
 }
 
-// Update Zendesk ticket with action result and internal note
-async function updateZendeskTicket(
-  ticketId: number,
-  success: boolean,
-  actionRequested: string,
-  note: string,
-  env: Env
-): Promise<void> {
-  const creds = await resolveZendeskCreds(env);
-  if (!creds) {
-    console.warn('[updateZendeskTicket] Missing Zendesk API credentials, skipping callback');
-    return;
-  }
-
-  if (!env.ZENDESK_FIELD_ACTION_STATUS || !env.ZENDESK_FIELD_ACTION_REQUESTED) {
-    console.warn('[updateZendeskTicket] Missing Zendesk field IDs, skipping callback');
-    return;
-  }
-
-  try {
-    const auth = btoa(`${creds.email}/token:${creds.apiToken}`);
-    const url = `https://${creds.subdomain}.zendesk.com/api/v2/tickets/${ticketId}`;
-
-    const customFields = [
-      { id: parseInt(env.ZENDESK_FIELD_ACTION_STATUS, 10), value: success ? 'success' : 'failed' },
-    ];
-
-    // Only reset action_requested to 'none' on success
-    if (success) {
-      customFields.push({ id: parseInt(env.ZENDESK_FIELD_ACTION_REQUESTED, 10), value: 'none' });
-    }
-
-    const response = await fetch(url, {
-      method: 'PUT',
-      headers: {
-        'Authorization': `Basic ${auth}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        ticket: {
-          custom_fields: customFields,
-          comment: {
-            body: note,
-            public: false,
-          },
-        },
-      }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      console.error(`[updateZendeskTicket] Failed to update ticket ${ticketId}: ${response.status} - ${errorText}`);
-    }
-  } catch (error) {
-    console.error('[updateZendeskTicket] Error:', error);
-  }
-}
-
-// Add internal note to Zendesk ticket (simpler than updateZendeskTicket - just adds comment, optionally solves)
 // Proxy handler for blocked media preview (Blossom admin bypass)
 // Moderators need to see media that Blossom blocks (Banned/Restricted status returns 404 on CDN).
 // This endpoint authenticates against Blossom's admin bypass and streams the content through.
@@ -2141,11 +2076,6 @@ async function handleZendeskRoutes(
 ): Promise<Response> {
   const subPath = path.replace('/api/zendesk', '');
 
-  // Webhook endpoint uses signature verification instead of JWT
-  if (subPath === '/webhook' && request.method === 'POST') {
-    return handleZendeskWebhook(request, env, corsHeaders);
-  }
-
   // Age review: parent replied to Zendesk ticket
   if (subPath === '/age-review-reply' && request.method === 'POST') {
     const bodyText = await request.text();
@@ -2195,12 +2125,6 @@ async function handleZendeskRoutes(
       }
       break;
 
-    case '/action':
-      if (request.method === 'POST') {
-        return handleZendeskAction(request, user, env, corsHeaders);
-      }
-      break;
-
     case '/verify':
       // Simple endpoint to verify JWT is valid
       if (request.method === 'GET') {
@@ -2216,152 +2140,6 @@ async function handleZendeskRoutes(
   }
 
   return jsonResponse({ success: false, error: 'Not found' }, 404, corsHeaders);
-}
-
-// Handle Zendesk webhook (triggered by ticket field changes)
-async function handleZendeskWebhook(
-  request: Request,
-  env: Env,
-  corsHeaders: Record<string, string>
-): Promise<Response> {
-  try {
-    const bodyText = await request.text();
-
-    // Verify webhook signature
-    const isValid = await verifyZendeskWebhook(request, bodyText, env.ZENDESK_WEBHOOK_SECRET);
-    if (!isValid) {
-      return jsonResponse({ success: false, error: 'Invalid webhook signature' }, 401, corsHeaders);
-    }
-
-    const body = JSON.parse(bodyText) as {
-      ticket_id: number;
-      action_requested?: string;
-      nostr_pubkey?: string;
-      nostr_event_id?: string;
-      agent_email?: string;
-    };
-
-    if (!body.action_requested || body.action_requested === 'none') {
-      return new Response(JSON.stringify({ success: true, message: 'No action requested' }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json', ...corsHeaders },
-      });
-    }
-
-    // Execute the moderation action via NIP-86 RPC utilities.
-    // NOTE: Zendesk-originated moderation actions may be dead code —
-    // Aleysha and team use relay.admin.divine.video for moderation,
-    // not Zendesk. Keeping for correctness but monitor for removal.
-    let actionResult: { success: boolean; error?: string } = { success: false, error: 'Unknown action' };
-
-    switch (body.action_requested) {
-      case 'ban_user':
-        if (body.nostr_pubkey) {
-          actionResult = await banPubkey(body.nostr_pubkey, `Zendesk ticket #${body.ticket_id}`, env);
-        }
-        break;
-
-      case 'delete_event':
-        // banevent RPC instead of kind 5: NIP-09 kind 5 only allows authors
-        // to delete their own events; admin key can't delete via kind 5.
-        if (body.nostr_event_id) {
-          actionResult = await banEvent(body.nostr_event_id, `Zendesk ticket #${body.ticket_id}`, env);
-        }
-        break;
-
-      case 'allow_user':
-        if (body.nostr_pubkey) {
-          actionResult = await unbanPubkey(body.nostr_pubkey, env);
-        }
-        break;
-    }
-
-    // Log the decision
-    if (env.DB && actionResult.success) {
-      await ensureSchemaOnce(env.DB);
-      await env.DB.prepare(`
-        INSERT INTO moderation_decisions (target_type, target_id, action, reason, moderator_pubkey, report_id)
-        VALUES (?, ?, ?, ?, ?, ?)
-      `).bind(
-        body.nostr_event_id ? 'event' : 'pubkey',
-        body.nostr_event_id || body.nostr_pubkey || '',
-        body.action_requested,
-        `Zendesk ticket #${body.ticket_id}`,
-        body.agent_email || null,
-        `zendesk:${body.ticket_id}`
-      ).run();
-
-      const targetType = body.nostr_event_id ? 'event' : 'pubkey';
-      const targetId = body.nostr_event_id || body.nostr_pubkey || '';
-      await markHumanReviewed(env.DB, targetType, targetId);
-
-      // Sync any linked Zendesk tickets (via our mapping table)
-      try {
-        await syncZendeskAfterAction(
-          env,
-          body.action_requested,
-          body.nostr_event_id ? 'event' : 'pubkey',
-          body.nostr_event_id || body.nostr_pubkey || '',
-          body.agent_email || 'webhook'
-        );
-      } catch (err) {
-        console.error('[handleZendeskWebhook] Zendesk sync error:', err);
-      }
-    }
-
-    // Callback to Zendesk to update ticket status and add internal note
-    // TODO: allow_user case skipped until semantics of allow_user vs unban are clarified
-    if (body.action_requested !== 'allow_user') {
-      const agentInfo = body.agent_email ? ` by ${body.agent_email}` : '';
-      let zendeskNote: string;
-
-      if (actionResult.success) {
-        switch (body.action_requested) {
-          case 'ban_user':
-            zendeskNote = `✅ Ban executed successfully for pubkey ${body.nostr_pubkey}${agentInfo}`;
-            break;
-          case 'delete_event':
-            zendeskNote = `✅ Delete event executed successfully for event ${body.nostr_event_id}${agentInfo}`;
-            break;
-          default:
-            zendeskNote = `✅ Action "${body.action_requested}" executed successfully${agentInfo}`;
-        }
-      } else {
-        switch (body.action_requested) {
-          case 'ban_user':
-            zendeskNote = `❌ Ban failed for pubkey ${body.nostr_pubkey}: ${actionResult.error}`;
-            break;
-          case 'delete_event':
-            zendeskNote = `❌ Delete event failed for event ${body.nostr_event_id}: ${actionResult.error}`;
-            break;
-          default:
-            zendeskNote = `❌ Action "${body.action_requested}" failed: ${actionResult.error}`;
-        }
-      }
-
-      try {
-        await updateZendeskTicket(body.ticket_id, actionResult.success, body.action_requested, zendeskNote, env);
-      } catch (err) {
-        console.error('[handleZendeskWebhook] Zendesk callback error:', err);
-      }
-    }
-
-    return new Response(JSON.stringify({
-      success: actionResult.success,
-      action: body.action_requested,
-      error: actionResult.error,
-    }), {
-      status: actionResult.success ? 200 : 500,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
-  } catch (error) {
-    console.error('Zendesk webhook error:', error);
-    return jsonResponse(
-      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
-      500,
-      corsHeaders
-    );
-  }
 }
 
 // Parse content report ticket and store mapping, add helpful links as internal note
@@ -2780,181 +2558,6 @@ async function handleZendeskContext(
     });
   } catch (error) {
     console.error('Zendesk context error:', error);
-    return jsonResponse(
-      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
-      500,
-      corsHeaders
-    );
-  }
-}
-
-// Execute moderation action from Zendesk sidebar
-async function handleZendeskAction(
-  request: Request,
-  user: ZendeskJWTPayload,
-  env: Env,
-  corsHeaders: Record<string, string>
-): Promise<Response> {
-  try {
-    const body = await request.json() as {
-      action: string;
-      pubkey?: string;
-      event_id?: string;
-      reason?: string;
-      ticket_id?: number;
-    };
-
-    if (!body.action) {
-      return jsonResponse({ success: false, error: 'Missing action' }, 400, corsHeaders);
-    }
-
-    const secretKey = await getSecretKey(env);
-    let actionResult: { success: boolean; error?: string } = { success: false, error: 'Unknown action' };
-
-    const reason = body.reason || `Via Zendesk by ${user.email}${body.ticket_id ? ` (ticket #${body.ticket_id})` : ''}`;
-
-    switch (body.action) {
-      case 'ban_user':
-        if (body.pubkey) {
-          const httpUrl = getManagementUrl(env);
-          const payload = JSON.stringify({ method: 'banpubkey', params: [body.pubkey, reason] });
-          const payloadHash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(payload));
-          const payloadHashHex = Array.from(new Uint8Array(payloadHash)).map(b => b.toString(16).padStart(2, '0')).join('');
-
-          const authEvent = finalizeEvent({
-            kind: 27235,
-            content: '',
-            tags: [['u', httpUrl], ['method', 'POST'], ['payload', payloadHashHex]],
-            created_at: Math.floor(Date.now() / 1000),
-          }, secretKey);
-
-          const response = await fetch(httpUrl, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/nostr+json+rpc',
-              'Authorization': `Nostr ${btoa(JSON.stringify(authEvent))}`,
-            },
-            body: payload,
-          });
-
-          actionResult = response.ok ? { success: true } : { success: false, error: `Relay error: ${response.status}` };
-        } else {
-          actionResult = { success: false, error: 'Missing pubkey' };
-        }
-        break;
-
-      case 'allow_user':
-        if (body.pubkey) {
-          const httpUrl = getManagementUrl(env);
-          const payload = JSON.stringify({ method: 'unbanpubkey', params: [body.pubkey] });
-          const payloadHash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(payload));
-          const payloadHashHex = Array.from(new Uint8Array(payloadHash)).map(b => b.toString(16).padStart(2, '0')).join('');
-
-          const authEvent = finalizeEvent({
-            kind: 27235,
-            content: '',
-            tags: [['u', httpUrl], ['method', 'POST'], ['payload', payloadHashHex]],
-            created_at: Math.floor(Date.now() / 1000),
-          }, secretKey);
-
-          const response = await fetch(httpUrl, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/nostr+json+rpc',
-              'Authorization': `Nostr ${btoa(JSON.stringify(authEvent))}`,
-            },
-            body: payload,
-          });
-
-          actionResult = response.ok ? { success: true } : { success: false, error: `Relay error: ${response.status}` };
-        } else {
-          actionResult = { success: false, error: 'Missing pubkey' };
-        }
-        break;
-
-      case 'delete_event':
-        // Use banevent RPC instead of kind 5. See handleZendeskWebhook
-        // delete_event comment for rationale.
-        // NOTE: Zendesk-originated moderation may be dead code — monitor
-        // for removal if relay admin tool fully replaces Zendesk actions.
-        if (body.event_id) {
-          const httpUrl = getManagementUrl(env);
-          const payload = JSON.stringify({ method: 'banevent', params: [body.event_id, reason] });
-          const payloadHash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(payload));
-          const payloadHashHex = Array.from(new Uint8Array(payloadHash)).map(b => b.toString(16).padStart(2, '0')).join('');
-
-          const authEvent = finalizeEvent({
-            kind: 27235,
-            content: '',
-            tags: [['u', httpUrl], ['method', 'POST'], ['payload', payloadHashHex]],
-            created_at: Math.floor(Date.now() / 1000),
-          }, secretKey);
-
-          const response = await fetch(httpUrl, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/nostr+json+rpc',
-              'Authorization': `Nostr ${btoa(JSON.stringify(authEvent))}`,
-            },
-            body: payload,
-          });
-
-          actionResult = response.ok ? { success: true } : { success: false, error: `Relay error: ${response.status}` };
-        } else {
-          actionResult = { success: false, error: 'Missing event_id' };
-        }
-        break;
-
-      default:
-        actionResult = { success: false, error: `Unknown action: ${body.action}` };
-    }
-
-    // Log the decision
-    if (env.DB && actionResult.success) {
-      await ensureSchemaOnce(env.DB);
-      await env.DB.prepare(`
-        INSERT INTO moderation_decisions (target_type, target_id, action, reason, moderator_pubkey, report_id)
-        VALUES (?, ?, ?, ?, ?, ?)
-      `).bind(
-        body.event_id ? 'event' : 'pubkey',
-        body.event_id || body.pubkey || '',
-        body.action,
-        reason,
-        user.email,
-        body.ticket_id ? `zendesk:${body.ticket_id}` : null
-      ).run();
-
-      const ztargetType = body.event_id ? 'event' : 'pubkey';
-      const ztargetId = body.event_id || body.pubkey || '';
-      await markHumanReviewed(env.DB, ztargetType, ztargetId);
-    }
-
-    // Sync any linked Zendesk tickets
-    if (actionResult.success) {
-      try {
-        await syncZendeskAfterAction(
-          env,
-          body.action,
-          body.event_id ? 'event' : 'pubkey',
-          body.event_id || body.pubkey || '',
-          user.email
-        );
-      } catch (err) {
-        console.error('[handleZendeskAction] Zendesk sync error:', err);
-      }
-    }
-
-    return new Response(JSON.stringify({
-      success: actionResult.success,
-      action: body.action,
-      error: actionResult.error,
-      moderator: user.email,
-    }), {
-      status: actionResult.success ? 200 : 500,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
-  } catch (error) {
-    console.error('Zendesk action error:', error);
     return jsonResponse(
       { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
       500,

--- a/worker/wrangler.local.toml
+++ b/worker/wrangler.local.toml
@@ -27,9 +27,6 @@ MODERATION_ADMIN_URL = "https://moderation-api.divine.video"
 REALNESS_API_URL = "https://realness.admin.divine.video"
 # Allow admin UI plus the managed web app and its preview deployments
 ALLOWED_ORIGINS = "https://relay.admin.divine.video,https://app.divine.video,https://*.openvine-app.pages.dev,*.divine-relay-manager.pages.dev,*.divine-relay-admin.pages.dev"
-# Zendesk custom field IDs for webhook callback
-ZENDESK_FIELD_ACTION_STATUS = "14545793289743"
-ZENDESK_FIELD_ACTION_REQUESTED = "14545826900367"
 # Zendesk custom field IDs for auto-solve required fields
 ZENDESK_FIELD_CATEGORY = "14559549220879"
 ZENDESK_FIELD_ISSUE = "14560383908879"

--- a/worker/wrangler.prod.toml
+++ b/worker/wrangler.prod.toml
@@ -93,9 +93,6 @@ MODERATION_ADMIN_URL = "https://moderation-api.divine.video"
 ALLOWED_ORIGINS = "https://relay.admin.divine.video,https://app.divine.video,https://*.openvine-app.pages.dev,*.divine-relay-manager.pages.dev,*.divine-relay-admin.pages.dev"
 # CDN domain for media proxy (Blossom admin bypass for blocked content preview)
 CDN_DOMAIN = "media.divine.video"
-# Zendesk custom field IDs for webhook callback
-ZENDESK_FIELD_ACTION_STATUS = "14545793289743"
-ZENDESK_FIELD_ACTION_REQUESTED = "14545826900367"
 # Slack webhook for age review deadline alerts (add via: wrangler secret put SLACK_WEBHOOK_URL --config wrangler.prod.toml)
 # SLACK_WEBHOOK_URL — not in [vars] because it's a secret
 # Zendesk custom field IDs for auto-solve required fields

--- a/worker/wrangler.staging.toml
+++ b/worker/wrangler.staging.toml
@@ -92,9 +92,6 @@ MODERATION_ADMIN_URL = "https://moderation-api.divine.video"
 ALLOWED_ORIGINS = "https://relay.admin.divine.video,https://app.divine.video,https://*.openvine-app.pages.dev,*.divine-relay-manager.pages.dev,*.divine-relay-admin.pages.dev"
 # CDN domain for media proxy (Blossom admin bypass for blocked content preview)
 CDN_DOMAIN = "media.divine.video"
-# Zendesk custom field IDs for webhook callback
-ZENDESK_FIELD_ACTION_STATUS = "14545793289743"
-ZENDESK_FIELD_ACTION_REQUESTED = "14545826900367"
 # Slack webhook for age review deadline alerts (add via: wrangler secret put SLACK_WEBHOOK_URL --config wrangler.staging.toml)
 # SLACK_WEBHOOK_URL — not in [vars] because it's a secret
 # Zendesk custom field IDs for auto-solve required fields


### PR DESCRIPTION
## Summary

Removes the dead Zendesk → relay-manager inbound moderation-execution path (worker side of #103). Moderation is performed in Relay Manager, not Zendesk; the Zendesk side reports decisions back (auto-solve + internal notes) but must not execute relay actions.

## Motivation

Investigation (recorded in #103) found this path was **live in Zendesk** (active trigger + webhook + `action_requested`/`action_status` fields) and reachable at the worker, but had **never successfully executed** — 0 zendesk-originated rows across the entire prod `moderation_decisions` table. It was inert by accident, not by design, and it bypassed Keycast enforcement + the moderation DM. "Inert by accident" is a latent risk: a secret rotation or a well-meaning fix could silently switch on Zendesk-driven bans that diverge from the main moderation path.

The Zendesk-side surface has already been deactivated (trigger, webhook, both fields — reversible, before/after snapshots captured; see #103). This PR removes the now-dead worker code behind it.

## What changed

**Removed:**
- `handleZendeskWebhook` (`POST /api/zendesk/webhook`) + its route
- `handleZendeskAction` (`POST /api/zendesk/action`) + its route/case
- `updateZendeskTicket` (only caller was `handleZendeskWebhook`)
- Imports orphaned by the removal — `banEvent` / `banPubkey` / `unbanPubkey` (nip86) and `resolveZendeskCreds` (zendesk-sync), confirmed used only by those handlers
- Orphaned `Env` fields `ZENDESK_WEBHOOK_SECRET`, `ZENDESK_FIELD_ACTION_STATUS`, `ZENDESK_FIELD_ACTION_REQUESTED`, and the two field-ID entries in `wrangler.{prod,staging,local}.toml`
- Retirement notes added to `docs/api-webhooks.md`

**Kept (verified independent):**
- The decision-reporting direction: `syncZendeskAfterAction` auto-solve + internal notes
- `parse-report`, `age-review-reply`, `pre-auth`, `mobile-jwt` integrations
- `verifyZendeskWebhook` (still used by `parse-report` and `age-review-reply`)

## Validation

Rebased on `main` @ `234e336` (after #91/#134/#135/#138 landed). Full CI sequence run locally, all green:
- root `npm run test` (tsc-app + eslint + vitest + vite build) — pass
- worker typecheck (`tsc -p tsconfig.json --noEmit`) — clean
- worker `test:run` — 259 passed; `test:d1` — 16 passed

API change only, no UI change. The removed endpoints return 404/401 (retired); no caller exists (mobile/web do not call them; the Zendesk trigger/webhook are deactivated).

Closes #103.
