### PR TITLE
feat(age-review): Greenlight consent funnel dashboard

### DIFF
--- a/docs/superpowers/plans/2026-06-29-greenlight-funnel-dashboard.md
+++ b/docs/superpowers/plans/2026-06-29-greenlight-funnel-dashboard.md
@@ -1,0 +1,621 @@
+# Greenlight Consent Funnel Dashboard v1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `GET /api/age-review/funnel` endpoint and a funnel summary panel to relay-manager, showing the 13-15 Greenlight cohort moving from request through approval, sourced from D1 (moderation outcomes) plus Zendesk tag counts (helpdesk intake).
+
+**Architecture:** A new admin-guarded worker endpoint runs one D1 group-by over `age_review_cases` and a few Zendesk Search counts, buckets them into funnel stages, and returns a small JSON payload. A React panel in the existing Age Review tab renders it. The endpoint is the durable contract that admin.divine.video can syndicate later (out of scope here). All work lives in the `divine-relay-manager` repo.
+
+**Tech Stack:** Cloudflare Workers (TypeScript), D1, Zendesk Search API, React + TanStack Query, shadcn/ui, Vitest.
+
+## Global Constraints
+
+- Repo: `divine-relay-manager`. No new dependencies.
+- D1 schema is maintained at runtime by `ensureSchema`; this feature adds **no** schema change. Never run `wrangler d1 migrations apply`.
+- Reuse existing helpers: `json(body, status, corsHeaders)`, `resolveZendeskCreds(env)`, `apiRequest<T>(apiUrl, path, method)`. Do not reimplement them.
+- Zendesk auth pattern (verbatim from `zendesk-sync.ts`): `btoa(\`${email}/token:${apiToken}\`)`, base `https://${subdomain}.zendesk.com`, header `Authorization: Basic ${auth}`.
+- Graceful degradation: a Zendesk failure must never block the moderation (D1) half of the response.
+- Run `npx eslint .` before any push (tsc + tests are not enough for this repo).
+- Commits: Conventional Commit style, no `Co-Authored-By` lines.
+- Canonical values (verbatim): age bands `under_13` | `age_13_15` | `age_16_plus_claimed`; terminal states `cleared`, `denied_closed`; `created_via` of `report` | `minor_onboarding`. `AGE_BANDS` and `TERMINAL_STATES` are exported from `shared/age-review.ts`.
+
+---
+
+### Task 1: Funnel types and moderation bucketing
+
+**Files:**
+- Modify: `shared/age-review.ts` (append exports)
+- Modify: `worker/src/age-review.ts` (add pure `bucketModerationCounts`)
+- Test: `worker/src/age-review.test.ts` (append a describe block)
+
+**Interfaces:**
+- Produces: `FunnelModerationCounts` and `AgeReviewFunnelResponse` types (shared); `bucketModerationCounts(rows: FunnelRow[]): FunnelModerationCounts` (worker).
+- Consumes: `AgeBand`, `TERMINAL_STATES` from `shared/age-review.ts`.
+
+- [ ] **Step 1: Add the shared types**
+
+In `shared/age-review.ts`, append:
+
+```ts
+export interface FunnelModerationCounts {
+  in_progress: number;
+  approved: { total: number; restored: number; new_minor: number };
+  denied_expired: number;
+}
+
+export interface AgeReviewFunnelResponse {
+  success: boolean;
+  age_band: AgeBand;
+  helpdesk: {
+    source: 'zendesk';
+    band_scope: 'all_bands';
+    reports_in: number | null;
+    requests_in: number | null;
+    video_received: number | null;
+  };
+  moderation: FunnelModerationCounts & { source: 'd1'; band_scope: AgeBand };
+  generated_at: string;
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+In `worker/src/age-review.test.ts`, add the import `bucketModerationCounts` to the existing `./age-review` import block, then append:
+
+```ts
+describe('bucketModerationCounts', () => {
+  it('sums non-terminal states into in_progress and splits approved by created_via', () => {
+    const result = bucketModerationCounts([
+      { state: 'cleared', created_via: 'report', c: 3 },
+      { state: 'cleared', created_via: 'minor_onboarding', c: 2 },
+      { state: 'denied_closed', created_via: 'report', c: 1 },
+      { state: 'submitted_for_review', created_via: 'report', c: 4 },
+      { state: 'restricted_pending_parental_consent', created_via: 'report', c: 5 },
+    ]);
+    expect(result.in_progress).toBe(9);
+    expect(result.approved).toEqual({ total: 5, restored: 3, new_minor: 2 });
+    expect(result.denied_expired).toBe(1);
+  });
+
+  it('returns zeroes for an empty set', () => {
+    expect(bucketModerationCounts([])).toEqual({
+      in_progress: 0,
+      approved: { total: 0, restored: 0, new_minor: 0 },
+      denied_expired: 0,
+    });
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `npx vitest run worker/src/age-review.test.ts -t bucketModerationCounts`
+Expected: FAIL with "bucketModerationCounts is not defined" (or import error).
+
+- [ ] **Step 4: Implement the pure function**
+
+In `worker/src/age-review.ts`, add the import `FunnelModerationCounts` to the existing `../../shared/age-review` import block, then add near the other exported helpers:
+
+```ts
+export interface FunnelRow {
+  state: string;
+  created_via: string | null;
+  c: number;
+}
+
+export function bucketModerationCounts(rows: FunnelRow[]): FunnelModerationCounts {
+  const terminal = new Set<string>(TERMINAL_STATES);
+  let in_progress = 0;
+  let approvedTotal = 0;
+  let approvedNewMinor = 0;
+  let denied_expired = 0;
+
+  for (const row of rows) {
+    const count = row.c ?? 0;
+    if (row.state === 'cleared') {
+      approvedTotal += count;
+      if (row.created_via === 'minor_onboarding') approvedNewMinor += count;
+    } else if (row.state === 'denied_closed') {
+      denied_expired += count;
+    } else if (!terminal.has(row.state)) {
+      in_progress += count;
+    }
+  }
+
+  return {
+    in_progress,
+    approved: {
+      total: approvedTotal,
+      restored: approvedTotal - approvedNewMinor,
+      new_minor: approvedNewMinor,
+    },
+    denied_expired,
+  };
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run worker/src/age-review.test.ts -t bucketModerationCounts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shared/age-review.ts worker/src/age-review.ts worker/src/age-review.test.ts
+git commit -m "feat(age-review): add funnel types and moderation bucketing"
+```
+
+---
+
+### Task 2: Zendesk tag-count helper
+
+**Files:**
+- Modify: `worker/src/age-review.ts` (add `fetchZendeskTagCount`)
+- Test: `worker/src/age-review.test.ts` (append a describe block)
+
+**Interfaces:**
+- Produces: `fetchZendeskTagCount(creds: { subdomain: string; email: string; apiToken: string }, query: string): Promise<number | null>`.
+- Uses the Zendesk Search count endpoint `/api/v2/search/count.json?query=...`, which returns `{ "count": number }`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `worker/src/age-review.test.ts`, add `fetchZendeskTagCount` to the `./age-review` import block, then append:
+
+```ts
+describe('fetchZendeskTagCount', () => {
+  const creds = { subdomain: 'rabblelabs', email: 'a@b.co', apiToken: 'tok' };
+
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('builds the search/count URL and returns the count', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ count: 7 }) });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await fetchZendeskTagCount(creds, 'type:ticket tags:age-review-response');
+
+    expect(result).toBe(7);
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('https://rabblelabs.zendesk.com/api/v2/search/count.json?query=');
+    expect(calledUrl).toContain(encodeURIComponent('type:ticket tags:age-review-response'));
+  });
+
+  it('returns null on a non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }));
+    expect(await fetchZendeskTagCount(creds, 'q')).toBeNull();
+  });
+
+  it('returns null when fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+    expect(await fetchZendeskTagCount(creds, 'q')).toBeNull();
+  });
+});
+```
+
+Ensure `afterEach` is in the file's vitest import (`import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';`).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run worker/src/age-review.test.ts -t fetchZendeskTagCount`
+Expected: FAIL with "fetchZendeskTagCount is not defined".
+
+- [ ] **Step 3: Implement the helper**
+
+In `worker/src/age-review.ts`, add:
+
+```ts
+export async function fetchZendeskTagCount(
+  creds: { subdomain: string; email: string; apiToken: string },
+  query: string,
+): Promise<number | null> {
+  try {
+    const auth = btoa(`${creds.email}/token:${creds.apiToken}`);
+    const url = `https://${creds.subdomain}.zendesk.com/api/v2/search/count.json?query=${encodeURIComponent(query)}`;
+    const response = await fetch(url, { headers: { Authorization: `Basic ${auth}` } });
+    if (!response.ok) return null;
+    const data = await response.json() as { count?: number };
+    return typeof data.count === 'number' ? data.count : null;
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run worker/src/age-review.test.ts -t fetchZendeskTagCount`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add worker/src/age-review.ts worker/src/age-review.test.ts
+git commit -m "feat(age-review): add Zendesk tag-count helper"
+```
+
+---
+
+### Task 3: Funnel handler and route
+
+**Files:**
+- Modify: `worker/src/age-review.ts` (add `handleGetAgeReviewFunnel`)
+- Modify: `worker/src/index.ts` (import + route, beside the cases route at line 559)
+- Test: `worker/src/age-review.test.ts` (append a describe block)
+
+**Interfaces:**
+- Consumes: `bucketModerationCounts`, `fetchZendeskTagCount` (Tasks 1-2), `resolveZendeskCreds(env)`, `json(...)`, `AGE_BANDS`.
+- Produces: `handleGetAgeReviewFunnel(request: Request, env: AgeReviewEnv, corsHeaders: Record<string, string>): Promise<Response>` returning an `AgeReviewFunnelResponse`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `worker/src/age-review.test.ts`, add `handleGetAgeReviewFunnel` to the `./age-review` import block, then append:
+
+```ts
+describe('handleGetAgeReviewFunnel', () => {
+  const cors = { 'Access-Control-Allow-Origin': '*' };
+  const groupRows = [
+    { state: 'cleared', created_via: 'report', c: 3 },
+    { state: 'cleared', created_via: 'minor_onboarding', c: 2 },
+    { state: 'denied_closed', created_via: 'report', c: 1 },
+    { state: 'submitted_for_review', created_via: 'report', c: 4 },
+  ];
+  const mockDb = {
+    prepare: vi.fn().mockReturnValue({
+      bind: vi.fn().mockReturnValue({ all: vi.fn().mockResolvedValue({ results: groupRows }) }),
+    }),
+  };
+  const req = new Request('https://api.test/api/age-review/funnel?age_band=age_13_15');
+
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('returns moderation counts and nulls helpdesk when Zendesk creds are absent', async () => {
+    const env = makeEnv(mockDb); // no ZENDESK_* set
+    const res = await handleGetAgeReviewFunnel(req, env, cors);
+    const body = await res.json() as import('../../shared/age-review').AgeReviewFunnelResponse;
+
+    expect(res.status).toBe(200);
+    expect(body.moderation.approved).toEqual({ total: 5, restored: 3, new_minor: 2 });
+    expect(body.moderation.in_progress).toBe(4);
+    expect(body.moderation.denied_expired).toBe(1);
+    expect(body.helpdesk).toMatchObject({ reports_in: null, requests_in: null, video_received: null });
+    expect(body.age_band).toBe('age_13_15');
+  });
+
+  it('populates helpdesk counts when Zendesk creds resolve', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ count: 9 }) }));
+    const env = makeEnv(mockDb, {
+      ZENDESK_SUBDOMAIN: 'rabblelabs', ZENDESK_EMAIL: 'a@b.co', ZENDESK_API_TOKEN: 'tok',
+    });
+    const res = await handleGetAgeReviewFunnel(req, env, cors);
+    const body = await res.json() as import('../../shared/age-review').AgeReviewFunnelResponse;
+
+    expect(body.helpdesk.requests_in).toBe(9);
+    expect(body.helpdesk.video_received).toBe(9);
+    expect(body.helpdesk.reports_in).toBe(9);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run worker/src/age-review.test.ts -t handleGetAgeReviewFunnel`
+Expected: FAIL with "handleGetAgeReviewFunnel is not defined".
+
+- [ ] **Step 3: Implement the handler**
+
+In `worker/src/age-review.ts`, add `AgeBand`, `AGE_BANDS` are already imported. Add `type AgeReviewFunnelResponse` to the `../../shared/age-review` import block. Then add:
+
+```ts
+export async function handleGetAgeReviewFunnel(
+  request: Request,
+  env: AgeReviewEnv,
+  corsHeaders: Record<string, string>,
+): Promise<Response> {
+  if (!env.DB) return json({ success: false, error: 'Database not configured' }, 500, corsHeaders);
+
+  const url = new URL(request.url);
+  const bandParam = url.searchParams.get('age_band');
+  const ageBand: AgeBand = bandParam && AGE_BANDS.includes(bandParam as AgeBand)
+    ? (bandParam as AgeBand)
+    : 'age_13_15';
+
+  const rows = await env.DB.prepare(
+    'SELECT state, created_via, COUNT(*) AS c FROM age_review_cases WHERE suspected_age_band = ? GROUP BY state, created_via',
+  ).bind(ageBand).all<FunnelRow>();
+  const moderation = bucketModerationCounts(rows.results ?? []);
+
+  let reports_in: number | null = null;
+  let requests_in: number | null = null;
+  let video_received: number | null = null;
+
+  const creds = await resolveZendeskCreds(env);
+  if (creds) {
+    [requests_in, video_received, reports_in] = await Promise.all([
+      fetchZendeskTagCount(creds, 'type:ticket tags:age-review-response'),
+      fetchZendeskTagCount(creds, 'type:ticket tags:consent_video_received'),
+      fetchZendeskTagCount(creds, 'type:ticket tags:age-review -tags:age-review-response'),
+    ]);
+  }
+
+  const payload: AgeReviewFunnelResponse = {
+    success: true,
+    age_band: ageBand,
+    helpdesk: { source: 'zendesk', band_scope: 'all_bands', reports_in, requests_in, video_received },
+    moderation: { source: 'd1', band_scope: ageBand, ...moderation },
+    generated_at: new Date().toISOString(),
+  };
+  return json(payload, 200, corsHeaders);
+}
+```
+
+- [ ] **Step 4: Wire the route**
+
+In `worker/src/index.ts`, add `handleGetAgeReviewFunnel,` to the import block from `./age-review` (around line 21). Then, immediately before the existing cases route at line 559, add:
+
+```ts
+      if (path === '/api/age-review/funnel' && request.method === 'GET') {
+        return handleGetAgeReviewFunnel(request, env, corsHeaders);
+      }
+```
+
+This sits inside the same admin-guarded block as the other `/api/age-review/*` routes, so it inherits `verifyAdminAccess`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run worker/src/age-review.test.ts -t handleGetAgeReviewFunnel`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Typecheck the worker route change**
+
+Run: `npx tsc -p tsconfig.app.json --noEmit`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add worker/src/age-review.ts worker/src/index.ts worker/src/age-review.test.ts
+git commit -m "feat(age-review): add funnel endpoint GET /api/age-review/funnel"
+```
+
+---
+
+### Task 4: Frontend API client and hook binding
+
+**Files:**
+- Modify: `src/lib/adminApi.ts` (add `getAgeReviewFunnel`)
+- Modify: `src/hooks/useAdminApi.ts` (bind it)
+
+**Interfaces:**
+- Produces: `adminApi.getAgeReviewFunnel(apiUrl: string, ageBand?: string): Promise<AgeReviewFunnelResponse>` and the bound `api.getAgeReviewFunnel(ageBand?: string)`.
+- Consumes: `apiRequest`, `AgeReviewFunnelResponse` (Task 1).
+
+- [ ] **Step 1: Add the API function**
+
+In `src/lib/adminApi.ts`, near `getAgeReviewCases`, add:
+
+```ts
+export async function getAgeReviewFunnel(
+  apiUrl: string,
+  ageBand: string = 'age_13_15',
+): Promise<import('../../shared/age-review').AgeReviewFunnelResponse> {
+  return apiRequest<import('../../shared/age-review').AgeReviewFunnelResponse>(
+    apiUrl,
+    `/api/age-review/funnel?age_band=${encodeURIComponent(ageBand)}`,
+    'GET',
+  );
+}
+```
+
+- [ ] **Step 2: Bind it in the hook**
+
+In `src/hooks/useAdminApi.ts`, inside the `boundApi` object next to `getAgeReviewCases`, add:
+
+```ts
+    getAgeReviewFunnel: (ageBand?: string) =>
+      adminApi.getAgeReviewFunnel(apiUrl, ageBand),
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npx tsc -p tsconfig.app.json --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/adminApi.ts src/hooks/useAdminApi.ts
+git commit -m "feat(age-review): add funnel API client and hook binding"
+```
+
+---
+
+### Task 5: Funnel panel component and mount
+
+**Files:**
+- Create: `src/components/AgeReviewFunnel.tsx`
+- Modify: `src/components/AgeReview.tsx` (mount the panel above the split layout)
+- Test: `src/components/AgeReviewFunnel.test.tsx`
+
+**Interfaces:**
+- Consumes: `useAdminApi().getAgeReviewFunnel`, `AgeReviewFunnelResponse`, shadcn `Card`, `Badge`.
+- Produces: the `AgeReviewFunnel` component (default-free named export).
+
+- [ ] **Step 1: Write the failing render test**
+
+Create `src/components/AgeReviewFunnel.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactElement } from 'react';
+import { AgeReviewFunnel } from './AgeReviewFunnel';
+
+vi.mock('@/hooks/useAdminApi', () => ({
+  useAdminApi: () => ({
+    getAgeReviewFunnel: vi.fn().mockResolvedValue({
+      success: true,
+      age_band: 'age_13_15',
+      helpdesk: { source: 'zendesk', band_scope: 'all_bands', reports_in: 12, requests_in: 8, video_received: 5 },
+      moderation: { source: 'd1', band_scope: 'age_13_15', in_progress: 4, approved: { total: 3, restored: 2, new_minor: 1 }, denied_expired: 1 },
+      generated_at: '2026-06-29T00:00:00Z',
+    }),
+  }),
+}));
+
+function renderWithClient(ui: ReactElement) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+describe('AgeReviewFunnel', () => {
+  it('renders stage labels and counts from the payload', async () => {
+    renderWithClient(<AgeReviewFunnel />);
+    expect(await screen.findByText('Requests in')).toBeInTheDocument();
+    expect(await screen.findByText('8')).toBeInTheDocument();
+    expect(await screen.findByText('Video received')).toBeInTheDocument();
+    expect(await screen.findByText('Approved')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/components/AgeReviewFunnel.test.tsx`
+Expected: FAIL (module `./AgeReviewFunnel` not found).
+
+- [ ] **Step 3: Implement the component**
+
+Create `src/components/AgeReviewFunnel.tsx`:
+
+```tsx
+import { useQuery } from "@tanstack/react-query";
+import { useAdminApi } from "@/hooks/useAdminApi";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function fmt(n: number | null): string {
+  return n == null ? "—" : String(n);
+}
+
+export function AgeReviewFunnel() {
+  const api = useAdminApi();
+  const { data, isLoading } = useQuery({
+    queryKey: ['age-review-funnel', 'age_13_15'],
+    queryFn: () => api.getAgeReviewFunnel('age_13_15'),
+    staleTime: 60_000,
+    refetchInterval: 60_000,
+  });
+
+  if (isLoading) {
+    return (
+      <Card className="p-3">
+        <Skeleton className="h-5 w-48 mb-3" />
+        <div className="grid grid-cols-3 sm:grid-cols-6 gap-3">
+          {Array.from({ length: 6 }).map((_, i) => <Skeleton key={i} className="h-14" />)}
+        </div>
+      </Card>
+    );
+  }
+
+  if (!data?.success) {
+    return (
+      <Card className="p-3 text-sm text-muted-foreground">
+        Funnel data unavailable.
+      </Card>
+    );
+  }
+
+  const stages: { label: string; value: number | null; sub?: string }[] = [
+    { label: "Reports in", value: data.helpdesk.reports_in, sub: "helpdesk" },
+    { label: "Requests in", value: data.helpdesk.requests_in, sub: "helpdesk" },
+    { label: "Video received", value: data.helpdesk.video_received, sub: "helpdesk" },
+    { label: "In progress", value: data.moderation.in_progress, sub: "moderation" },
+    { label: "Approved", value: data.moderation.approved.total, sub: `${data.moderation.approved.restored} restored / ${data.moderation.approved.new_minor} new` },
+    { label: "Denied / expired", value: data.moderation.denied_expired, sub: "moderation" },
+  ];
+
+  return (
+    <Card className="p-3">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-medium">Greenlight: age-review consent funnel</h3>
+        <Badge variant="secondary" className="text-xs">13-15</Badge>
+      </div>
+      <div className="grid grid-cols-3 sm:grid-cols-6 gap-3">
+        {stages.map((s) => (
+          <div key={s.label} className="rounded-md border p-2">
+            <div className="text-xl font-semibold tabular-nums">{fmt(s.value)}</div>
+            <div className="text-xs font-medium mt-0.5">{s.label}</div>
+            {s.sub && <div className="text-[10px] text-muted-foreground mt-0.5">{s.sub}</div>}
+          </div>
+        ))}
+      </div>
+      <div className="text-[10px] text-muted-foreground mt-2">
+        Helpdesk stages count all age-review tickets; moderation stages are 13-15 only.
+      </div>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/components/AgeReviewFunnel.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Mount the panel in the Age Review tab**
+
+In `src/components/AgeReview.tsx`, add the import at the top:
+
+```tsx
+import { AgeReviewFunnel } from "@/components/AgeReviewFunnel";
+```
+
+Replace the desktop `return` block (the `<div className="h-full flex gap-4">` ... closing `</div>` at the end of the component) with:
+
+```tsx
+  return (
+    <div className="h-full flex flex-col gap-4">
+      <AgeReviewFunnel />
+      <div className="flex-1 min-h-0 flex gap-4">
+        <Card className="w-[360px] shrink-0 flex flex-col overflow-hidden">
+          {listContent}
+        </Card>
+        <Card className="flex-1 overflow-hidden">
+          {detailContent}
+        </Card>
+      </div>
+    </div>
+  );
+```
+
+(The mobile `return` block is left unchanged for v1.)
+
+- [ ] **Step 6: Typecheck and lint**
+
+Run: `npx tsc -p tsconfig.app.json --noEmit && npx eslint .`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/AgeReviewFunnel.tsx src/components/AgeReviewFunnel.test.tsx src/components/AgeReview.tsx
+git commit -m "feat(age-review): add Greenlight funnel panel to Age Review tab"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full pipeline: `npm test` (runs tsc, eslint, vitest, and the build).
+- [ ] Manual check on staging: open the Age Review tab and confirm the funnel card renders, the moderation counts match the case list for the 13-15 band, and the helpdesk counts populate (or show "—" if Zendesk creds are not configured in that environment).
+
+## Self-review notes (coverage against spec)
+
+- Funnel stages (spec table): reports/requests/video from Zendesk tags, in-progress/approved/denied from D1 group-by. Covered in Tasks 1-3 and the panel in Task 5.
+- Two-source assembly and graceful Zendesk degradation: Task 3, with an explicit no-creds test.
+- Band scope labeling (helpdesk all-bands, moderation 13-15): encoded in the response `band_scope` fields and surfaced in the panel footnote.
+- Admin auth: inherited by route placement (Task 3, Step 4).
+- Out of scope for v1 (per spec follow-ons): Zendesk band tags, per-case video join, admin.divine.video syndication, the webform. Not in this plan by design.

--- a/docs/superpowers/specs/2026-06-29-greenlight-funnel-dashboard-design.md
+++ b/docs/superpowers/specs/2026-06-29-greenlight-funnel-dashboard-design.md
@@ -1,0 +1,132 @@
+# Greenlight Consent Funnel Dashboard: Design
+
+**Status:** Draft for review
+**Date:** 2026-06-29
+**Author:** Matthew Bradley
+**Tracking:** support-trust-safety#172 (item 2)
+
+---
+
+## Context
+
+Support leadership asked for a baseline on how the Greenlight 13-15 parent/teen onboarding is yielding: how many requests come in, how many verification videos are received, and how many accounts actually get authorized. We have initial ticket counts from Zendesk, but two parts of that funnel are not visible today:
+
+- **The outcome end** (how many requests become approved, onboarded accounts) lives in the moderation tool, not in Zendesk.
+- **"Verification video received"** is not recorded anywhere structured. A macro (`consent_video_received`, shipped 2026-06-29) now tags tickets when a video arrives, which makes this countable going forward.
+
+This design adds a single funnel view that shows the whole journey, request through outcome, by combining the two systems that hold the data.
+
+## Goal
+
+Give an at-a-glance funnel for the 13-15 Greenlight cohort, sourced from where the data actually lives, that an admin can read or screenshot for support leadership.
+
+Non-goals for v1: self-serve access for non-admins, perfect 1:1 reconciliation between helpdesk and moderation records, and band-perfect helpdesk counts (see Known Limitations).
+
+## The two-source reality
+
+The funnel spans two systems, and the exploration confirmed a clean way to read each:
+
+- **Helpdesk side (Zendesk)** holds intake and the video signal. A built-in discriminator already runs: third-party in-app *reports* get tagged `age-review` only, while a parent or teen who reaches the helpdesk themselves gets tagged `age-review` **and** `age-review-response`. The new `consent_video_received` tag is the third signal.
+- **Moderation side (relay-manager D1, `age_review_cases`)** is authoritative for outcomes. "Approved" is state `cleared`, and it splits into a restored account vs a brand-new approved minor account (`created_via = 'minor_onboarding'`). "Denied/expired" is state `denied_closed`. Keycast only stores per-user status with no aggregates, so D1 is the single outcome source.
+
+The seam: not every helpdesk request becomes a moderation case, and the two sides do not join 1:1. That is expected for a funnel, which shows drop-off rather than a single ledger.
+
+## Funnel stages
+
+| Stage | Plain meaning | Source | Query basis |
+|---|---|---|---|
+| Reports in (feeder) | someone flagged a possible under-16 account | Zendesk | `tags:age-review -tags:age-review-response` |
+| Requests in | a parent or teen reached the helpdesk to verify consent | Zendesk | `tags:age-review-response` |
+| Video received | a consent video arrived (attachment or link) | Zendesk | `tags:consent_video_received` |
+| In progress | open moderation case, not yet resolved (under review, restricted, or awaiting response) | relay-manager D1 | non-terminal states, band `age_13_15` |
+| Approved | account authorized (restored, or new approved minor) | relay-manager D1 | `state = cleared`, split by `created_via` |
+| Denied / expired | closed without approval, or 15-day clock lapsed | relay-manager D1 | `state = denied_closed` |
+
+Relevant D1 values (verified): states `open_reported`, `under_moderator_review`, `restricted_pending_user_response`, `restricted_pending_parental_consent`, `restricted_pending_support_email`, `submitted_for_review`, `needs_follow_up`, `cleared`, `denied_closed`; age bands `under_13`, `age_13_15`, `age_16_plus_claimed`; `created_via` of `report` or `minor_onboarding`.
+
+## Architecture
+
+The build separates into three cleanly independent parts. v1 delivers the first two; the third is an additive follow-on.
+
+### 1. Data endpoint (the syndication contract)
+
+`GET /api/age-review/funnel?age_band=age_13_15` in relay-manager.
+
+Relay-manager is the right home because it already holds both ingredients: the `age_review_cases` D1 table and Zendesk API credentials (its existing `zendesk-sync` code). The endpoint assembles counts from both sources and returns a small, self-describing payload. It is guarded like the other admin routes (CF Access JWT, or `X-Admin-Key` matching `ADMIN_API_KEY` for server-to-server callers, the same path moderation-service already uses).
+
+Data assembly:
+
+- **D1 (band-accurate):** one grouped query
+  ```sql
+  SELECT state, created_via, COUNT(*) AS c
+  FROM age_review_cases
+  WHERE suspected_age_band = 'age_13_15'
+  GROUP BY state, created_via;
+  ```
+  Bucketed in code: `in_progress` = all non-terminal states; `approved.total` = `cleared`, split into `new_minor` (`created_via = 'minor_onboarding'`) and `restored` (everything else cleared); `denied_expired` = `denied_closed`.
+- **Zendesk (Search API counts):** one count query per signal (`age-review-response`, `consent_video_received`, and `age-review -age-review-response` for the feeder).
+
+Response shape:
+```json
+{
+  "success": true,
+  "age_band": "age_13_15",
+  "helpdesk": {
+    "source": "zendesk",
+    "band_scope": "all_bands",
+    "reports_in": 0,
+    "requests_in": 0,
+    "video_received": 0
+  },
+  "moderation": {
+    "source": "d1",
+    "band_scope": "age_13_15",
+    "in_progress": 0,
+    "approved": { "total": 0, "restored": 0, "new_minor": 0 },
+    "denied_expired": 0
+  },
+  "generated_at": "2026-06-29T00:00:00Z"
+}
+```
+
+**Graceful degradation:** if the Zendesk call fails, the endpoint still returns the moderation (D1) section and nulls the helpdesk section, mirroring how the dashboard's existing `collectTrustStats` degrades. The moderation outcome is the more important half and must never be blocked by a Zendesk hiccup.
+
+### 2. v1 renderer: relay.admin.divine.video (relay-manager UI)
+
+A compact funnel panel in the existing Age Review tab (`AgeReview.tsx` header area), rendered from the endpoint above. Reuses the existing shadcn primitives (Card, Badge). Stages shown in order with counts and a light bar indicating relative drop-off, titled so it reads as Greenlight-specific.
+
+This is the surface the owner controls and deploys, so v1 ships and gets acceptance here with a single PR, with no dependency on the admin.divine.video deploy path.
+
+### 3. v2 syndication: admin.divine.video Pulse card (follow-on)
+
+`divine-admin-dashboard` is already a cached fan-out aggregator: it pulls stats from the constituent admin tools and the relay, caches them in its `STATS_CACHE` KV, and renders "Product + Trust Pulse" cards (for example, "Pending reports" is sourced by querying the relay). Syndicating the funnel is additive:
+
+- add the funnel endpoint to the existing fan-out (`collectAdminStats`),
+- render a "Greenlight: age-review consent funnel" card next to "Pending reports."
+
+The dashboard worker calls the relay-manager endpoint server-to-server with `X-Admin-Key`, so it needs the relay-manager `ADMIN_API_KEY` as a secret binding (set via `wrangler secret`, not committed). This step is gated only on admin.divine.video deploy access and does not block v1.
+
+## Known limitations (v1)
+
+1. **Helpdesk band ambiguity.** Zendesk does not tag age band, so the three helpdesk stages count all age-review tickets, not strictly 13-15. In practice this is dominated by the 13-15 flow. The moderation stages are band-accurate. Flagged in the payload via `band_scope`.
+2. **Top and bottom do not reconcile to one number,** by design. A request and an outcome are not the same record. Presented as funnel drop-off, not a ledger.
+3. **Video stage is only as complete as macro use,** including back-fill of already-handled cases. The webform (item 3 below) eventually retires this dependency.
+4. **Zendesk Search is eventually consistent and rate-limited.** Acceptable for an admin dashboard; add light caching if call volume warrants.
+5. **Admin-gated access.** relay.admin.divine.video is behind CF Access, so this is for admins and screenshots, not self-serve reporting for support leadership.
+
+## Follow-ons
+
+- **Band tags on the three age-review email triggers** (Zendesk trigger ids `16124091415311`, `16124092809743`, `16124126362127`) so the helpdesk stages can filter to 13-15. Fastest path to closing limitation 1.
+- **Per-case video join** via the `zendesk_ticket_id` already stored on each case, for a band-accurate video stage.
+- **v2 syndication** to the admin.divine.video Pulse card (section 3).
+- **Verification webform** (support-trust-safety#172 item 3): structured consent submission that makes intake and video first-class and removes the manual macro dependency.
+
+## Testing
+
+- **relay-manager endpoint:** unit tests for the bucketing logic (state to stage, `created_via` split) against mocked D1 group-by rows, and for graceful degradation when the Zendesk client throws. Follow the existing `worker/src/age-review.test.ts` patterns.
+- **relay-manager UI:** a light render test of the panel with a sample payload.
+- No exhaustive UI coverage; focus on the aggregation and degradation logic, which is where a regression would actually mislead the numbers.
+
+## Confidence
+
+High. Every piece reuses a verified existing path: the D1 query (relay-manager already lists cases), the Zendesk Search call (relay-manager already calls Zendesk), server-to-server auth (already used by moderation-service), and card rendering plus KV caching on the dashboard side (already done for "Pending reports").

--- a/shared/age-review.ts
+++ b/shared/age-review.ts
@@ -125,3 +125,26 @@ export interface AgeReviewCaseResponse {
   enforcementComplete?: boolean;
   enforcement?: AgeReviewEnforcement;
 }
+
+// Greenlight consent funnel: moderation (D1) outcome counts for one age band.
+export interface FunnelModerationCounts {
+  in_progress: number;
+  approved: { total: number; restored: number; new_minor: number };
+  denied_expired: number;
+}
+
+// Full funnel payload returned by GET /api/age-review/funnel. Helpdesk counts
+// are nullable: a Zendesk failure nulls that half while moderation still returns.
+export interface AgeReviewFunnelResponse {
+  success: boolean;
+  age_band: AgeBand;
+  helpdesk: {
+    source: 'zendesk';
+    band_scope: 'all_bands';
+    reports_in: number | null;
+    requests_in: number | null;
+    video_received: number | null;
+  };
+  moderation: FunnelModerationCounts & { source: 'd1'; band_scope: AgeBand };
+  generated_at: string;
+}

--- a/shared/age-review.ts
+++ b/shared/age-review.ts
@@ -133,6 +133,19 @@ export interface FunnelModerationCounts {
   denied_expired: number;
 }
 
+// Exact Zendesk Search queries behind each helpdesk funnel stage. Single source
+// of truth: the worker counts with these, and the UI surfaces them verbatim in
+// tooltips, so the displayed criteria can never drift from what is counted.
+// Reports vs requests are a clean partition of all `age-review` tickets: a
+// third-party in-app report carries `age-review` only, while a parent/teen who
+// reaches the helpdesk also carries `age-review-response`. Not band-filtered
+// (Zendesk does not tag age band), so these count all ages.
+export const FUNNEL_ZENDESK_QUERIES = {
+  reports_in: 'type:ticket tags:age-review -tags:age-review-response',
+  requests_in: 'type:ticket tags:age-review-response',
+  video_received: 'type:ticket tags:consent_video_received',
+} as const;
+
 // Full funnel payload returned by GET /api/age-review/funnel. Helpdesk counts
 // are nullable: a Zendesk failure nulls that half while moderation still returns.
 export interface AgeReviewFunnelResponse {

--- a/src/components/AgeReview.tsx
+++ b/src/components/AgeReview.tsx
@@ -240,6 +240,7 @@ export function AgeReview() {
 
   return (
     <div className="h-full flex flex-col gap-4">
+      {/* Funnel is desktop-only in v1; the mobile branch above is unchanged. */}
       <AgeReviewFunnel />
       <div className="flex-1 min-h-0 flex gap-4">
         <Card className="w-[360px] shrink-0 flex flex-col overflow-hidden">

--- a/src/components/AgeReview.tsx
+++ b/src/components/AgeReview.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/select";
 import { Clock, RefreshCw, Filter, AlertTriangle } from "lucide-react";
 import { AgeReviewDetail } from "@/components/AgeReviewDetail";
+import { AgeReviewFunnel } from "@/components/AgeReviewFunnel";
 import { CreateMinorAccountDialog } from "@/components/CreateMinorAccountDialog";
 import { UserIdentifier } from "@/components/UserIdentifier";
 import { useIsMobile } from "@/hooks/useIsMobile";
@@ -238,13 +239,16 @@ export function AgeReview() {
   }
 
   return (
-    <div className="h-full flex gap-4">
-      <Card className="w-[360px] shrink-0 flex flex-col overflow-hidden">
-        {listContent}
-      </Card>
-      <Card className="flex-1 overflow-hidden">
-        {detailContent}
-      </Card>
+    <div className="h-full flex flex-col gap-4">
+      <AgeReviewFunnel />
+      <div className="flex-1 min-h-0 flex gap-4">
+        <Card className="w-[360px] shrink-0 flex flex-col overflow-hidden">
+          {listContent}
+        </Card>
+        <Card className="flex-1 overflow-hidden">
+          {detailContent}
+        </Card>
+      </div>
     </div>
   );
 }

--- a/src/components/AgeReviewFunnel.test.tsx
+++ b/src/components/AgeReviewFunnel.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactElement } from 'react';
+import { AgeReviewFunnel } from './AgeReviewFunnel';
+
+vi.mock('@/hooks/useAdminApi', () => ({
+  useAdminApi: () => ({
+    getAgeReviewFunnel: vi.fn().mockResolvedValue({
+      success: true,
+      age_band: 'age_13_15',
+      helpdesk: { source: 'zendesk', band_scope: 'all_bands', reports_in: 12, requests_in: 8, video_received: 5 },
+      moderation: { source: 'd1', band_scope: 'age_13_15', in_progress: 4, approved: { total: 3, restored: 2, new_minor: 1 }, denied_expired: 1 },
+      generated_at: '2026-06-29T00:00:00Z',
+    }),
+  }),
+}));
+
+function renderWithClient(ui: ReactElement) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+describe('AgeReviewFunnel', () => {
+  it('renders stage labels and counts from the payload', async () => {
+    renderWithClient(<AgeReviewFunnel />);
+    expect(await screen.findByText('Requests in')).toBeInTheDocument();
+    expect(await screen.findByText('8')).toBeInTheDocument();
+    expect(await screen.findByText('Video received')).toBeInTheDocument();
+    expect(await screen.findByText('Approved')).toBeInTheDocument();
+  });
+});

--- a/src/components/AgeReviewFunnel.tsx
+++ b/src/components/AgeReviewFunnel.tsx
@@ -1,0 +1,68 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAdminApi } from "@/hooks/useAdminApi";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function fmt(n: number | null): string {
+  return n == null ? "—" : String(n);
+}
+
+export function AgeReviewFunnel() {
+  const api = useAdminApi();
+  const { data, isLoading } = useQuery({
+    queryKey: ['age-review-funnel', 'age_13_15'],
+    queryFn: () => api.getAgeReviewFunnel('age_13_15'),
+    staleTime: 60_000,
+    refetchInterval: 60_000,
+  });
+
+  if (isLoading) {
+    return (
+      <Card className="p-3">
+        <Skeleton className="h-5 w-48 mb-3" />
+        <div className="grid grid-cols-3 sm:grid-cols-6 gap-3">
+          {Array.from({ length: 6 }).map((_, i) => <Skeleton key={i} className="h-14" />)}
+        </div>
+      </Card>
+    );
+  }
+
+  if (!data?.success) {
+    return (
+      <Card className="p-3 text-sm text-muted-foreground">
+        Funnel data unavailable.
+      </Card>
+    );
+  }
+
+  const stages: { label: string; value: number | null; sub?: string }[] = [
+    { label: "Reports in", value: data.helpdesk.reports_in, sub: "helpdesk" },
+    { label: "Requests in", value: data.helpdesk.requests_in, sub: "helpdesk" },
+    { label: "Video received", value: data.helpdesk.video_received, sub: "helpdesk" },
+    { label: "In progress", value: data.moderation.in_progress, sub: "moderation" },
+    { label: "Approved", value: data.moderation.approved.total, sub: `${data.moderation.approved.restored} restored / ${data.moderation.approved.new_minor} new` },
+    { label: "Denied / expired", value: data.moderation.denied_expired, sub: "moderation" },
+  ];
+
+  return (
+    <Card className="p-3">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-medium">Greenlight: age-review consent funnel</h3>
+        <Badge variant="secondary" className="text-xs">13-15</Badge>
+      </div>
+      <div className="grid grid-cols-3 sm:grid-cols-6 gap-3">
+        {stages.map((s) => (
+          <div key={s.label} className="rounded-md border p-2">
+            <div className="text-xl font-semibold tabular-nums">{fmt(s.value)}</div>
+            <div className="text-xs font-medium mt-0.5">{s.label}</div>
+            {s.sub && <div className="text-[10px] text-muted-foreground mt-0.5">{s.sub}</div>}
+          </div>
+        ))}
+      </div>
+      <div className="text-[10px] text-muted-foreground mt-2">
+        Helpdesk stages count all age-review tickets; moderation stages are 13-15 only.
+      </div>
+    </Card>
+  );
+}

--- a/src/components/AgeReviewFunnel.tsx
+++ b/src/components/AgeReviewFunnel.tsx
@@ -111,7 +111,10 @@ export function AgeReviewFunnel() {
           {stages.map((s) => (
             <Tooltip key={s.label}>
               <TooltipTrigger asChild>
-                <div className="rounded-md border p-2 cursor-help">
+                <div
+                  tabIndex={0}
+                  className="rounded-md border p-2 cursor-help focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
                   <div className="text-xl font-semibold tabular-nums">{fmt(s.value)}</div>
                   <div className="flex items-center gap-1 mt-0.5">
                     <span className="text-xs font-medium">{s.label}</span>

--- a/src/components/AgeReviewFunnel.tsx
+++ b/src/components/AgeReviewFunnel.tsx
@@ -1,11 +1,30 @@
 import { useQuery } from "@tanstack/react-query";
+import { Info } from "lucide-react";
 import { useAdminApi } from "@/hooks/useAdminApi";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { FUNNEL_ZENDESK_QUERIES, TERMINAL_STATES } from "../../shared/age-review";
 
 function fmt(n: number | null): string {
   return n == null ? "—" : String(n);
+}
+
+interface Stage {
+  label: string;
+  value: number | null;
+  sub: string;
+  // Plain-language meaning of the stage, for a moderator reading the card.
+  tip: string;
+  // The exact, auditable criteria behind the count. Sourced from the same shared
+  // constants the worker counts with, so it cannot drift from what is measured.
+  criteria: string;
 }
 
 export function AgeReviewFunnel() {
@@ -36,13 +55,49 @@ export function AgeReviewFunnel() {
     );
   }
 
-  const stages: { label: string; value: number | null; sub?: string }[] = [
-    { label: "Reports in", value: data.helpdesk.reports_in, sub: "helpdesk" },
-    { label: "Requests in", value: data.helpdesk.requests_in, sub: "helpdesk" },
-    { label: "Video received", value: data.helpdesk.video_received, sub: "helpdesk" },
-    { label: "In progress", value: data.moderation.in_progress, sub: "moderation" },
-    { label: "Approved", value: data.moderation.approved.total, sub: `${data.moderation.approved.restored} restored / ${data.moderation.approved.new_minor} new` },
-    { label: "Denied / expired", value: data.moderation.denied_expired, sub: "moderation" },
+  const stages: Stage[] = [
+    {
+      label: "Reports in",
+      value: data.helpdesk.reports_in,
+      sub: "helpdesk",
+      tip: "Third-party reports of a suspected underage account, filed in-app and routed to the helpdesk. Counts all ages, not just 13-15.",
+      criteria: `Zendesk · ${FUNNEL_ZENDESK_QUERIES.reports_in}`,
+    },
+    {
+      label: "Requests in",
+      value: data.helpdesk.requests_in,
+      sub: "helpdesk",
+      tip: "A parent or teen who contacted the helpdesk themselves to verify consent. Counts all ages, not just 13-15.",
+      criteria: `Zendesk · ${FUNNEL_ZENDESK_QUERIES.requests_in}`,
+    },
+    {
+      label: "Video received",
+      value: data.helpdesk.video_received,
+      sub: "helpdesk",
+      tip: "A consent verification video arrived (attachment or link), flagged by the consent_video_received macro. Counts all ages.",
+      criteria: `Zendesk · ${FUNNEL_ZENDESK_QUERIES.video_received}`,
+    },
+    {
+      label: "In progress",
+      value: data.moderation.in_progress,
+      sub: "moderation",
+      tip: "Open 13-15 moderation case, not yet resolved: under review, awaiting user / parent / support response, submitted, or needs follow-up.",
+      criteria: `D1 age_review_cases · band age_13_15 · state ∉ {${TERMINAL_STATES.join(", ")}}`,
+    },
+    {
+      label: "Approved",
+      value: data.moderation.approved.total,
+      sub: `${data.moderation.approved.restored} restored / ${data.moderation.approved.new_minor} new`,
+      tip: "13-15 account authorized. Restored = an existing account cleared; new = a brand-new approved minor account created via onboarding.",
+      criteria: "D1 · band age_13_15 · state cleared · new = created_via minor_onboarding",
+    },
+    {
+      label: "Denied / expired",
+      value: data.moderation.denied_expired,
+      sub: "moderation",
+      tip: "13-15 case closed without approval, or the 15-day consent clock lapsed.",
+      criteria: "D1 · band age_13_15 · state denied_closed",
+    },
   ];
 
   return (
@@ -51,15 +106,28 @@ export function AgeReviewFunnel() {
         <h3 className="text-sm font-medium">Greenlight: age-review consent funnel</h3>
         <Badge variant="secondary" className="text-xs">13-15</Badge>
       </div>
-      <div className="grid grid-cols-3 sm:grid-cols-6 gap-3">
-        {stages.map((s) => (
-          <div key={s.label} className="rounded-md border p-2">
-            <div className="text-xl font-semibold tabular-nums">{fmt(s.value)}</div>
-            <div className="text-xs font-medium mt-0.5">{s.label}</div>
-            {s.sub && <div className="text-[10px] text-muted-foreground mt-0.5">{s.sub}</div>}
-          </div>
-        ))}
-      </div>
+      <TooltipProvider delayDuration={150}>
+        <div className="grid grid-cols-3 sm:grid-cols-6 gap-3">
+          {stages.map((s) => (
+            <Tooltip key={s.label}>
+              <TooltipTrigger asChild>
+                <div className="rounded-md border p-2 cursor-help">
+                  <div className="text-xl font-semibold tabular-nums">{fmt(s.value)}</div>
+                  <div className="flex items-center gap-1 mt-0.5">
+                    <span className="text-xs font-medium">{s.label}</span>
+                    <Info className="h-3 w-3 text-muted-foreground/60 shrink-0" />
+                  </div>
+                  <div className="text-[10px] text-muted-foreground mt-0.5">{s.sub}</div>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="max-w-xs">
+                <p className="text-xs">{s.tip}</p>
+                <p className="text-[10px] font-mono text-muted-foreground mt-1 break-words">{s.criteria}</p>
+              </TooltipContent>
+            </Tooltip>
+          ))}
+        </div>
+      </TooltipProvider>
       <div className="text-[10px] text-muted-foreground mt-2">
         Helpdesk stages count all age-review tickets; moderation stages are 13-15 only.
       </div>

--- a/src/hooks/useAdminApi.ts
+++ b/src/hooks/useAdminApi.ts
@@ -125,6 +125,8 @@ export function useAdminApi() {
     // Age review
     getAgeReviewCases: (params?: { state?: string; age_band?: string }) =>
       adminApi.getAgeReviewCases(apiUrl, params),
+    getAgeReviewFunnel: (ageBand?: string) =>
+      adminApi.getAgeReviewFunnel(apiUrl, ageBand),
     getAgeReviewCase: (caseId: string) =>
       adminApi.getAgeReviewCase(apiUrl, caseId),
     updateAgeReviewCase: (caseId: string, updates: Record<string, unknown>) =>

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -1036,6 +1036,17 @@ export async function getAgeReviewCase(
   return apiRequest<AgeReviewCaseResponse>(apiUrl, `/api/age-review/cases/${caseId}`, 'GET');
 }
 
+export async function getAgeReviewFunnel(
+  apiUrl: string,
+  ageBand: string = 'age_13_15',
+): Promise<import('../../shared/age-review').AgeReviewFunnelResponse> {
+  return apiRequest<import('../../shared/age-review').AgeReviewFunnelResponse>(
+    apiUrl,
+    `/api/age-review/funnel?age_band=${encodeURIComponent(ageBand)}`,
+    'GET',
+  );
+}
+
 export async function updateAgeReviewCase(
   apiUrl: string,
   caseId: string,

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -13,6 +13,7 @@ import {
   updateAgeReviewConfig,
   bucketModerationCounts,
   fetchZendeskTagCount,
+  handleGetAgeReviewFunnel,
   type AgeReviewEnv,
 } from './age-review';
 import type { AgeReviewCase } from '../../shared/age-review';
@@ -1798,5 +1799,49 @@ describe('fetchZendeskTagCount', () => {
   it('returns null when fetch throws', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
     expect(await fetchZendeskTagCount(creds, 'q')).toBeNull();
+  });
+});
+
+describe('handleGetAgeReviewFunnel', () => {
+  const cors = { 'Access-Control-Allow-Origin': '*' };
+  const groupRows = [
+    { state: 'cleared', created_via: 'report', c: 3 },
+    { state: 'cleared', created_via: 'minor_onboarding', c: 2 },
+    { state: 'denied_closed', created_via: 'report', c: 1 },
+    { state: 'submitted_for_review', created_via: 'report', c: 4 },
+  ];
+  const mockDb = {
+    prepare: vi.fn().mockReturnValue({
+      bind: vi.fn().mockReturnValue({ all: vi.fn().mockResolvedValue({ results: groupRows }) }),
+    }),
+  };
+  const req = new Request('https://api.test/api/age-review/funnel?age_band=age_13_15');
+
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('returns moderation counts and nulls helpdesk when Zendesk creds are absent', async () => {
+    const env = makeEnv(mockDb); // no ZENDESK_* set
+    const res = await handleGetAgeReviewFunnel(req, env, cors);
+    const body = await res.json() as import('../../shared/age-review').AgeReviewFunnelResponse;
+
+    expect(res.status).toBe(200);
+    expect(body.moderation.approved).toEqual({ total: 5, restored: 3, new_minor: 2 });
+    expect(body.moderation.in_progress).toBe(4);
+    expect(body.moderation.denied_expired).toBe(1);
+    expect(body.helpdesk).toMatchObject({ reports_in: null, requests_in: null, video_received: null });
+    expect(body.age_band).toBe('age_13_15');
+  });
+
+  it('populates helpdesk counts when Zendesk creds resolve', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ count: 9 }) }));
+    const env = makeEnv(mockDb, {
+      ZENDESK_SUBDOMAIN: 'rabblelabs', ZENDESK_EMAIL: 'a@b.co', ZENDESK_API_TOKEN: 'tok',
+    });
+    const res = await handleGetAgeReviewFunnel(req, env, cors);
+    const body = await res.json() as import('../../shared/age-review').AgeReviewFunnelResponse;
+
+    expect(body.helpdesk.requests_in).toBe(9);
+    expect(body.helpdesk.video_received).toBe(9);
+    expect(body.helpdesk.reports_in).toBe(9);
   });
 });

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -1877,6 +1877,21 @@ describe('handleGetAgeReviewFunnel', () => {
     expect(body.helpdesk).toMatchObject({ reports_in: null, requests_in: null, video_received: null });
   });
 
+  it('keeps moderation counts and nulls helpdesk when Zendesk secret resolution fails', async () => {
+    const env = makeEnv(mockDb, {
+      ZENDESK_SUBDOMAIN: { get: vi.fn().mockRejectedValue(new Error('secret store down')) },
+      ZENDESK_EMAIL: 'a@b.co',
+      ZENDESK_API_TOKEN: 'tok',
+    });
+    const res = await handleGetAgeReviewFunnel(req, env, cors);
+    const body = await res.json() as import('../../shared/age-review').AgeReviewFunnelResponse;
+
+    expect(res.status).toBe(200);
+    expect(body.moderation.approved).toEqual({ total: 5, restored: 3, new_minor: 2 });
+    expect(body.moderation.in_progress).toBe(4);
+    expect(body.helpdesk).toMatchObject({ reports_in: null, requests_in: null, video_received: null });
+  });
+
   it('counts each helpdesk stage with the exact shared criteria query', async () => {
     const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ count: 9 }) });
     vi.stubGlobal('fetch', mockFetch);

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -1773,33 +1773,50 @@ describe('bucketModerationCounts', () => {
       denied_expired: 0,
     });
   });
+
+  it('treats an unknown/future state as in_progress (open) by design', () => {
+    const result = bucketModerationCounts([
+      { state: 'some_future_state', created_via: 'report', c: 6 },
+    ]);
+    expect(result.in_progress).toBe(6);
+    expect(result.approved.total).toBe(0);
+    expect(result.denied_expired).toBe(0);
+  });
+
+  it('counts a cleared row with null created_via as restored', () => {
+    const result = bucketModerationCounts([
+      { state: 'cleared', created_via: null, c: 4 },
+    ]);
+    expect(result.approved).toEqual({ total: 4, restored: 4, new_minor: 0 });
+  });
 });
 
 describe('fetchZendeskTagCount', () => {
-  const creds = { subdomain: 'rabblelabs', email: 'a@b.co', apiToken: 'tok' };
+  const config = { auth: btoa('a@b.co/token:tok'), baseUrl: 'https://rabblelabs.zendesk.com/api/v2' };
 
   afterEach(() => { vi.unstubAllGlobals(); });
 
-  it('builds the search/count URL and returns the count', async () => {
+  it('builds the search/count URL from the config and returns the count', async () => {
     const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ count: 7 }) });
     vi.stubGlobal('fetch', mockFetch);
 
-    const result = await fetchZendeskTagCount(creds, 'type:ticket tags:age-review-response');
+    const result = await fetchZendeskTagCount(config, 'type:ticket tags:age-review-response');
 
     expect(result).toBe(7);
-    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    const [calledUrl, init] = mockFetch.mock.calls[0];
     expect(calledUrl).toContain('https://rabblelabs.zendesk.com/api/v2/search/count.json?query=');
     expect(calledUrl).toContain(encodeURIComponent('type:ticket tags:age-review-response'));
+    expect((init as RequestInit).headers).toMatchObject({ Authorization: `Basic ${config.auth}` });
   });
 
   it('returns null on a non-ok response', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }));
-    expect(await fetchZendeskTagCount(creds, 'q')).toBeNull();
+    expect(await fetchZendeskTagCount(config, 'q')).toBeNull();
   });
 
   it('returns null when fetch throws', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
-    expect(await fetchZendeskTagCount(creds, 'q')).toBeNull();
+    expect(await fetchZendeskTagCount(config, 'q')).toBeNull();
   });
 });
 
@@ -1844,6 +1861,20 @@ describe('handleGetAgeReviewFunnel', () => {
     expect(body.helpdesk.requests_in).toBe(9);
     expect(body.helpdesk.video_received).toBe(9);
     expect(body.helpdesk.reports_in).toBe(9);
+  });
+
+  it('keeps moderation counts and nulls helpdesk when Zendesk creds resolve but the call fails', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('zendesk down')));
+    const env = makeEnv(mockDb, {
+      ZENDESK_SUBDOMAIN: 'rabblelabs', ZENDESK_EMAIL: 'a@b.co', ZENDESK_API_TOKEN: 'tok',
+    });
+    const res = await handleGetAgeReviewFunnel(req, env, cors);
+    const body = await res.json() as import('../../shared/age-review').AgeReviewFunnelResponse;
+
+    expect(res.status).toBe(200);
+    expect(body.moderation.approved).toEqual({ total: 5, restored: 3, new_minor: 2 });
+    expect(body.moderation.in_progress).toBe(4);
+    expect(body.helpdesk).toMatchObject({ reports_in: null, requests_in: null, video_received: null });
   });
 
   it('counts each helpdesk stage with the exact shared criteria query', async () => {

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -12,6 +12,7 @@ import {
   getAgeReviewConfig,
   updateAgeReviewConfig,
   bucketModerationCounts,
+  fetchZendeskTagCount,
   type AgeReviewEnv,
 } from './age-review';
 import type { AgeReviewCase } from '../../shared/age-review';
@@ -1769,5 +1770,33 @@ describe('bucketModerationCounts', () => {
       approved: { total: 0, restored: 0, new_minor: 0 },
       denied_expired: 0,
     });
+  });
+});
+
+describe('fetchZendeskTagCount', () => {
+  const creds = { subdomain: 'rabblelabs', email: 'a@b.co', apiToken: 'tok' };
+
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('builds the search/count URL and returns the count', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ count: 7 }) });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await fetchZendeskTagCount(creds, 'type:ticket tags:age-review-response');
+
+    expect(result).toBe(7);
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('https://rabblelabs.zendesk.com/api/v2/search/count.json?query=');
+    expect(calledUrl).toContain(encodeURIComponent('type:ticket tags:age-review-response'));
+  });
+
+  it('returns null on a non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }));
+    expect(await fetchZendeskTagCount(creds, 'q')).toBeNull();
+  });
+
+  it('returns null when fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+    expect(await fetchZendeskTagCount(creds, 'q')).toBeNull();
   });
 });

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -17,6 +17,7 @@ import {
   type AgeReviewEnv,
 } from './age-review';
 import type { AgeReviewCase } from '../../shared/age-review';
+import { FUNNEL_ZENDESK_QUERIES } from '../../shared/age-review';
 import { suspendUser, unsuspendUser, banUser, createMinorAccount } from './keycast-client';
 import { suspendPubkey, unsuspendPubkey, banPubkey } from './nip86';
 
@@ -1843,5 +1844,21 @@ describe('handleGetAgeReviewFunnel', () => {
     expect(body.helpdesk.requests_in).toBe(9);
     expect(body.helpdesk.video_received).toBe(9);
     expect(body.helpdesk.reports_in).toBe(9);
+  });
+
+  it('counts each helpdesk stage with the exact shared criteria query', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ count: 9 }) });
+    vi.stubGlobal('fetch', mockFetch);
+    const env = makeEnv(mockDb, {
+      ZENDESK_SUBDOMAIN: 'rabblelabs', ZENDESK_EMAIL: 'a@b.co', ZENDESK_API_TOKEN: 'tok',
+    });
+    await handleGetAgeReviewFunnel(req, env, cors);
+
+    // The displayed tooltip criteria are sourced from these same constants, so
+    // asserting the worker queries with them keeps explanation == measurement.
+    const calledUrls = mockFetch.mock.calls.map((c) => c[0] as string);
+    for (const query of Object.values(FUNNEL_ZENDESK_QUERIES)) {
+      expect(calledUrls.some((u) => u.includes(encodeURIComponent(query)))).toBe(true);
+    }
   });
 });

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   handleGetAgeReviewCases,
   handleGetAgeReviewCase,
@@ -11,6 +11,7 @@ import {
   syncAgeReviewTicketResolution,
   getAgeReviewConfig,
   updateAgeReviewConfig,
+  bucketModerationCounts,
   type AgeReviewEnv,
 } from './age-review';
 import type { AgeReviewCase } from '../../shared/age-review';
@@ -1745,5 +1746,28 @@ describe('handleCreateMinorAccount', () => {
     // Assert positionally: toContain(null) would also match the null zendesk_ticket_id.
     expect(bindArgs[2]).toBe('https://login.test/claim/abc');
     expect(bindArgs[3]).toBeNull();
+  });
+});
+
+describe('bucketModerationCounts', () => {
+  it('sums non-terminal states into in_progress and splits approved by created_via', () => {
+    const result = bucketModerationCounts([
+      { state: 'cleared', created_via: 'report', c: 3 },
+      { state: 'cleared', created_via: 'minor_onboarding', c: 2 },
+      { state: 'denied_closed', created_via: 'report', c: 1 },
+      { state: 'submitted_for_review', created_via: 'report', c: 4 },
+      { state: 'restricted_pending_parental_consent', created_via: 'report', c: 5 },
+    ]);
+    expect(result.in_progress).toBe(9);
+    expect(result.approved).toEqual({ total: 5, restored: 3, new_minor: 2 });
+    expect(result.denied_expired).toBe(1);
+  });
+
+  it('returns zeroes for an empty set', () => {
+    expect(bucketModerationCounts([])).toEqual({
+      in_progress: 0,
+      approved: { total: 0, restored: 0, new_minor: 0 },
+      denied_expired: 0,
+    });
   });
 });

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -14,6 +14,7 @@ import {
   type AgeReviewEnforcement,
   type AgeReviewCaseResponse,
   type FunnelModerationCounts,
+  type AgeReviewFunnelResponse,
 } from '../../shared/age-review';
 import { runBulkModeration, type BulkModerateEnv } from './bulk-moderate';
 import { resolveZendeskCreds } from './zendesk-sync';
@@ -1238,6 +1239,50 @@ export async function fetchZendeskTagCount(
   } catch {
     return null;
   }
+}
+
+// GET /api/age-review/funnel: one D1 group-by for band-accurate moderation
+// outcomes, plus Zendesk tag counts for the helpdesk intake stages. The Zendesk
+// half is best-effort and nulls out on failure; the D1 half always returns.
+export async function handleGetAgeReviewFunnel(
+  request: Request,
+  env: AgeReviewEnv,
+  corsHeaders: Record<string, string>,
+): Promise<Response> {
+  if (!env.DB) return json({ success: false, error: 'Database not configured' }, 500, corsHeaders);
+
+  const url = new URL(request.url);
+  const bandParam = url.searchParams.get('age_band');
+  const ageBand: AgeBand = bandParam && AGE_BANDS.includes(bandParam as AgeBand)
+    ? (bandParam as AgeBand)
+    : 'age_13_15';
+
+  const rows = await env.DB.prepare(
+    'SELECT state, created_via, COUNT(*) AS c FROM age_review_cases WHERE suspected_age_band = ? GROUP BY state, created_via',
+  ).bind(ageBand).all<FunnelRow>();
+  const moderation = bucketModerationCounts(rows.results ?? []);
+
+  let reports_in: number | null = null;
+  let requests_in: number | null = null;
+  let video_received: number | null = null;
+
+  const creds = await resolveZendeskCreds(env);
+  if (creds) {
+    [requests_in, video_received, reports_in] = await Promise.all([
+      fetchZendeskTagCount(creds, 'type:ticket tags:age-review-response'),
+      fetchZendeskTagCount(creds, 'type:ticket tags:consent_video_received'),
+      fetchZendeskTagCount(creds, 'type:ticket tags:age-review -tags:age-review-response'),
+    ]);
+  }
+
+  const payload: AgeReviewFunnelResponse = {
+    success: true,
+    age_band: ageBand,
+    helpdesk: { source: 'zendesk', band_scope: 'all_bands', reports_in, requests_in, video_received },
+    moderation: { source: 'd1', band_scope: ageBand, ...moderation },
+    generated_at: new Date().toISOString(),
+  };
+  return json(payload, 200, corsHeaders);
 }
 
 // ---------------------------------------------------------------------------

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -1268,13 +1268,17 @@ export async function handleGetAgeReviewFunnel(
   let requests_in: number | null = null;
   let video_received: number | null = null;
 
-  const zendesk = await getZendeskClientConfig(env);
-  if (zendesk) {
-    [requests_in, video_received, reports_in] = await Promise.all([
-      fetchZendeskTagCount(zendesk, FUNNEL_ZENDESK_QUERIES.requests_in),
-      fetchZendeskTagCount(zendesk, FUNNEL_ZENDESK_QUERIES.video_received),
-      fetchZendeskTagCount(zendesk, FUNNEL_ZENDESK_QUERIES.reports_in),
-    ]);
+  try {
+    const zendesk = await getZendeskClientConfig(env);
+    if (zendesk) {
+      [requests_in, video_received, reports_in] = await Promise.all([
+        fetchZendeskTagCount(zendesk, FUNNEL_ZENDESK_QUERIES.requests_in),
+        fetchZendeskTagCount(zendesk, FUNNEL_ZENDESK_QUERIES.video_received),
+        fetchZendeskTagCount(zendesk, FUNNEL_ZENDESK_QUERIES.reports_in),
+      ]);
+    }
+  } catch (error) {
+    console.warn('[age-review] Zendesk funnel counts unavailable:', error);
   }
 
   const payload: AgeReviewFunnelResponse = {

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -1190,9 +1190,10 @@ export interface FunnelRow {
   c: number;
 }
 
-// Pure bucketing of the D1 group-by rows into funnel stages. Non-terminal states
-// roll up to in_progress; `cleared` is approved (split into new_minor vs restored
-// by created_via); `denied_closed` is denied/expired.
+// Pure bucketing of the D1 group-by rows into funnel stages. `cleared` is
+// approved (split into new_minor vs restored by created_via); `denied_closed` is
+// denied/expired; every other state (the seven non-terminal states, and by
+// design any unknown/future state) rolls up to in_progress as "still open".
 export function bucketModerationCounts(rows: FunnelRow[]): FunnelModerationCounts {
   const terminal = new Set<string>(TERMINAL_STATES);
   let in_progress = 0;
@@ -1223,17 +1224,17 @@ export function bucketModerationCounts(rows: FunnelRow[]): FunnelModerationCount
   };
 }
 
-// Count tickets matching a Zendesk Search query via /search/count.json. Returns
-// null on any failure so a Zendesk hiccup degrades gracefully rather than
-// blocking the moderation half of the funnel.
+// Count tickets matching a Zendesk Search query via /search/count.json. Takes a
+// resolved client config (auth + baseUrl from getZendeskClientConfig) so it does
+// not duplicate auth/URL construction. Returns null on any failure so a Zendesk
+// hiccup degrades gracefully rather than blocking the moderation half.
 export async function fetchZendeskTagCount(
-  creds: { subdomain: string; email: string; apiToken: string },
+  config: { auth: string; baseUrl: string },
   query: string,
 ): Promise<number | null> {
   try {
-    const auth = btoa(`${creds.email}/token:${creds.apiToken}`);
-    const url = `https://${creds.subdomain}.zendesk.com/api/v2/search/count.json?query=${encodeURIComponent(query)}`;
-    const response = await fetch(url, { headers: { Authorization: `Basic ${auth}` } });
+    const url = `${config.baseUrl}/search/count.json?query=${encodeURIComponent(query)}`;
+    const response = await fetch(url, { headers: { Authorization: `Basic ${config.auth}` } });
     if (!response.ok) return null;
     const data = await response.json() as { count?: number };
     return typeof data.count === 'number' ? data.count : null;
@@ -1267,12 +1268,12 @@ export async function handleGetAgeReviewFunnel(
   let requests_in: number | null = null;
   let video_received: number | null = null;
 
-  const creds = await resolveZendeskCreds(env);
-  if (creds) {
+  const zendesk = await getZendeskClientConfig(env);
+  if (zendesk) {
     [requests_in, video_received, reports_in] = await Promise.all([
-      fetchZendeskTagCount(creds, FUNNEL_ZENDESK_QUERIES.requests_in),
-      fetchZendeskTagCount(creds, FUNNEL_ZENDESK_QUERIES.video_received),
-      fetchZendeskTagCount(creds, FUNNEL_ZENDESK_QUERIES.reports_in),
+      fetchZendeskTagCount(zendesk, FUNNEL_ZENDESK_QUERIES.requests_in),
+      fetchZendeskTagCount(zendesk, FUNNEL_ZENDESK_QUERIES.video_received),
+      fetchZendeskTagCount(zendesk, FUNNEL_ZENDESK_QUERIES.reports_in),
     ]);
   }
 

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -13,6 +13,7 @@ import {
   type EnforcementLegStatus,
   type AgeReviewEnforcement,
   type AgeReviewCaseResponse,
+  type FunnelModerationCounts,
 } from '../../shared/age-review';
 import { runBulkModeration, type BulkModerateEnv } from './bulk-moderate';
 import { resolveZendeskCreds } from './zendesk-sync';
@@ -1174,6 +1175,50 @@ export async function updateAgeReviewConfig(
     ).bind(String(config.auto_delete_on_deny)).run();
   }
   return getAgeReviewConfig(db);
+}
+
+// ---------------------------------------------------------------------------
+// Greenlight consent funnel
+// ---------------------------------------------------------------------------
+
+// One row of the funnel's D1 group-by (state x created_via, with a count).
+export interface FunnelRow {
+  state: string;
+  created_via: string | null;
+  c: number;
+}
+
+// Pure bucketing of the D1 group-by rows into funnel stages. Non-terminal states
+// roll up to in_progress; `cleared` is approved (split into new_minor vs restored
+// by created_via); `denied_closed` is denied/expired.
+export function bucketModerationCounts(rows: FunnelRow[]): FunnelModerationCounts {
+  const terminal = new Set<string>(TERMINAL_STATES);
+  let in_progress = 0;
+  let approvedTotal = 0;
+  let approvedNewMinor = 0;
+  let denied_expired = 0;
+
+  for (const row of rows) {
+    const count = row.c ?? 0;
+    if (row.state === 'cleared') {
+      approvedTotal += count;
+      if (row.created_via === 'minor_onboarding') approvedNewMinor += count;
+    } else if (row.state === 'denied_closed') {
+      denied_expired += count;
+    } else if (!terminal.has(row.state)) {
+      in_progress += count;
+    }
+  }
+
+  return {
+    in_progress,
+    approved: {
+      total: approvedTotal,
+      restored: approvedTotal - approvedNewMinor,
+      new_minor: approvedNewMinor,
+    },
+    denied_expired,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -1221,6 +1221,25 @@ export function bucketModerationCounts(rows: FunnelRow[]): FunnelModerationCount
   };
 }
 
+// Count tickets matching a Zendesk Search query via /search/count.json. Returns
+// null on any failure so a Zendesk hiccup degrades gracefully rather than
+// blocking the moderation half of the funnel.
+export async function fetchZendeskTagCount(
+  creds: { subdomain: string; email: string; apiToken: string },
+  query: string,
+): Promise<number | null> {
+  try {
+    const auth = btoa(`${creds.email}/token:${creds.apiToken}`);
+    const url = `https://${creds.subdomain}.zendesk.com/api/v2/search/count.json?query=${encodeURIComponent(query)}`;
+    const response = await fetch(url, { headers: { Authorization: `Basic ${auth}` } });
+    if (!response.ok) return null;
+    const data = await response.json() as { count?: number };
+    return typeof data.count === 'number' ? data.count : null;
+  } catch {
+    return null;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -15,6 +15,7 @@ import {
   type AgeReviewCaseResponse,
   type FunnelModerationCounts,
   type AgeReviewFunnelResponse,
+  FUNNEL_ZENDESK_QUERIES,
 } from '../../shared/age-review';
 import { runBulkModeration, type BulkModerateEnv } from './bulk-moderate';
 import { resolveZendeskCreds } from './zendesk-sync';
@@ -1269,9 +1270,9 @@ export async function handleGetAgeReviewFunnel(
   const creds = await resolveZendeskCreds(env);
   if (creds) {
     [requests_in, video_received, reports_in] = await Promise.all([
-      fetchZendeskTagCount(creds, 'type:ticket tags:age-review-response'),
-      fetchZendeskTagCount(creds, 'type:ticket tags:consent_video_received'),
-      fetchZendeskTagCount(creds, 'type:ticket tags:age-review -tags:age-review-response'),
+      fetchZendeskTagCount(creds, FUNNEL_ZENDESK_QUERIES.requests_in),
+      fetchZendeskTagCount(creds, FUNNEL_ZENDESK_QUERIES.video_received),
+      fetchZendeskTagCount(creds, FUNNEL_ZENDESK_QUERIES.reports_in),
     ]);
   }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -20,6 +20,7 @@ import { suspendUser, unsuspendUser, banUser } from './keycast-client';
 import {
   handleGetAgeReviewCases,
   handleGetAgeReviewCase,
+  handleGetAgeReviewFunnel,
   handleUpdateAgeReviewCase,
   handleCreateMinorAccount,
   handleGetModerationStatus,
@@ -562,6 +563,10 @@ export default {
       }
 
       // Age review case management
+      if (path === '/api/age-review/funnel' && request.method === 'GET') {
+        if (env.DB) await ensureSchemaOnce(env.DB);
+        return handleGetAgeReviewFunnel(request, env, corsHeaders);
+      }
       if (path === '/api/age-review/cases' && request.method === 'GET') {
         if (env.DB) await ensureSchemaOnce(env.DB);
         return handleGetAgeReviewCases(request, env, corsHeaders);


### PR DESCRIPTION
## Summary

Adds a v1 Greenlight age-review consent funnel to the relay-manager Age Review tab, plus per-stage tooltips that document the exact criteria behind every count. The funnel shows the whole 13-15 onboarding journey, request through outcome, sourced from the two systems that actually hold the data:

- **Helpdesk side (Zendesk):** intake and the video signal, via tag counts. `age-review` without `age-review-response` (third-party reports), `age-review-response` (parent/teen requests), and `consent_video_received` (the macro shipped 2026-06-29).
- **Moderation side (relay-manager D1, `age_review_cases`):** authoritative outcomes from one band-accurate group-by. Non-terminal states roll up to *In progress*; `cleared` is *Approved* (split into restored vs new minor account by `created_via`); `denied_closed` is *Denied / expired*.

The two sides do not join 1:1 by design. This is a funnel showing drop-off, not a single ledger.

## What's included

- `GET /api/age-review/funnel?age_band=age_13_15` worker endpoint, inside the existing admin-guarded `/api/age-review/*` block (inherits `verifyAdminAccess`).
- Pure `bucketModerationCounts` for state-to-stage bucketing, and `fetchZendeskTagCount` (Zendesk Search `/count.json`).
- Frontend `getAgeReviewFunnel` API client + `useAdminApi` binding.
- `AgeReviewFunnel` panel mounted above the case split-view in the Age Review tab.
- **Per-stage criteria tooltips.** Each card has a hover tooltip with a plain-language meaning and the exact, auditable criteria behind the count (the Zendesk query or the D1 rule). The three Zendesk queries live in one shared `FUNNEL_ZENDESK_QUERIES` constant consumed by both the worker (which counts with them) and the UI (which displays them), so the shown criteria cannot drift from what is measured. The in-progress rule renders from the shared `TERMINAL_STATES` for the same reason.
- Spec and implementation plan imported under `docs/superpowers/` (this repo is now their canonical home since the code lives here).

## Funnel stages and exact criteria

| Stage | Source | Criteria |
|---|---|---|
| Reports in | Zendesk | `type:ticket tags:age-review -tags:age-review-response` |
| Requests in | Zendesk | `type:ticket tags:age-review-response` |
| Video received | Zendesk | `type:ticket tags:consent_video_received` |
| In progress | D1 | band `age_13_15`, state ∉ {`cleared`, `denied_closed`} |
| Approved | D1 | band `age_13_15`, state `cleared` (new = `created_via=minor_onboarding`, restored = the rest) |
| Denied / expired | D1 | band `age_13_15`, state `denied_closed` |

## Criteria verification (against live Zendesk + a seeded local D1)

I ran the full local stack and verified the criteria are correct, not just that they return numbers:

- **Helpdesk partition is clean.** Live Zendesk counts: `337` reports + `44` requests = `381` = total `age-review` tickets. `age-review-response` without `age-review` = `0`. So reports and requests are a clean, non-overlapping partition of all age-review tickets.
- **Tag semantics confirmed by sampling real tickets.** Reports are "Content Report: underageUser" (third-party in-app reports). Requests are parent/teen "account review help" and always also carry `age-review`. The built-in Zendesk discriminator holds.
- **Helpdesk stages genuinely span all ages.** One sampled request was an under-13 ticket, confirming the documented `band_scope: all_bands` caveat. The tooltips and the panel footnote state this explicitly.
- **Moderation counts match the case list.** With representative 13-15 rows seeded into a local D1, the funnel showed In progress `4` / Approved `5` (3 restored, 2 new) / Denied `2`, and the Active case list showed exactly those 4 in-progress cases. An `age_16_plus` row was correctly excluded by the band filter.
- **Explanation == measurement is enforced in code.** A worker test asserts the handler queries Zendesk with the exact `FUNNEL_ZENDESK_QUERIES` strings the tooltips display.

## Graceful degradation

A Zendesk failure (bad creds, timeout, non-200, or Secret Store resolution failure) nulls the helpdesk half and the moderation (D1) half still returns 200. There are explicit no-creds, fetch-failure, and secret-resolution-failure tests asserting this. The UI renders "—" for null helpdesk counts. Verified live: before seeding, the moderation half returned zeros while the helpdesk half still populated from Zendesk.

## Known limitations (v1)

- Helpdesk stages count all age-review tickets, not strictly 13-15 (Zendesk does not tag age band). Flagged in the payload via `band_scope: all_bands`, in each helpdesk tooltip, and in a panel footnote. Moderation stages are band-accurate.
- Video stage is only as complete as macro use / back-fill. It currently reads `0` because the `consent_video_received` macro shipped 2026-06-29 and no tickets are tagged yet; it climbs as the macro is used.

## Out of scope (documented follow-ons)

Zendesk age-band trigger tags, the per-case video join via `zendesk_ticket_id`, admin.divine.video Pulse-card syndication, and the verification webform.

## Test plan

- Frontend `npx vitest run`: green, 12 files, 141 passed, 1 skipped.
- Worker `npx vitest run`: green, 10 files, 259 passed.
- `npx tsc -p tsconfig.app.json --noEmit` and `cd worker && npx tsc -p tsconfig.json --noEmit`: clean.
- `npx eslint .`: clean.
- `npx vite build`: OK.
- Unit coverage: bucketing logic, Zendesk count helper (ok / non-ok / throws), handler with and without Zendesk creds, fetch-failure and Secret Store-resolution graceful degradation, handler queries with the exact shared criteria, and a panel render test.
- Manual: ran the full local stack and confirmed in the Age Review tab that the funnel renders, helpdesk counts populate from live Zendesk, moderation counts match the case list, and the tooltips show the correct per-stage criteria.

No schema change (D1 is maintained at runtime by `ensureSchema`).

Closes divinevideo/support-trust-safety#172.
