### PR TITLE
feat(minor-safety): clear verified_minor on revoke/deny via keycast (#147)

### DIFF
--- a/docs/superpowers/specs/2026-07-07-clear-verified-minor-on-revoke-design.md
+++ b/docs/superpowers/specs/2026-07-07-clear-verified-minor-on-revoke-design.md
@@ -23,20 +23,26 @@ mistaken approval / cleared → unsuspend); keycast's primitive is clear-only.
    with the service-token auth the other calls use. Returns `KeycastResult`.
 2. **New enforcement leg** in the age-review state-transition handler
    (`worker/src/age-review.ts`, alongside the Keycast status leg at ~:349):
-   run on `deniedCase` and `clearedCase` transitions, **unconditionally** —
-   keycast's clear is an idempotent success no-op on never-minor/already-cleared
-   accounts and only writes the durable audit row on a real transition, so no
-   pre-read of `verified_minor` is needed.
+   run on the **`deniedCase`** (revoke) transition only, plus the deadline-expiry
+   auto-deny in the cron. **Not on `cleared`** — `cleared` is the favorable
+   outcome and is overloaded: for a 13-15 consent-verified case it restores a
+   *confirmed protected minor* who must keep `verified_minor` (moderator guide,
+   13-15 band); the 16+ mistaken-flag case also uses `cleared` where the flag is
+   a no-op. Since the transition can't distinguish them, we leave the flag alone
+   on `cleared` (over-protecting a mistaken adult is the safe side) and only
+   deny/revoke removes it. keycast's clear is an idempotent no-op for
+   never-minor accounts, so no pre-read of `verified_minor` is needed.
 3. **Leg status surfaces like the others**: tracked via the shared
    `runStatusLeg` wrapper, folded into `enforcementComplete`, so a keycast
    failure is reported (HTTP 207, success:false) rather than silently leaving
    the flag set — issue requirement "must not silently leave the flag set."
-4. **actor + reason**: actor = the case row's `moderator_pubkey` (already an
-   accepted, persisted PATCH field), reason derived from the transition
-   (`age_review_denied` / `age_review_cleared`), so keycast writes the durable
-   `admin_audit_events` row. A malformed actor is dropped client-side (keycast
-   400s on it, which would fail the whole clear); absent actor → keycast's
-   log-only fallback per #265.
+4. **actor + reason**: actor = the case row's `moderator_pubkey` (best-effort:
+   relay-manager auths with a shared admin pubkey, so no per-actor signal, and
+   the field is unvalidated on write). reason is the revoke-direction
+   `age_review_denied` (interactive) / `age_review_expired` (cron), so keycast
+   writes the durable `admin_audit_events` row. A malformed/absent actor is
+   dropped server-side in `clearVerifiedMinor` → keycast's log-only fallback
+   per #265.
 
 ## Out of scope
 
@@ -47,7 +53,8 @@ mistaken approval / cleared → unsuspend); keycast's primitive is clear-only.
 
 - client: `clearVerifiedMinor` happy path, keycast error surfaced, URL/auth shape.
 - handler: deny transition runs the clear leg and reports it in `enforcement`;
-  cleared transition likewise; leg failure → `enforcementComplete=false` / 207;
+  **cleared transition does NOT clear** (favorable outcome keeps a confirmed
+  minor protected); leg failure → `enforcementComplete=false` / 207;
   non-terminal transitions do not call clear.
 - Follow existing `age-review.test.ts` / `keycast-client.test.ts` harnesses.
 

--- a/docs/superpowers/specs/2026-07-07-clear-verified-minor-on-revoke-design.md
+++ b/docs/superpowers/specs/2026-07-07-clear-verified-minor-on-revoke-design.md
@@ -1,0 +1,57 @@
+# Clear verified_minor on revoke/deny (relay-manager#147)
+
+**Status:** WIP design — implementation follows on this branch.
+**Part of:** support-trust-safety#173 (protected-minor epic). Follow-on of keycast#265 / keycast PR #280.
+**Depends on:** keycast#280 merging (the `DELETE /api/admin/users/:pubkey/verified-minor` endpoint). Built against that PR's pinned contract; mergeable once it lands.
+
+## Problem
+
+Revoking an approved minor's approval in relay-manager changes account status but
+leaves `verified_minor` set in keycast, so protected-minor protections persist (or,
+for a mistaken approval being reversed, linger on a normal account). keycast#265
+added the clear primitive; this wires the moderator flow to call it.
+
+## Design
+
+**Compose, do not couple** (per issue #147): revoke = existing status leg +
+a new clear-verified-minor leg. The status decision stays here (deny → ban,
+mistaken approval / cleared → unsuspend); keycast's primitive is clear-only.
+
+1. **New client fn** `clearVerifiedMinor(pubkey, actor, reason, env)` in
+   `worker/src/keycast-client.ts`, following the existing fn pattern:
+   `DELETE {url}/api/admin/users/{pubkey}/verified-minor?actor=<hex>&reason=<text>`
+   with the service-token auth the other calls use. Returns `KeycastResult`.
+2. **New enforcement leg** in the age-review state-transition handler
+   (`worker/src/age-review.ts`, alongside the Keycast status leg at ~:349):
+   run on `deniedCase` and `clearedCase` transitions, **unconditionally** —
+   keycast's clear is an idempotent success no-op on never-minor/already-cleared
+   accounts and only writes the durable audit row on a real transition, so no
+   pre-read of `verified_minor` is needed.
+3. **Leg status surfaces like the others**: tracked via the shared
+   `runStatusLeg` wrapper, folded into `enforcementComplete`, so a keycast
+   failure is reported (HTTP 207, success:false) rather than silently leaving
+   the flag set — issue requirement "must not silently leave the flag set."
+4. **actor + reason**: pass the acting moderator's pubkey as `actor` and a
+   reason derived from the transition (e.g. `age_review_denied` /
+   `age_review_mistaken_approval`) so keycast writes the durable
+   `admin_audit_events` row. OPEN: confirm where the handler gets the
+   moderator identity (CF Access context vs request body) — if unavailable,
+   keycast falls back to log-only per #265, acceptable but not preferred.
+
+## Out of scope
+
+- Age-up transitions (support-trust-safety#179, deferred by the epic).
+- Surfacing active protections in the age-review view (relay-manager#143).
+
+## Tests
+
+- client: `clearVerifiedMinor` happy path, keycast error surfaced, URL/auth shape.
+- handler: deny transition runs the clear leg and reports it in `enforcement`;
+  cleared transition likewise; leg failure → `enforcementComplete=false` / 207;
+  non-terminal transitions do not call clear.
+- Follow existing `age-review.test.ts` / `keycast-client.test.ts` harnesses.
+
+## Acceptance (from #147)
+
+Revoking an approved minor in relay-manager clears `verified_minor` in keycast
+(with a durable audit row), and the age-review view reflects the change.

--- a/docs/superpowers/specs/2026-07-07-clear-verified-minor-on-revoke-design.md
+++ b/docs/superpowers/specs/2026-07-07-clear-verified-minor-on-revoke-design.md
@@ -1,6 +1,6 @@
 # Clear verified_minor on revoke/deny (relay-manager#147)
 
-**Status:** WIP design — implementation follows on this branch.
+**Status:** Implemented on this branch; PR stays draft until keycast#280 lands and Matt green-lights review.
 **Part of:** support-trust-safety#173 (protected-minor epic). Follow-on of keycast#265 / keycast PR #280.
 **Depends on:** keycast#280 merging (the `DELETE /api/admin/users/:pubkey/verified-minor` endpoint). Built against that PR's pinned contract; mergeable once it lands.
 
@@ -31,12 +31,12 @@ mistaken approval / cleared → unsuspend); keycast's primitive is clear-only.
    `runStatusLeg` wrapper, folded into `enforcementComplete`, so a keycast
    failure is reported (HTTP 207, success:false) rather than silently leaving
    the flag set — issue requirement "must not silently leave the flag set."
-4. **actor + reason**: pass the acting moderator's pubkey as `actor` and a
-   reason derived from the transition (e.g. `age_review_denied` /
-   `age_review_mistaken_approval`) so keycast writes the durable
-   `admin_audit_events` row. OPEN: confirm where the handler gets the
-   moderator identity (CF Access context vs request body) — if unavailable,
-   keycast falls back to log-only per #265, acceptable but not preferred.
+4. **actor + reason**: actor = the case row's `moderator_pubkey` (already an
+   accepted, persisted PATCH field), reason derived from the transition
+   (`age_review_denied` / `age_review_cleared`), so keycast writes the durable
+   `admin_audit_events` row. A malformed actor is dropped client-side (keycast
+   400s on it, which would fail the whole clear); absent actor → keycast's
+   log-only fallback per #265.
 
 ## Out of scope
 

--- a/shared/age-review.ts
+++ b/shared/age-review.ts
@@ -112,6 +112,10 @@ export interface AgeReviewEnforcement {
   bulkError?: string;
   keycast: EnforcementLegStatus;
   keycastError?: string;
+  /** Keycast verified_minor clear on revoke/deny (issue #147). Optional so
+   * payloads from an older worker still type-check. */
+  keycastMinorClear?: EnforcementLegStatus;
+  keycastMinorClearError?: string;
 }
 
 // Response body for a case GET/PATCH. On a partial-enforcement PATCH the worker

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -670,7 +670,9 @@ describe('Keycast suspension wiring', () => {
     );
   });
 
-  it('clears verified_minor with the cleared reason on a cleared transition', async () => {
+  it('does NOT clear verified_minor on a cleared transition (favorable outcome keeps a confirmed minor protected)', async () => {
+    // `cleared` restores a 13-15 consent-verified account (a confirmed protected
+    // minor who must keep verified_minor). Only deny/revoke removes the flag.
     const restrictedCase = makeCase({ state: 'restricted_pending_user_response' });
     const updatedCase = { ...restrictedCase, state: 'cleared' as const };
 
@@ -679,17 +681,11 @@ describe('Keycast suspension wiring', () => {
       body: JSON.stringify({ state: 'cleared' }),
     });
     const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(makeDbFor(restrictedCase, updatedCase)), corsHeaders);
-    const body = await res.json() as { success: boolean; enforcement: { keycastMinorClear: string } };
 
     expect(res.status).toBe(200);
-    expect(body.enforcement.keycastMinorClear).toBe('ok');
-    // moderator_pubkey is null on this case: actor omitted -> keycast log-only fallback.
-    expect(clearVerifiedMinor).toHaveBeenCalledWith(
-      restrictedCase.pubkey,
-      undefined,
-      'age_review_cleared',
-      expect.objectContaining({ DB: expect.anything() }),
-    );
+    expect(clearVerifiedMinor).not.toHaveBeenCalled();
+    const body = await res.json() as { enforcement: { keycastMinorClear: string } };
+    expect(body.enforcement.keycastMinorClear).toBe('not_attempted');
   });
 
   it('surfaces a verified_minor clear failure as incomplete enforcement (207)', async () => {

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -670,6 +670,31 @@ describe('Keycast suspension wiring', () => {
     );
   });
 
+  it('clears verified_minor with an undefined actor when the case has no moderator_pubkey', async () => {
+    // relay-manager auths with a shared admin pubkey, so a case row may carry a
+    // null moderator_pubkey. The clear must still fire, with actor `undefined`
+    // (keycast then falls back to a log-only audit row). Locks the handler's
+    // `(updated ?? existing) ?? undefined` fallback on the interactive path.
+    const restrictedCase = makeCase({ state: 'restricted_pending_user_response', moderator_pubkey: null });
+    const updatedCase = { ...restrictedCase, state: 'denied_closed' as const };
+
+    const req = new Request('https://api.test/api/age-review/cases/case-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ state: 'denied_closed' }),
+    });
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(makeDbFor(restrictedCase, updatedCase)), corsHeaders);
+    const body = await res.json() as { enforcement: { keycastMinorClear: string } };
+
+    expect(res.status).toBe(200);
+    expect(body.enforcement.keycastMinorClear).toBe('ok');
+    expect(clearVerifiedMinor).toHaveBeenCalledWith(
+      restrictedCase.pubkey,
+      undefined,
+      'age_review_denied',
+      expect.objectContaining({ DB: expect.anything() }),
+    );
+  });
+
   it('does NOT clear verified_minor on a cleared transition (favorable outcome keeps a confirmed minor protected)', async () => {
     // `cleared` restores a 13-15 consent-verified account (a confirmed protected
     // minor who must keep verified_minor). Only deny/revoke removes the flag.

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -1104,6 +1104,7 @@ describe('checkAgeReviewDeadlines', () => {
     vi.mocked(suspendUser).mockClear().mockResolvedValue({ success: true });
     vi.mocked(unsuspendUser).mockClear().mockResolvedValue({ success: true });
     vi.mocked(banUser).mockClear().mockResolvedValue({ success: true });
+    vi.mocked(clearVerifiedMinor).mockClear().mockResolvedValue({ success: true });
   });
 
   it('does nothing when DB unavailable', async () => {
@@ -1157,6 +1158,10 @@ describe('checkAgeReviewDeadlines', () => {
     // Verify Keycast ban was sent for the expired case
     expect(banUser).toHaveBeenCalledOnce();
     expect(banUser).toHaveBeenCalledWith(expiredCase.pubkey, 'age_review_expired', expect.objectContaining({ DB: expect.anything() }));
+
+    // Auto-deny must also clear verified_minor (#147) — system actor (undefined),
+    // so a deadline-expired account isn't left banned with the flag still set.
+    expect(clearVerifiedMinor).toHaveBeenCalledWith(expiredCase.pubkey, undefined, 'age_review_expired', expect.objectContaining({ DB: expect.anything() }));
 
     vi.unstubAllGlobals();
   });

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -18,13 +18,14 @@ import {
 } from './age-review';
 import type { AgeReviewCase } from '../../shared/age-review';
 import { FUNNEL_ZENDESK_QUERIES } from '../../shared/age-review';
-import { suspendUser, unsuspendUser, banUser, createMinorAccount } from './keycast-client';
+import { suspendUser, unsuspendUser, banUser, clearVerifiedMinor, createMinorAccount } from './keycast-client';
 import { suspendPubkey, unsuspendPubkey, banPubkey } from './nip86';
 
 vi.mock('./keycast-client', () => ({
   suspendUser: vi.fn().mockResolvedValue({ success: true }),
   unsuspendUser: vi.fn().mockResolvedValue({ success: true }),
   banUser: vi.fn().mockResolvedValue({ success: true }),
+  clearVerifiedMinor: vi.fn().mockResolvedValue({ success: true }),
   createMinorAccount: vi.fn().mockResolvedValue({ success: true, pubkey: 'a'.repeat(64), claim_url: 'https://login.test/claim/abc' }),
 }));
 
@@ -382,6 +383,7 @@ describe('Keycast suspension wiring', () => {
     vi.mocked(suspendUser).mockClear().mockResolvedValue({ success: true });
     vi.mocked(unsuspendUser).mockClear().mockResolvedValue({ success: true });
     vi.mocked(banUser).mockClear().mockResolvedValue({ success: true });
+    vi.mocked(clearVerifiedMinor).mockClear().mockResolvedValue({ success: true });
   });
 
   it('calls suspendUser when transitioning to restricted_pending_user_response', async () => {
@@ -621,6 +623,117 @@ describe('Keycast suspension wiring', () => {
     expect(body.keycastUpdated).toBe(true);
     expect(banUser).toHaveBeenCalledOnce();
     expect(banUser).toHaveBeenCalledWith(restrictedCase.pubkey, 'age_review_denied', expect.objectContaining({ DB: expect.anything() }));
+  });
+
+  // Issue #147: revoke/deny composes a verified_minor clear with the status leg.
+  const makeDbFor = (existing: ReturnType<typeof makeCase>, updated: ReturnType<typeof makeCase>) => {
+    let selectCount = 0;
+    const firstFor = (sql: string) => async () => {
+      if (sql.includes('WHERE id = ?')) {
+        selectCount += 1;
+        return selectCount === 1 ? existing : updated;
+      }
+      return null; // age_review_config -> default config
+    };
+    return {
+      prepare: vi.fn().mockImplementation((sql: string) => ({
+        first: vi.fn().mockImplementation(firstFor(sql)),
+        bind: vi.fn().mockReturnValue({
+          first: vi.fn().mockImplementation(firstFor(sql)),
+          run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+        }),
+      })),
+    };
+  };
+
+  it('clears verified_minor (with actor + deny reason) when transitioning to denied_closed', async () => {
+    const moderator = 'b'.repeat(64);
+    const restrictedCase = makeCase({ state: 'restricted_pending_user_response', moderator_pubkey: moderator });
+    const updatedCase = { ...restrictedCase, state: 'denied_closed' as const };
+
+    const req = new Request('https://api.test/api/age-review/cases/case-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ state: 'denied_closed' }),
+    });
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(makeDbFor(restrictedCase, updatedCase)), corsHeaders);
+    const body = await res.json() as { success: boolean; enforcement: { keycastMinorClear: string } };
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.enforcement.keycastMinorClear).toBe('ok');
+    expect(clearVerifiedMinor).toHaveBeenCalledOnce();
+    expect(clearVerifiedMinor).toHaveBeenCalledWith(
+      restrictedCase.pubkey,
+      moderator,
+      'age_review_denied',
+      expect.objectContaining({ DB: expect.anything() }),
+    );
+  });
+
+  it('clears verified_minor with the cleared reason on a cleared transition', async () => {
+    const restrictedCase = makeCase({ state: 'restricted_pending_user_response' });
+    const updatedCase = { ...restrictedCase, state: 'cleared' as const };
+
+    const req = new Request('https://api.test/api/age-review/cases/case-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ state: 'cleared' }),
+    });
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(makeDbFor(restrictedCase, updatedCase)), corsHeaders);
+    const body = await res.json() as { success: boolean; enforcement: { keycastMinorClear: string } };
+
+    expect(res.status).toBe(200);
+    expect(body.enforcement.keycastMinorClear).toBe('ok');
+    // moderator_pubkey is null on this case: actor omitted -> keycast log-only fallback.
+    expect(clearVerifiedMinor).toHaveBeenCalledWith(
+      restrictedCase.pubkey,
+      undefined,
+      'age_review_cleared',
+      expect.objectContaining({ DB: expect.anything() }),
+    );
+  });
+
+  it('surfaces a verified_minor clear failure as incomplete enforcement (207)', async () => {
+    vi.mocked(clearVerifiedMinor).mockResolvedValueOnce({ success: false, error: 'Connection refused' });
+
+    const restrictedCase = makeCase({ state: 'restricted_pending_user_response' });
+    const updatedCase = { ...restrictedCase, state: 'denied_closed' as const };
+
+    const req = new Request('https://api.test/api/age-review/cases/case-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ state: 'denied_closed' }),
+    });
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(makeDbFor(restrictedCase, updatedCase)), corsHeaders);
+    const body = await res.json() as {
+      success: boolean; enforcementComplete: boolean;
+      enforcement: { keycastMinorClear: string; keycastMinorClearError: string; keycast: string };
+      case: { state: string };
+    };
+
+    expect(res.status).toBe(207);
+    expect(body.success).toBe(false);
+    expect(body.enforcementComplete).toBe(false);
+    expect(body.enforcement.keycastMinorClear).toBe('failed');
+    expect(body.enforcement.keycastMinorClearError).toContain('Connection refused');
+    // Other legs unaffected; the flag failure must not mask or be masked.
+    expect(body.enforcement.keycast).toBe('ok');
+    // DB transition still persisted (enforcement remediation is out-of-band).
+    expect(body.case.state).toBe('denied_closed');
+  });
+
+  it('does not clear verified_minor on a restricting transition', async () => {
+    const reviewCase = makeCase({ state: 'under_moderator_review' });
+    const updatedCase = { ...reviewCase, state: 'restricted_pending_user_response' as const };
+
+    const req = new Request('https://api.test/api/age-review/cases/case-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ state: 'restricted_pending_user_response' }),
+    });
+    const res = await handleUpdateAgeReviewCase(req, 'case-1', makeEnv(makeDbFor(reviewCase, updatedCase)), corsHeaders);
+
+    expect(res.status).toBe(200);
+    expect(clearVerifiedMinor).not.toHaveBeenCalled();
+    const body = await res.json() as { enforcement: { keycastMinorClear: string } };
+    expect(body.enforcement.keycastMinorClear).toBe('not_attempted');
   });
 
   it('surfaces a Keycast failure (success:false / 207) but still applies the state transition', async () => {

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -356,24 +356,31 @@ export async function handleUpdateAgeReviewCase(
     keycast = keycastLeg.status;
     keycastError = keycastLeg.error;
 
-    // Clear verified_minor on revoke/deny (issue #147). Compose, don't couple:
-    // the status outcome above stays this side's decision; this leg only lifts
-    // the protected-minor flag so protections release across clients (#174).
-    // Unconditional on the deny/cleared transitions — keycast's clear is an
-    // idempotent no-op for never-minor accounts and only audits real
-    // transitions (keycast#265), so no pre-read of verified_minor is needed.
-    // actor = the case's moderator; a malformed/absent actor is re-validated
-    // and dropped server-side in clearVerifiedMinor (keycast then falls back to
-    // log-only audit). reason distinguishes deny from cleared in the audit row.
+    // Clear verified_minor on the DENY/revoke transition ONLY (issue #147:
+    // "Revoking an approved minor... clears verified_minor"). Compose, don't
+    // couple: the status outcome above stays this side's decision; this leg
+    // only lifts the protected-minor flag so protections release across
+    // clients (#174).
+    //
+    // Deliberately NOT on `cleared`: `cleared` is the favorable outcome and
+    // is overloaded. For a 13-15 consent-verified case it "restores the
+    // account" (age-review-process.md, 13-15 band) — a *confirmed protected
+    // minor* who must KEEP verified_minor. Clearing there would strip
+    // protection from a minor, the worst failure direction on this path. The
+    // 16+ mistaken-flag case also uses `cleared`, where the flag is a no-op;
+    // we cannot distinguish the two from the transition alone, so we leave the
+    // flag untouched on `cleared` (an over-protected mistaken adult is the safe
+    // side). Only deny/revoke removes it. keycast's clear is an idempotent
+    // no-op for never-minor accounts, so no pre-read is needed.
+    //
+    // actor = the case's assigned moderator (best-effort: relay-manager auths
+    // with a shared admin pubkey, so there's no per-actor signal, and
+    // moderator_pubkey is unvalidated on write). A malformed/absent actor is
+    // dropped server-side in clearVerifiedMinor → keycast logs-only.
     const minorClearActor = (updated?.moderator_pubkey ?? existing.moderator_pubkey) ?? undefined;
     const minorClearLeg = await runStatusLeg('Keycast verified_minor clear', () =>
-      deniedCase || clearedCase
-        ? clearVerifiedMinor(
-            existing.pubkey,
-            minorClearActor,
-            deniedCase ? 'age_review_denied' : 'age_review_cleared',
-            env,
-          )
+      deniedCase
+        ? clearVerifiedMinor(existing.pubkey, minorClearActor, 'age_review_denied', env)
         : undefined);
     keycastMinorClear = minorClearLeg.status;
     keycastMinorClearError = minorClearLeg.error;

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -20,7 +20,7 @@ import {
 import { runBulkModeration, type BulkModerateEnv } from './bulk-moderate';
 import { resolveZendeskCreds } from './zendesk-sync';
 import type { BulkAction } from '../../shared/bulk-moderation';
-import { suspendUser, unsuspendUser, banUser, createMinorAccount, type KeycastEnv } from './keycast-client';
+import { suspendUser, unsuspendUser, banUser, clearVerifiedMinor, createMinorAccount, type KeycastEnv } from './keycast-client';
 import { suspendPubkey, unsuspendPubkey, banPubkey, type SecretStoreSecret } from './nip86';
 
 export interface AgeReviewEnv extends BulkModerateEnv, KeycastEnv {
@@ -287,6 +287,8 @@ export async function handleUpdateAgeReviewCase(
   let relayError: string | undefined;
   let keycast: EnforcementLegStatus = 'not_attempted';
   let keycastError: string | undefined;
+  let keycastMinorClear: EnforcementLegStatus = 'not_attempted';
+  let keycastMinorClearError: string | undefined;
 
   // Shared wrapper for the relay and Keycast legs (both resolve to
   // { success, error }). Returns not_attempted when no call applies.
@@ -353,6 +355,27 @@ export async function handleUpdateAgeReviewCase(
       : undefined);
     keycast = keycastLeg.status;
     keycastError = keycastLeg.error;
+
+    // Clear verified_minor on revoke/deny (issue #147). Compose, don't couple:
+    // the status outcome above stays this side's decision; this leg only lifts
+    // the protected-minor flag so protections release across clients (#174).
+    // Unconditional on the deny/cleared transitions — keycast's clear is an
+    // idempotent no-op for never-minor accounts and only audits real
+    // transitions (keycast#265), so no pre-read of verified_minor is needed.
+    // actor = the case's moderator (already validated shape client-side);
+    // reason distinguishes deny from mistaken-approval clear in the audit row.
+    const minorClearActor = (updated?.moderator_pubkey ?? existing.moderator_pubkey) ?? undefined;
+    const minorClearLeg = await runStatusLeg('Keycast verified_minor clear', () =>
+      deniedCase || clearedCase
+        ? clearVerifiedMinor(
+            existing.pubkey,
+            minorClearActor,
+            deniedCase ? 'age_review_denied' : 'age_review_cleared',
+            env,
+          )
+        : undefined);
+    keycastMinorClear = minorClearLeg.status;
+    keycastMinorClearError = minorClearLeg.error;
   }
 
   // A failed critical leg is reported (success:false, HTTP 207) so the
@@ -365,8 +388,12 @@ export async function handleUpdateAgeReviewCase(
   if (!updated) {
     return json({ success: false, error: 'Case not found after update' }, 500, corsHeaders);
   }
-  const enforcement: AgeReviewEnforcement = { relay, relayError, bulk, bulkError, keycast, keycastError };
-  const enforcementComplete = relay !== 'failed' && bulk !== 'failed' && keycast !== 'failed';
+  const enforcement: AgeReviewEnforcement = {
+    relay, relayError, bulk, bulkError, keycast, keycastError,
+    keycastMinorClear, keycastMinorClearError,
+  };
+  const enforcementComplete = relay !== 'failed' && bulk !== 'failed' && keycast !== 'failed'
+    && keycastMinorClear !== 'failed';
   const response: AgeReviewCaseResponse = {
     success: enforcementComplete,
     case: updated,

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -362,8 +362,9 @@ export async function handleUpdateAgeReviewCase(
     // Unconditional on the deny/cleared transitions — keycast's clear is an
     // idempotent no-op for never-minor accounts and only audits real
     // transitions (keycast#265), so no pre-read of verified_minor is needed.
-    // actor = the case's moderator (already validated shape client-side);
-    // reason distinguishes deny from mistaken-approval clear in the audit row.
+    // actor = the case's moderator; a malformed/absent actor is re-validated
+    // and dropped server-side in clearVerifiedMinor (keycast then falls back to
+    // log-only audit). reason distinguishes deny from cleared in the audit row.
     const minorClearActor = (updated?.moderator_pubkey ?? existing.moderator_pubkey) ?? undefined;
     const minorClearLeg = await runStatusLeg('Keycast verified_minor clear', () =>
       deniedCase || clearedCase
@@ -1070,6 +1071,23 @@ export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> 
       }
     } catch (error) {
       console.error(`[age-review] Keycast ban failed for expired case ${row.id}:`, error);
+    }
+
+    // Clear verified_minor on the auto-deny path too (#147): the interactive
+    // deny leg does this; the deadline-expiry auto-deny is the same terminal
+    // outcome with no moderator, so it must not leave a banned account with
+    // its protected-minor flag still set. System-initiated => no actor
+    // (keycast falls back to log-only audit). Idempotent no-op for a
+    // never-minor account. Best-effort, logged on failure.
+    try {
+      const clearResult = await clearVerifiedMinor(row.pubkey, undefined, 'age_review_expired', env);
+      if (clearResult.success) {
+        console.log(`[age-review] Keycast verified_minor clear sent for expired case ${row.id}`);
+      } else {
+        console.error(`[age-review] Keycast verified_minor clear failed for expired case ${row.id}: ${clearResult.error}`);
+      }
+    } catch (error) {
+      console.error(`[age-review] Keycast verified_minor clear failed for expired case ${row.id}:`, error);
     }
 
     // purge the user's events at the relay (one-way) -- the case is closed

--- a/worker/src/keycast-client.test.ts
+++ b/worker/src/keycast-client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest';
-import { suspendUser, unsuspendUser, banUser, getUserStatus, createMinorAccount, type KeycastEnv } from './keycast-client';
+import { suspendUser, unsuspendUser, banUser, clearVerifiedMinor, getUserStatus, createMinorAccount, type KeycastEnv } from './keycast-client';
 
 const VALID_PUBKEY = 'a'.repeat(64);
 
@@ -57,6 +57,60 @@ describe('keycast-client', () => {
       fetchMock.mockRejectedValue(new Error('Connection refused'));
       const result = await suspendUser(VALID_PUBKEY, 'age_review', makeEnv());
       expect(result).toEqual({ success: false, error: expect.stringContaining('Connection refused') });
+    });
+  });
+
+  describe('clearVerifiedMinor', () => {
+    it('sends DELETE to the verified-minor endpoint with actor and reason', async () => {
+      const actor = 'b'.repeat(64);
+      const result = await clearVerifiedMinor(VALID_PUBKEY, actor, 'age_review_denied', makeEnv());
+      expect(result).toEqual({ success: true });
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe(
+        `https://login.test.divine.video/api/admin/users/${VALID_PUBKEY}/verified-minor?actor=${actor}&reason=age_review_denied`,
+      );
+      expect(opts.method).toBe('DELETE');
+      expect(opts.headers['Authorization']).toBe('Bearer test-service-token');
+    });
+
+    it('omits actor and reason when absent (keycast log-only fallback)', async () => {
+      const result = await clearVerifiedMinor(VALID_PUBKEY, undefined, undefined, makeEnv());
+      expect(result).toEqual({ success: true });
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toBe(`https://login.test.divine.video/api/admin/users/${VALID_PUBKEY}/verified-minor`);
+    });
+
+    it('drops a malformed actor instead of failing the clear (keycast 400s on it)', async () => {
+      const result = await clearVerifiedMinor(VALID_PUBKEY, 'not-a-pubkey', 'age_review_denied', makeEnv());
+      expect(result).toEqual({ success: true });
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).not.toContain('actor=');
+      expect(url).toContain('reason=age_review_denied');
+    });
+
+    it('returns success false with status on 4xx', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 401, text: () => Promise.resolve('bad token') });
+      const result = await clearVerifiedMinor(VALID_PUBKEY, undefined, undefined, makeEnv());
+      expect(result).toEqual({ success: false, status: 401, error: expect.stringContaining('401') });
+    });
+
+    it('returns success false on network error without throwing', async () => {
+      fetchMock.mockRejectedValue(new Error('Connection refused'));
+      const result = await clearVerifiedMinor(VALID_PUBKEY, undefined, undefined, makeEnv());
+      expect(result).toEqual({ success: false, error: expect.stringContaining('Connection refused') });
+    });
+
+    it('rejects an invalid target pubkey without calling keycast', async () => {
+      const result = await clearVerifiedMinor('nope', undefined, undefined, makeEnv());
+      expect(result.success).toBe(false);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('reports not configured when env is missing', async () => {
+      const result = await clearVerifiedMinor(VALID_PUBKEY, undefined, undefined, makeEnv({ KEYCAST_URL: undefined }));
+      expect(result).toEqual({ success: false, error: 'not configured' });
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 

--- a/worker/src/keycast-client.ts
+++ b/worker/src/keycast-client.ts
@@ -80,6 +80,71 @@ export async function banUser(pubkey: string, reason: KeycastReason, env: Keycas
   return callKeycast(pubkey, { status: 'banned', reason }, env);
 }
 
+/**
+ * Clear a Keycast account's verified_minor flag (protected-minor revocation,
+ * issue #147; endpoint from keycast#265). Composes with the status calls —
+ * the status outcome stays the caller's decision, this only lifts the flag.
+ * Keycast's clear is an idempotent success no-op on never-minor /
+ * already-cleared accounts and only writes a durable admin_audit_events row
+ * on a real transition, so callers invoke it unconditionally on revoke/deny
+ * without a pre-read. `actor` (moderator hex pubkey) and `reason` feed that
+ * audit row; a malformed actor is dropped (keycast 400s on it, which would
+ * fail the whole clear) so keycast falls back to log-only.
+ */
+export async function clearVerifiedMinor(
+  pubkey: string,
+  actor: string | undefined,
+  reason: string | undefined,
+  env: KeycastEnv,
+): Promise<KeycastResult> {
+  if (!env.KEYCAST_URL || !env.KEYCAST_SERVICE_TOKEN) {
+    return { success: false, error: 'not configured' };
+  }
+
+  if (!HEX_64.test(pubkey)) {
+    return { success: false, error: 'invalid pubkey: must be 64 hex chars' };
+  }
+
+  const token = await resolveToken(env.KEYCAST_SERVICE_TOKEN);
+  if (!token) {
+    return { success: false, error: 'not configured' };
+  }
+
+  const params = new URLSearchParams();
+  if (actor) {
+    if (HEX_64.test(actor)) {
+      params.set('actor', actor);
+    } else {
+      console.warn(`[keycast] dropping malformed actor for verified_minor clear on ${pubkey}; audit falls back to log-only`);
+    }
+  }
+  if (reason) {
+    params.set('reason', reason);
+  }
+  const qs = params.size > 0 ? `?${params.toString()}` : '';
+
+  try {
+    const res = await fetch(`${env.KEYCAST_URL}/api/admin/users/${pubkey}/verified-minor${qs}`, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+      },
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      console.error(`[keycast] verified_minor clear failed for ${pubkey}: ${res.status} ${text}`);
+      return { success: false, status: res.status, error: `${res.status}: ${text}` };
+    }
+
+    return { success: true };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[keycast] verified_minor clear failed for ${pubkey}: ${msg}`);
+    return { success: false, error: msg };
+  }
+}
+
 export interface UserStatusResult {
   success: boolean;
   pubkey?: string;

--- a/worker/src/keycast-client.ts
+++ b/worker/src/keycast-client.ts
@@ -89,12 +89,14 @@ export async function banUser(pubkey: string, reason: KeycastReason, env: Keycas
  * on a real transition, so callers invoke it unconditionally on revoke/deny
  * without a pre-read. `actor` (moderator hex pubkey) and `reason` feed that
  * audit row; a malformed actor is dropped (keycast 400s on it, which would
- * fail the whole clear) so keycast falls back to log-only.
+ * fail the whole clear) so keycast falls back to log-only. Only the
+ * revoke-direction reasons are valid here (age_review_denied / _expired);
+ * `cleared` is deliberately not a clear trigger (see age-review.ts).
  */
 export async function clearVerifiedMinor(
   pubkey: string,
   actor: string | undefined,
-  reason: string | undefined,
+  reason: KeycastReason | undefined,
   env: KeycastEnv,
 ): Promise<KeycastResult> {
   if (!env.KEYCAST_URL || !env.KEYCAST_SERVICE_TOKEN) {


### PR DESCRIPTION
**Ready for review. ⚠️ Merge-gated: do not merge until keycast#280's endpoint (`DELETE /api/admin/users/:pubkey/verified-minor`) is DEPLOYED and live in keycast prod (Cloud Run) — merged ≠ deployed. Until it's live the clear leg 404s and degrades to a graceful HTTP 207 (`enforcementComplete:false`), so nothing hard-breaks; it just isn't wired end to end. Review can proceed now.**

Closes #147. Part of divinevideo/support-trust-safety#173 (protected-minor epic).

Wires the age-review revoke/deny moderator flow to also clear `verified_minor` via keycast's `DELETE /api/admin/users/:pubkey/verified-minor` (keycast#265 / PR keycast#280, now merged), so protections lift end to end when an approved minor is revoked.

## What this does

- New `clearVerifiedMinor(pubkey, actor, reason, env)` in `worker/src/keycast-client.ts`, following the existing client pattern. Malformed/absent actor is dropped server-side so the audit falls back to log-only rather than failing the clear.
- New enforcement leg in the age-review transition handler, composed with the existing relay/bulk/keycast-status legs via `runStatusLeg`.
- **Scope (corrected in review): clears on the DENY/revoke direction ONLY** — interactive `denied_closed` plus the cron deadline-expiry auto-deny. **Not on `cleared`:** `cleared` is the favorable outcome and is overloaded — for a 13-15 consent-verified case it restores a *confirmed protected minor* who must keep `verified_minor` (moderator guide, 13-15 band). Clearing there would strip protection from a minor, so the flag is left intact on `cleared`.
- actor = the case's `moderator_pubkey` (best-effort; relay-manager auths with a shared admin pubkey). reason = `age_review_denied` (interactive) / `age_review_expired` (cron).
- Failure surfaces as `enforcement.keycastMinorClear: 'failed'` + HTTP 207 / `enforcementComplete: false` — never silent.

## Review + tests

- Picky review loop (superpowers): caught + fixed a child-safety regression (the earlier scope cleared on `cleared`); re-review clean, "Ready to merge: Yes".
- Handler tests: deny clears with actor+reason; **cleared does NOT clear** (confirmed minor stays protected); clear failure → 207 with other legs intact; restricting transition → not_attempted; cron auto-deny clears with system actor. Client tests: URL/method/auth shape, actor/reason omission, malformed-actor drop, 4xx, network error, invalid pubkey, unconfigured env.
- **Remote CI green** (test / semantic / CLA all pass). The only failing tests anywhere are 3 pre-existing `bulk-moderate.test.ts` local-env cases that reproduce on pristine main and pass in CI — unrelated to this PR.

Design: `docs/superpowers/specs/2026-07-07-clear-verified-minor-on-revoke-design.md`

## Merge dependency

Built against keycast#280's contract. #280 is **merged**; this PR stays draft until that endpoint is **deployed and live in keycast prod** — until then the clear leg 404s and surfaces gracefully as a 207 ("enforcement incomplete"), it does not hard-break.
