### PR TITLE
test: fix local vitest suite (exclude .worktrees, drop hanging App smoke test)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,8 +1,0 @@
-import { render } from '@testing-library/react';
-import { test } from 'vitest';
-
-import App from './App';
-
-test('App', () => {
-  render(<App />);
-})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,10 @@ export default defineConfig(() => {
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
-    exclude: ['node_modules', 'worker/**'],
+    // `node_modules` alone only skips the top-level dir; a git worktree under
+    // `.worktrees/*/node_modules` would otherwise get globbed and run ~20k
+    // third-party package tests. Match nested node_modules and worktrees too.
+    exclude: ['**/node_modules/**', '**/dist/**', '**/.worktrees/**', 'worker/**'],
     onConsoleLog(log) {
       return !log.includes("React Router Future Flag Warning");
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import react from "@vitejs/plugin-react-swc";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 // https://vitejs.dev/config/
 export default defineConfig(() => {
@@ -27,10 +27,12 @@ export default defineConfig(() => {
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
-    // `node_modules` alone only skips the top-level dir; a git worktree under
-    // `.worktrees/*/node_modules` would otherwise get globbed and run ~20k
-    // third-party package tests. Match nested node_modules and worktrees too.
-    exclude: ['**/node_modules/**', '**/dist/**', '**/.worktrees/**', 'worker/**'],
+    // Extend (don't replace) Vitest's defaults — a user `exclude` overrides
+    // them, and the defaults' `**/node_modules/**` is what keeps a stale git
+    // worktree under `.worktrees/*/node_modules` (a full repo checkout) from
+    // being globbed and running ~20k third-party package tests. We additionally
+    // exclude the worktrees' own source and the separately-tested `worker/`.
+    exclude: [...configDefaults.exclude, '**/.worktrees/**', 'worker/**'],
     onConsoleLog(log) {
       return !log.includes("React Router Future Flag Warning");
     },


### PR DESCRIPTION
Standalone test-infra fix so `npx vitest run` is usable locally again. Closes #144, closes #145. (Kept out of the #141/#142 feature PR deliberately — different concern.)

## Two problems, both making local runs unusable
1. **Stray worktree pollution (#144).** `vite.config.ts` `test.exclude` was `['node_modules', 'worker/**']`. A git worktree under `.worktrees/*/` is a **full repo checkout**, so vitest's include glob collected both its duplicated `src/**/*.test.*` files *and* its `node_modules` package tests — ~20k tests, **50+ minutes**. Fixed by excluding `**/.worktrees/**` (the load-bearing pattern — a worktree is gitignored, ephemeral, and never holds tracked source) plus `**/node_modules/**` and `**/dist/**` (vitest's canonical defaults, since a custom `exclude` overrides the built-in list).
2. **Hanging App smoke test (#145).** `src/App.test.tsx` was the MKStack scaffold's zero-assertion `test('App', () => render(<App/>))`. Mounting `<App/>` opens real relay WebSocket connections (`NostrProvider` → `NPool`/`NRelay1`, plus other providers) that never tear down, so vitest can't finish the worker and the run **hangs** on this file. It asserted nothing (net-negative: broke local runs without testing behavior), so it's removed. It passed in CI only because CI has no outbound network.

## Result
`npx vitest run` (no flags) now completes in **~3s** (11 files, 142 tests) instead of hanging, while still collecting every real `src` test.

If we want an app-level smoke test later, it should mock the socket-opening providers (`NostrProvider`/`NPool`/`NRelay1` — and note mocking `NostrProvider` alone is not enough) and assert something. Out of scope for this cleanup.
