### PR TITLE
fix(age-review): emit snake_case restriction status so the app renders the review screen

### DIFF
--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -802,7 +802,7 @@ describe('handleGetModerationStatus', () => {
     expect(body.restriction.status).toBe('active');
   });
 
-  it('returns restrictedMinorReview when active case exists', async () => {
+  it('returns restricted_minor_review when active case exists', async () => {
     const c = makeCase({ state: 'restricted_pending_user_response' });
     const db = createMockDb([c]);
     // Override first() to return the case for the pubkey query
@@ -817,12 +817,21 @@ describe('handleGetModerationStatus', () => {
     const res = await handleGetModerationStatus(c.pubkey, makeEnv(db), corsHeaders);
     const body = await res.json() as {
       restriction: { status: string };
-      minorReviewCase: { id: string; state: string };
+      minorReviewCase: {
+        id: string;
+        state: string;
+        suspectedAgeBand: string;
+        allowedResolution: string;
+      };
     };
 
-    expect(body.restriction.status).toBe('restrictedMinorReview');
+    // The mobile client keys off snake_case wire values; the whole contract
+    // (top-level status AND the nested enum values) must stay snake_case.
+    expect(body.restriction.status).toBe('restricted_minor_review');
     expect(body.minorReviewCase.id).toBe('case-1');
     expect(body.minorReviewCase.state).toBe('restricted_pending_user_response');
+    expect(body.minorReviewCase.suspectedAgeBand).toBe('age_13_15');
+    expect(body.minorReviewCase.allowedResolution).toBe('parent_video_or_email');
   });
 
   it('returns active for open_reported case (pre-moderator review)', async () => {

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -488,7 +488,7 @@ export async function handleGetModerationStatus(
   }
 
   return json({
-    restriction: { status: 'restrictedMinorReview' },
+    restriction: { status: 'restricted_minor_review' },
     minorReviewCase: {
       id: activeCase.id,
       state: activeCase.state,


### PR DESCRIPTION
## What and why

`/v1/account/moderation-status` emits `restriction.status` as camelCase `restrictedMinorReview`, but the mobile client only accepts snake_case `restricted_minor_review` and falls back to `active` otherwise, so the in-app age-review screen has never rendered for a restricted account. This emits `restricted_minor_review`, matching the client's existing expectation and the endpoint's own (already snake_case) nested fields.

Server-side by design: it reaches already-shipped app builds on deploy; a client change would be App Store gated and wouldn't reach affected users. Not a regression, the two sides shipped with mismatched casing (#67 worker, #3531 mobile) and never matched. Full background in the issue.

## Changes

- `worker/src/age-review.ts`: emit `restricted_minor_review`.
- `worker/src/age-review.test.ts`: assert the snake_case value and lock the rest of the wire contract (`state`, `suspectedAgeBand`, `allowedResolution`) so it can't drift again.

## Testing

- `npm run typecheck` clean
- `npm run test:run` 265 passed
- `npm run test:d1` 16 passed
- Confirmed `divine-web` does not consume this endpoint; `divine-mobile` is the sole consumer and already expects snake_case.

## Residual (follow-up, not in this PR)

Clients predating the age-review screens (#3531) have no screen to render, so some users still need manual outreach. Separate from this contract fix.

Closes #149
