### PR TITLE
feat(minor-safety): T&S protected-minor visibility (#141)

### DIFF
--- a/docs/superpowers/specs/2026-07-01-protected-minor-visibility-design.md
+++ b/docs/superpowers/specs/2026-07-01-protected-minor-visibility-design.md
@@ -1,0 +1,43 @@
+# Protected-minor visibility in the moderator UI — design
+
+**Issue:** divinevideo/divine-relay-manager#141 (T&S visibility of protected-minor status). Part of the protected-minor safeguards epic (support-trust-safety#173); equal sibling of keycast#265 (lifecycle).
+**Date:** 2026-07-01
+**Status:** WIP (draft PR staked out early to flag work-in-progress).
+
+## Goal
+Let a moderator see, from the age-review case view, whether the account is an **approved protected minor (13-15)** — i.e. keycast's durable `verified_minor` flag — and what protections that implies.
+
+## What already exists (so this is mostly surfacing)
+- `worker/src/keycast-client.ts` `getUserStatus(pubkey, env)` already calls keycast `GET /api/admin/users/:pubkey/status` and returns `verified_minor` + `verified_minor_at` (already used by `ReportWatcher.ts`).
+- `AgeReviewDetail.tsx` is the moderator case view and has the case `pubkey`.
+- Frontend uses `adminApi.ts` + React Query.
+
+## Approved decisions
+1. **Dedicated endpoint + lazy hook** (not folded into the case GET): keeps live keycast status separate from the case record, degrades gracefully, and is reusable.
+2. **Surface `verified_minor` + static policy text** (not per-device "active protections", which aren't server-observable and depend on unbuilt #175/#176).
+
+## Design
+
+**Worker** — new route `GET /api/account-status/:pubkey`:
+- Auth: same admin auth as the other `/api/*` moderator routes.
+- Validates the 64-hex pubkey; calls `getUserStatus`; returns `{ verified_minor, verified_minor_at, status, suspended_reason?, suspended_at? }`.
+- If keycast is not configured or errors, returns a graceful "unknown" shape (not a hard failure) so the UI can degrade.
+
+**Frontend**:
+- `adminApi.ts`: `getAccountStatus(pubkey)` client method.
+- `useAccountStatus(pubkey)` React Query hook (keyed on pubkey; enabled when a pubkey is present).
+- `AgeReviewDetail.tsx`: an **Account status** section that, when `verified_minor` is true, shows a badge "Approved protected minor (13-15)", the `verified_minor_at` date, and a short static line: "Protections that apply: adult content locked; DMs restricted to HQ/Support (client-enforced)." When false/unknown, it stays unobtrusive (no badge, or a muted "not a protected minor / status unavailable").
+
+**Placement:** age-review case detail only (not the cases list — avoids N keycast calls per list load). The hook is reusable elsewhere later (nuke button, user lookup).
+
+## Error handling
+Best-effort: the account-status fetch is independent of the case load, so a keycast blip shows "status unavailable" and never blocks the case. No retries needed beyond React Query defaults.
+
+## Testing
+- Worker: endpoint auth, invalid pubkey rejected, `getUserStatus` success maps `verified_minor`/`_at`, and not-configured/error degrades to a graceful response (not a 500).
+- Frontend: hook maps the response; `AgeReviewDetail` renders the badge + policy text when `verified_minor` is true, stays quiet when false, and shows an unobtrusive fallback on loading/error.
+
+## Out of scope
+- Lifecycle reflection (age-up/revocation) — keycast#265.
+- Real per-device "active" protection telemetry — depends on #175/#176.
+- Cases-list badge.

--- a/docs/superpowers/specs/2026-07-01-protected-minor-visibility-design.md
+++ b/docs/superpowers/specs/2026-07-01-protected-minor-visibility-design.md
@@ -1,43 +1,44 @@
 # Protected-minor visibility in the moderator UI — design
 
 **Issue:** divinevideo/divine-relay-manager#141 (T&S visibility of protected-minor status). Part of the protected-minor safeguards epic (support-trust-safety#173); equal sibling of keycast#265 (lifecycle).
+**Follow-on:** #143 (surface active protections once #175/#176 exist).
 **Date:** 2026-07-01
-**Status:** WIP (draft PR staked out early to flag work-in-progress).
+**Status:** WIP (draft PR #142).
 
 ## Goal
-Let a moderator see, from the age-review case view, whether the account is an **approved protected minor (13-15)** — i.e. keycast's durable `verified_minor` flag — and what protections that implies.
+Let a moderator see, from the age-review case view, whether the account is an **approved protected minor (13-15)** — keycast's durable `verified_minor` flag. This is a true, server-backed fact today (it confirms the minor-approval flow actually set the flag).
 
 ## What already exists (so this is mostly surfacing)
-- `worker/src/keycast-client.ts` `getUserStatus(pubkey, env)` already calls keycast `GET /api/admin/users/:pubkey/status` and returns `verified_minor` + `verified_minor_at` (already used by `ReportWatcher.ts`).
+- `worker/src/keycast-client.ts` `getUserStatus(pubkey, env)` already calls keycast `GET /api/admin/users/:pubkey/status` and returns `verified_minor` + `verified_minor_at` (already used by `ReportWatcher.ts`). **Note:** this is keycast's *admin* endpoint, which already exposed `verified_minor` before keycast#263 — so #141 is **independent** of the in-review detection PRs.
 - `AgeReviewDetail.tsx` is the moderator case view and has the case `pubkey`.
 - Frontend uses `adminApi.ts` + React Query.
 
 ## Approved decisions
 1. **Dedicated endpoint + lazy hook** (not folded into the case GET): keeps live keycast status separate from the case record, degrades gracefully, and is reusable.
-2. **Surface `verified_minor` + static policy text** (not per-device "active protections", which aren't server-observable and depend on unbuilt #175/#176).
+2. **Surface `verified_minor` only (honest MVP).** Do **not** display "which protections are active." The protections (content-lock #175, DM-restriction #176) do not exist yet, so asserting them — even as static policy text — would give moderators **false assurance** of protection that isn't being enforced. The active-protections display is deferred to follow-on **#143**, to land once #175/#176 are real. #141's acceptance is re-scoped to "surface `verified_minor`" accordingly.
 
 ## Design
 
 **Worker** — new route `GET /api/account-status/:pubkey`:
 - Auth: same admin auth as the other `/api/*` moderator routes.
 - Validates the 64-hex pubkey; calls `getUserStatus`; returns `{ verified_minor, verified_minor_at, status, suspended_reason?, suspended_at? }`.
-- If keycast is not configured or errors, returns a graceful "unknown" shape (not a hard failure) so the UI can degrade.
+- If keycast is not configured or errors, returns a graceful shape the UI reads as "unavailable" (not a hard 500), so it never blocks the case view.
 
 **Frontend**:
 - `adminApi.ts`: `getAccountStatus(pubkey)` client method.
 - `useAccountStatus(pubkey)` React Query hook (keyed on pubkey; enabled when a pubkey is present).
-- `AgeReviewDetail.tsx`: an **Account status** section that, when `verified_minor` is true, shows a badge "Approved protected minor (13-15)", the `verified_minor_at` date, and a short static line: "Protections that apply: adult content locked; DMs restricted to HQ/Support (client-enforced)." When false/unknown, it stays unobtrusive (no badge, or a muted "not a protected minor / status unavailable").
+- `AgeReviewDetail.tsx`: an **Account status** line that, when `verified_minor` is true, shows a badge **"Approved protected minor (13-15)"** + the `verified_minor_at` date. When false, it stays quiet (or a muted "not a protected minor"); on loading/error, an unobtrusive "status unavailable". The badge is clearly the *outcome* ("Approved"), distinct from the case's existing *suspected* age-band badge.
 
 **Placement:** age-review case detail only (not the cases list — avoids N keycast calls per list load). The hook is reusable elsewhere later (nuke button, user lookup).
 
 ## Error handling
-Best-effort: the account-status fetch is independent of the case load, so a keycast blip shows "status unavailable" and never blocks the case. No retries needed beyond React Query defaults.
+Best-effort and independent of the case load: a keycast blip shows "status unavailable" and never blocks the case. React Query defaults suffice.
 
 ## Testing
 - Worker: endpoint auth, invalid pubkey rejected, `getUserStatus` success maps `verified_minor`/`_at`, and not-configured/error degrades to a graceful response (not a 500).
-- Frontend: hook maps the response; `AgeReviewDetail` renders the badge + policy text when `verified_minor` is true, stays quiet when false, and shows an unobtrusive fallback on loading/error.
+- Frontend: hook maps the response; `AgeReviewDetail` renders the "Approved protected minor" badge + date when `verified_minor` is true, stays quiet when false, and shows an unobtrusive fallback on loading/error.
 
-## Out of scope
+## Out of scope (tracked)
+- **Active-protections display** (which protections apply/are active) — **follow-on #143**, after #175/#176.
 - Lifecycle reflection (age-up/revocation) — keycast#265.
-- Real per-device "active" protection telemetry — depends on #175/#176.
 - Cases-list badge.

--- a/docs/superpowers/specs/2026-07-01-protected-minor-visibility-design.md
+++ b/docs/superpowers/specs/2026-07-01-protected-minor-visibility-design.md
@@ -1,9 +1,9 @@
 # Protected-minor visibility in the moderator UI — design
 
-**Issue:** divinevideo/divine-relay-manager#141 (T&S visibility of protected-minor status). Part of the protected-minor safeguards epic (support-trust-safety#173); equal sibling of keycast#265 (lifecycle).
+**Issue:** divinevideo/divine-relay-manager#141 (T&S visibility of protected-minor status).
 **Follow-on:** #143 (surface active protections once #175/#176 exist).
 **Date:** 2026-07-01
-**Status:** WIP (draft PR #142).
+**Status:** Ready for review in PR #142.
 
 ## Goal
 Let a moderator see, from the age-review case view, whether the account is an **approved protected minor (13-15)** — keycast's durable `verified_minor` flag. This is a true, server-backed fact today (it confirms the minor-approval flow actually set the flag).

--- a/docs/superpowers/specs/2026-07-01-protected-minor-visibility-design.md
+++ b/docs/superpowers/specs/2026-07-01-protected-minor-visibility-design.md
@@ -9,7 +9,7 @@
 Let a moderator see, from the age-review case view, whether the account is an **approved protected minor (13-15)** — keycast's durable `verified_minor` flag. This is a true, server-backed fact today (it confirms the minor-approval flow actually set the flag).
 
 ## What already exists (so this is mostly surfacing)
-- `worker/src/keycast-client.ts` `getUserStatus(pubkey, env)` already calls keycast `GET /api/admin/users/:pubkey/status` and returns `verified_minor` + `verified_minor_at` (already used by `ReportWatcher.ts`). **Note:** this is keycast's *admin* endpoint, which already exposed `verified_minor` before keycast#263 — so #141 is **independent** of the in-review detection PRs.
+- `worker/src/keycast-client.ts` `getUserStatus(pubkey, env)` already calls keycast `GET /api/admin/users/:pubkey/status` and returns `verified_minor` + `verified_minor_at` (already used by `ReportWatcher.ts`). **Note:** this is keycast's *admin* endpoint, so #141 is **independent** of the in-review detection PRs.
 - `AgeReviewDetail.tsx` is the moderator case view and has the case `pubkey`.
 - Frontend uses `adminApi.ts` + React Query.
 
@@ -26,7 +26,7 @@ Let a moderator see, from the age-review case view, whether the account is an **
 
 **Frontend**:
 - `adminApi.ts`: `getAccountStatus(pubkey)` client method.
-- `useAccountStatus(pubkey)` React Query hook (keyed on pubkey; enabled when a pubkey is present).
+- Account-status React Query hook (keyed on selected API URL + pubkey; enabled when both are present).
 - `AgeReviewDetail.tsx`: an **Account status** line that, when `verified_minor` is true, shows a badge **"Approved protected minor (13-15)"** + the `verified_minor_at` date. When false, it stays quiet (or a muted "not a protected minor"); on loading/error, an unobtrusive "status unavailable". The badge is clearly the *outcome* ("Approved"), distinct from the case's existing *suspected* age-band badge.
 
 **Placement:** age-review case detail only (not the cases list — avoids N keycast calls per list load). The hook is reusable elsewhere later (nuke button, user lookup).
@@ -40,5 +40,5 @@ Best-effort and independent of the case load: a keycast blip shows "status unava
 
 ## Out of scope (tracked)
 - **Active-protections display** (which protections apply/are active) — **follow-on #143**, after #175/#176.
-- Lifecycle reflection (age-up/revocation) — keycast#265.
+- Lifecycle reflection (age-up/revocation).
 - Cases-list badge.

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -290,6 +290,23 @@ describe('AgeReviewDetail', () => {
     expect(
       await screen.findByText(/approved protected minor/i)
     ).toBeInTheDocument();
+    // The approved date renders (UTC), distinct from the badge label.
+    expect(screen.getByText(/approved \d/i)).toHaveTextContent('2026');
+  });
+
+  it('renders the badge but omits the date when verified_minor_at is malformed', async () => {
+    getAccountStatus.mockResolvedValue({
+      success: true,
+      verified_minor: true,
+      verified_minor_at: 'not-a-date',
+    });
+
+    renderDetail(makeCase());
+
+    expect(
+      await screen.findByText(/approved protected minor/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/approved \d/i)).not.toBeInTheDocument();
   });
 
   it('does not show the protected-minor badge when verified_minor is false', async () => {

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -8,6 +8,7 @@ import type { AgeReviewCase, AgeBand, AgeReviewState } from '../../shared/age-re
 
 const updateAgeReviewCase = vi.fn().mockResolvedValue({ success: true });
 const getAgeReviewConfig = vi.fn().mockResolvedValue({ auto_delete_on_deny: false });
+const getAccountStatus = vi.fn().mockResolvedValue({ success: false });
 const writeText = vi.fn().mockResolvedValue(undefined);
 const toast = vi.fn();
 
@@ -15,6 +16,7 @@ vi.mock('@/hooks/useAdminApi', () => ({
   useAdminApi: () => ({
     updateAgeReviewCase,
     getAgeReviewConfig,
+    getAccountStatus,
   }),
 }));
 
@@ -270,5 +272,30 @@ describe('AgeReviewDetail', () => {
     }));
 
     expect(screen.queryByText('Claim Link')).not.toBeInTheDocument();
+  });
+
+  it('shows the approved-protected-minor badge when verified_minor is true', async () => {
+    getAccountStatus.mockResolvedValue({
+      success: true,
+      verified_minor: true,
+      verified_minor_at: '2026-06-30T12:00:00Z',
+    });
+
+    renderDetail(makeCase());
+
+    expect(
+      await screen.findByText(/approved protected minor/i)
+    ).toBeInTheDocument();
+  });
+
+  it('does not show the protected-minor badge when verified_minor is false', async () => {
+    getAccountStatus.mockResolvedValue({ success: true, verified_minor: false });
+
+    renderDetail(makeCase());
+
+    await waitFor(() => expect(getAccountStatus).toHaveBeenCalled());
+    expect(
+      screen.queryByText(/approved protected minor/i)
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -83,6 +83,8 @@ describe('AgeReviewDetail', () => {
     updateAgeReviewCase.mockResolvedValue({ success: true });
     getAgeReviewConfig.mockClear();
     getAgeReviewConfig.mockResolvedValue({ auto_delete_on_deny: false });
+    getAccountStatus.mockClear();
+    getAccountStatus.mockResolvedValue({ success: true, verified_minor: false });
     toast.mockClear();
     writeText.mockClear();
     Object.assign(navigator, {
@@ -315,5 +317,15 @@ describe('AgeReviewDetail', () => {
     expect(
       screen.queryByText(/approved protected minor/i)
     ).not.toBeInTheDocument();
+  });
+
+  it('shows status-unavailable when the account-status query rejects', async () => {
+    getAccountStatus.mockRejectedValue(new Error('network'));
+
+    renderDetail(makeCase());
+
+    expect(
+      await screen.findByText(/protected-minor status unavailable/i)
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -15,6 +15,7 @@ const writeText = vi.fn().mockResolvedValue(undefined);
 const toast = vi.fn();
 
 vi.mock('@/hooks/useAdminApi', () => ({
+  useApiUrl: () => 'https://api.test.divine.video',
   useAdminApi: () => ({
     updateAgeReviewCase,
     getAgeReviewConfig,

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -8,7 +8,9 @@ import type { AgeReviewCase, AgeBand, AgeReviewState } from '../../shared/age-re
 
 const updateAgeReviewCase = vi.fn().mockResolvedValue({ success: true });
 const getAgeReviewConfig = vi.fn().mockResolvedValue({ auto_delete_on_deny: false });
-const getAccountStatus = vi.fn().mockResolvedValue({ success: false });
+const getAccountStatus = vi
+  .fn()
+  .mockResolvedValue({ success: true, verified_minor: false });
 const writeText = vi.fn().mockResolvedValue(undefined);
 const toast = vi.fn();
 
@@ -294,6 +296,22 @@ describe('AgeReviewDetail', () => {
     renderDetail(makeCase());
 
     await waitFor(() => expect(getAccountStatus).toHaveBeenCalled());
+    expect(
+      screen.queryByText(/approved protected minor/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/status unavailable/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows status-unavailable when the account status could not be loaded', async () => {
+    getAccountStatus.mockResolvedValue({ success: false });
+
+    renderDetail(makeCase());
+
+    expect(
+      await screen.findByText(/protected-minor status unavailable/i)
+    ).toBeInTheDocument();
     expect(
       screen.queryByText(/approved protected minor/i)
     ).not.toBeInTheDocument();

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -160,6 +160,13 @@ export function AgeReviewDetail({ caseData: c }: Props) {
     enabled: !!c.pubkey,
     staleTime: 60_000, // verified_minor is durable; avoid refetching per case reopen
   });
+  const verifiedMinorAtDate = accountStatus?.verified_minor_at
+    ? new Date(accountStatus.verified_minor_at)
+    : null;
+  const verifiedMinorAtLabel =
+    verifiedMinorAtDate && !Number.isNaN(verifiedMinorAtDate.getTime())
+      ? verifiedMinorAtDate.toLocaleDateString()
+      : null;
 
   return (
     <ScrollArea className="h-full">
@@ -179,10 +186,9 @@ export function AgeReviewDetail({ caseData: c }: Props) {
                 <Badge className="bg-emerald-600 text-white hover:bg-emerald-600">
                   Approved protected minor (13-15)
                 </Badge>
-                {accountStatus.verified_minor_at ? (
+                {verifiedMinorAtLabel ? (
                   <span className="text-xs text-muted-foreground">
-                    approved{' '}
-                    {new Date(accountStatus.verified_minor_at).toLocaleDateString()}
+                    approved {verifiedMinorAtLabel}
                   </span>
                 ) : null}
               </>

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -152,6 +152,14 @@ export function AgeReviewDetail({ caseData: c }: Props) {
     queryFn: () => api.getAgeReviewConfig(),
   });
 
+  // Keycast-backed protected-minor status (verified_minor). Best-effort: a
+  // keycast blip resolves to success:false, so we simply don't show the badge.
+  const { data: accountStatus } = useQuery({
+    queryKey: ['account-status', c.pubkey],
+    queryFn: () => api.getAccountStatus(c.pubkey),
+    enabled: !!c.pubkey,
+  });
+
   return (
     <ScrollArea className="h-full">
       <div className="space-y-4 p-4">
@@ -164,6 +172,19 @@ export function AgeReviewDetail({ caseData: c }: Props) {
               <Badge variant="outline" className="gap-1">
                 <Pause className="h-3 w-3" /> Clock Paused
               </Badge>
+            ) : null}
+            {accountStatus?.verified_minor ? (
+              <>
+                <Badge className="bg-emerald-600 text-white hover:bg-emerald-600">
+                  Approved protected minor (13-15)
+                </Badge>
+                {accountStatus.verified_minor_at ? (
+                  <span className="text-xs text-muted-foreground">
+                    approved{' '}
+                    {new Date(accountStatus.verified_minor_at).toLocaleDateString()}
+                  </span>
+                ) : null}
+              </>
             ) : null}
           </div>
 

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -154,10 +154,11 @@ export function AgeReviewDetail({ caseData: c }: Props) {
 
   // Keycast-backed protected-minor status (verified_minor). Best-effort: a
   // keycast blip resolves to success:false, so we simply don't show the badge.
-  const { data: accountStatus } = useQuery({
+  const { data: accountStatus, isError: accountStatusFailed } = useQuery({
     queryKey: ['account-status', c.pubkey],
     queryFn: () => api.getAccountStatus(c.pubkey),
     enabled: !!c.pubkey,
+    staleTime: 60_000, // verified_minor is durable; avoid refetching per case reopen
   });
 
   return (
@@ -185,6 +186,12 @@ export function AgeReviewDetail({ caseData: c }: Props) {
                   </span>
                 ) : null}
               </>
+            ) : accountStatusFailed || accountStatus?.success === false ? (
+              // Couldn't determine (keycast down/misconfig) — don't let a blip
+              // read the same as a confirmed non-minor; keep the safety signal.
+              <span className="text-xs text-muted-foreground">
+                protected-minor status unavailable
+              </span>
             ) : null}
           </div>
 

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAdminApi } from "@/hooks/useAdminApi";
+import { useAdminApi, useApiUrl } from "@/hooks/useAdminApi";
 import { ApiError } from "@/lib/adminApi";
 import { useToast } from "@/hooks/useToast";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
@@ -94,6 +94,7 @@ const ENFORCEMENT_STATES: AgeReviewState[] = [
 
 export function AgeReviewDetail({ caseData: c }: Props) {
   const api = useAdminApi();
+  const apiUrl = useApiUrl();
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [resolutionNote, setResolutionNote] = useState(c.resolution_note ?? "");
@@ -153,11 +154,11 @@ export function AgeReviewDetail({ caseData: c }: Props) {
   });
 
   // Keycast-backed protected-minor status (verified_minor). Best-effort: a
-  // keycast blip resolves to success:false, so we simply don't show the badge.
+  // keycast blip resolves to success:false, so we show status unavailable.
   const { data: accountStatus, isError: accountStatusFailed } = useQuery({
-    queryKey: ['account-status', c.pubkey],
+    queryKey: ['account-status', apiUrl, c.pubkey],
     queryFn: () => api.getAccountStatus(c.pubkey),
-    enabled: !!c.pubkey,
+    enabled: !!apiUrl && !!c.pubkey,
     staleTime: 60_000, // verified_minor is durable; avoid refetching per case reopen
   });
   const verifiedMinorAtDate = accountStatus?.verified_minor_at

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -165,7 +165,9 @@ export function AgeReviewDetail({ caseData: c }: Props) {
     : null;
   const verifiedMinorAtLabel =
     verifiedMinorAtDate && !Number.isNaN(verifiedMinorAtDate.getTime())
-      ? verifiedMinorAtDate.toLocaleDateString()
+      ? // UTC so every moderator sees the same approval date regardless of their
+        // local timezone (a near-midnight-UTC timestamp would otherwise shift a day).
+        verifiedMinorAtDate.toLocaleDateString(undefined, { timeZone: 'UTC' })
       : null;
 
   return (

--- a/src/hooks/useAdminApi.ts
+++ b/src/hooks/useAdminApi.ts
@@ -129,6 +129,8 @@ export function useAdminApi() {
       adminApi.getAgeReviewFunnel(apiUrl, ageBand),
     getAgeReviewCase: (caseId: string) =>
       adminApi.getAgeReviewCase(apiUrl, caseId),
+    getAccountStatus: (pubkey: string) =>
+      adminApi.getAccountStatus(apiUrl, pubkey),
     updateAgeReviewCase: (caseId: string, updates: Record<string, unknown>) =>
       adminApi.updateAgeReviewCase(apiUrl, caseId, updates),
 

--- a/src/lib/adminApi.test.ts
+++ b/src/lib/adminApi.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   getWorkerInfo,
+  getAccountStatus,
   publishEvent,
   moderateAction,
   deleteEvent,
@@ -48,6 +49,28 @@ const API_URL = 'https://test-api.example.com';
 describe('adminApi', () => {
   beforeEach(() => {
     mockFetch.mockReset();
+  });
+
+  describe('getAccountStatus', () => {
+    it('GETs /api/account-status/:pubkey and returns the parsed status', async () => {
+      const pubkey = 'a'.repeat(64);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          verified_minor: true,
+          verified_minor_at: '2026-06-30T12:00:00Z',
+        }),
+      });
+
+      const result = await getAccountStatus(API_URL, pubkey);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${API_URL}/api/account-status/${pubkey}`,
+        expect.objectContaining({ method: 'GET' }),
+      );
+      expect(result).toMatchObject({ success: true, verified_minor: true });
+    });
   });
 
   describe('apiRequest (via getWorkerInfo)', () => {

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -1036,6 +1036,31 @@ export async function getAgeReviewCase(
   return apiRequest<AgeReviewCaseResponse>(apiUrl, `/api/age-review/cases/${caseId}`, 'GET');
 }
 
+/** Keycast-backed account status for moderators: surfaces the durable
+ * `verified_minor` flag (approved protected minor 13-15). A keycast blip returns
+ * `{ success: false }` (HTTP 200), so callers degrade to "status unavailable". */
+export interface AccountStatusResponse {
+  success: boolean;
+  pubkey?: string;
+  status?: string;
+  suspended_reason?: string;
+  suspended_at?: string;
+  verified_minor?: boolean;
+  verified_minor_at?: string;
+  error?: string;
+}
+
+export async function getAccountStatus(
+  apiUrl: string,
+  pubkey: string,
+): Promise<AccountStatusResponse> {
+  return apiRequest<AccountStatusResponse>(
+    apiUrl,
+    `/api/account-status/${pubkey}`,
+    'GET',
+  );
+}
+
 export async function getAgeReviewFunnel(
   apiUrl: string,
   ageBand: string = 'age_13_15',

--- a/worker/src/account-status.test.ts
+++ b/worker/src/account-status.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { handleAccountStatus } from './account-status';
+import type { KeycastEnv } from './keycast-client';
+
+const VALID_PUBKEY = 'a'.repeat(64);
+const CORS = { 'Access-Control-Allow-Origin': '*' };
+
+function makeEnv(overrides: Partial<KeycastEnv> = {}): KeycastEnv {
+  return {
+    KEYCAST_URL: 'https://login.test.divine.video',
+    KEYCAST_SERVICE_TOKEN: 'test-service-token',
+    ...overrides,
+  };
+}
+
+describe('handleAccountStatus', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('returns verified_minor from keycast on success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            pubkey: VALID_PUBKEY,
+            status: 'active',
+            verified_minor: true,
+            verified_minor_at: '2026-06-30T12:00:00Z',
+          }),
+      }),
+    );
+
+    const res = await handleAccountStatus(VALID_PUBKEY, makeEnv(), CORS);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      success: true,
+      verified_minor: true,
+      verified_minor_at: '2026-06-30T12:00:00Z',
+    });
+  });
+
+  it('rejects an invalid pubkey with 400 (before calling keycast)', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const res = await handleAccountStatus('not-a-pubkey', makeEnv(), CORS);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('degrades gracefully (200, success:false) when keycast is unavailable', async () => {
+    const res = await handleAccountStatus(
+      VALID_PUBKEY,
+      makeEnv({ KEYCAST_URL: undefined }),
+      CORS,
+    );
+
+    // Not a hard failure: the moderator UI reads this as "status unavailable"
+    // without blocking the case view.
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+});

--- a/worker/src/account-status.test.ts
+++ b/worker/src/account-status.test.ts
@@ -50,7 +50,7 @@ describe('handleAccountStatus', () => {
     const res = await handleAccountStatus('not-a-pubkey', makeEnv(), CORS);
 
     expect(res.status).toBe(400);
-    const body = await res.json();
+    const body = (await res.json()) as { success: boolean };
     expect(body.success).toBe(false);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
@@ -65,7 +65,24 @@ describe('handleAccountStatus', () => {
     // Not a hard failure: the moderator UI reads this as "status unavailable"
     // without blocking the case view.
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = (await res.json()) as { success: boolean };
+    expect(body.success).toBe(false);
+  });
+
+  it('degrades gracefully when keycast returns a server error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('boom'),
+      }),
+    );
+
+    const res = await handleAccountStatus(VALID_PUBKEY, makeEnv(), CORS);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean };
     expect(body.success).toBe(false);
   });
 });

--- a/worker/src/account-status.ts
+++ b/worker/src/account-status.ts
@@ -1,0 +1,59 @@
+// ABOUTME: Moderator-facing account-status endpoint. Surfaces keycast's durable
+// ABOUTME: verified_minor flag (approved protected minor 13-15) for the age-review view.
+
+import { getUserStatus, type KeycastEnv } from './keycast-client';
+
+const HEX_64 = /^[0-9a-f]{64}$/;
+
+function json(
+  data: unknown,
+  status: number,
+  headers: Record<string, string>,
+): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...headers, 'Content-Type': 'application/json' },
+  });
+}
+
+/**
+ * `GET /api/account-status/:pubkey` — the account's keycast status for moderators.
+ *
+ * Returns the durable `verified_minor` flag (+ `verified_minor_at`) so the
+ * age-review view can show whether an account is an approved protected minor.
+ * An invalid pubkey is a 400; a keycast failure/misconfiguration degrades to
+ * `200 { success: false }` so the moderator UI reads "status unavailable"
+ * without blocking the case view.
+ */
+export async function handleAccountStatus(
+  pubkey: string,
+  env: KeycastEnv,
+  corsHeaders: Record<string, string>,
+): Promise<Response> {
+  if (!HEX_64.test(pubkey)) {
+    return json(
+      { success: false, error: 'invalid pubkey: must be 64 hex chars' },
+      400,
+      corsHeaders,
+    );
+  }
+
+  const result = await getUserStatus(pubkey, env);
+  if (!result.success) {
+    return json({ success: false, error: result.error ?? 'unavailable' }, 200, corsHeaders);
+  }
+
+  return json(
+    {
+      success: true,
+      pubkey: result.pubkey,
+      status: result.status,
+      suspended_reason: result.suspended_reason,
+      suspended_at: result.suspended_at,
+      verified_minor: result.verified_minor ?? false,
+      verified_minor_at: result.verified_minor_at,
+    },
+    200,
+    corsHeaders,
+  );
+}

--- a/worker/src/account-status.ts
+++ b/worker/src/account-status.ts
@@ -1,9 +1,7 @@
 // ABOUTME: Moderator-facing account-status endpoint. Surfaces keycast's durable
 // ABOUTME: verified_minor flag (approved protected minor 13-15) for the age-review view.
 
-import { getUserStatus, type KeycastEnv } from './keycast-client';
-
-const HEX_64 = /^[0-9a-f]{64}$/;
+import { getUserStatus, HEX_64, type KeycastEnv } from './keycast-client';
 
 function json(
   data: unknown,

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -531,3 +531,54 @@ describe('relay-rpc admin access via MOD_RELAY_ADMIN_KEY (Secrets Store shared k
     expect(response.status).toBe(401);
   });
 });
+
+describe('GET /api/account-status/:pubkey', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  const accountEnv = {
+    ALLOWED_ORIGINS: 'https://app.divine.video',
+    RELAY_URL: 'wss://relay.divine.video',
+    ADMIN_API_KEY: 'test-admin-key',
+    KEYCAST_URL: 'https://login.test.divine.video',
+    KEYCAST_SERVICE_TOKEN: 'test-service-token',
+  } as never;
+  const PUBKEY = 'a'.repeat(64);
+
+  it('surfaces verified_minor for an admin-authed request', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        pubkey: PUBKEY,
+        status: 'active',
+        verified_minor: true,
+        verified_minor_at: '2026-06-30T12:00:00Z',
+      }),
+    }));
+
+    const response = await worker.fetch(
+      new Request(`https://api.divine.video/api/account-status/${PUBKEY}`, {
+        headers: { 'X-Admin-Key': 'test-admin-key', Origin: 'https://app.divine.video' },
+      }),
+      accountEnv,
+      ctx,
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { success: boolean; verified_minor?: boolean };
+    expect(body.success).toBe(true);
+    expect(body.verified_minor).toBe(true);
+  });
+
+  it('requires admin auth (401 without an admin key)', async () => {
+    const response = await worker.fetch(
+      new Request(`https://api.divine.video/api/account-status/${PUBKEY}`, {
+        headers: { Origin: 'https://app.divine.video' },
+      }),
+      accountEnv,
+      ctx,
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -26,6 +26,7 @@ import {
   getAgeReviewConfig,
   updateAgeReviewConfig,
 } from './age-review';
+import { handleAccountStatus } from './account-status';
 import { handleBulkModerateEnqueue, handleBulkJobStatus, processBulkJob } from './bulk-moderate';
 import type { BulkJobMessage } from '../../shared/bulk-moderation';
 import { ensureZendeskTable, addZendeskInternalNote, syncZendeskAfterAction } from './zendesk-sync';
@@ -424,6 +425,12 @@ export default {
       });
       if (adminAuthError) {
         return jsonResponse({ success: false, error: adminAuthError }, 401, corsHeaders);
+      }
+
+      // Moderator-facing account status (surfaces keycast verified_minor for the age-review view).
+      if (path.startsWith('/api/account-status/') && request.method === 'GET') {
+        const targetPubkey = path.replace('/api/account-status/', '');
+        return handleAccountStatus(targetPubkey, env, corsHeaders);
       }
 
       if (path === '/api/publish' && request.method === 'POST') {

--- a/worker/src/keycast-client.ts
+++ b/worker/src/keycast-client.ts
@@ -13,7 +13,7 @@ export interface KeycastResult {
 
 export type KeycastReason = 'age_review' | 'age_review_denied' | 'age_review_expired' | 'moderation';
 
-const HEX_64 = /^[0-9a-f]{64}$/;
+export const HEX_64 = /^[0-9a-f]{64}$/;
 
 async function resolveToken(binding: string | SecretStoreSecret | undefined): Promise<string | null> {
   if (!binding) return null;


### PR DESCRIPTION
## Summary

- Add `GET /api/account-status/:pubkey` behind the existing admin gate to surface keycast's durable `verified_minor` and `verified_minor_at` fields.
- Add the frontend admin API method and an age-review detail query that shows an approved protected-minor badge when keycast confirms the account is an approved protected minor.
- Show an explicit protected-minor status unavailable message when the status check fails, and keep the account-status cache isolated by selected environment.

## Motivation

Moderators need to distinguish a suspected 13-15 case from an account that has already completed the protected-minor approval flow. This PR surfaces only the server-backed `verified_minor` fact and intentionally defers any active-protection display until those enforcement features exist.

## Linked issue

Closes #141.

Follow-on: #143 tracks displaying active protections after the underlying enforcement work exists.

## Manual validation

- `npx vitest run src/components/AgeReviewDetail.test.tsx src/lib/adminApi.test.ts`
- `cd worker && npx vitest run src/account-status.test.ts src/index.test.ts`
- `npx tsc --noEmit`
- `npx vite build`
