### PR TITLE
fix(age-review): route underage reports into the flow and guard generic suspend/unsuspend

### DIFF
--- a/src/components/AgeReview.tsx
+++ b/src/components/AgeReview.tsx
@@ -1,4 +1,5 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { useAdminApi } from "@/hooks/useAdminApi";
 import { Card } from "@/components/ui/card";
@@ -52,7 +53,18 @@ type FilterMode = 'active' | 'closed' | 'all';
 export function AgeReview() {
   const api = useAdminApi();
   const isMobile = useIsMobile();
-  const [selectedCaseId, setSelectedCaseId] = useState<string | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedCaseId = searchParams.get('case');
+  const pubkeyParam = searchParams.get('pubkey');
+
+  // Case selection lives in the URL (?case=<id>) so a report hand-off can
+  // deep-link straight to a case; ?pubkey=<hex> is resolved to its active case.
+  const setSelectedCaseId = useCallback((id: string | null) => {
+    const next = new URLSearchParams(searchParams);
+    if (id) next.set('case', id); else next.delete('case');
+    next.delete('pubkey');
+    setSearchParams(next, { replace: true });
+  }, [searchParams, setSearchParams]);
   const [filterMode, setFilterMode] = useState<FilterMode>('active');
   const [bandFilter, setBandFilter] = useState<string>('all');
 
@@ -72,7 +84,7 @@ export function AgeReview() {
 
   const filteredCases = data?.cases ?? [];
 
-  const selectedCase = filteredCases.find(c => c.id === selectedCaseId) ?? null;
+  const inFilteredList = filteredCases.find(c => c.id === selectedCaseId) ?? null;
 
   const { data: activeData } = useQuery({
     queryKey: ['age-review-cases', { state: 'active' }],
@@ -80,6 +92,23 @@ export function AgeReview() {
     staleTime: 30_000,
     refetchInterval: 30_000,
   });
+
+  // Fallback fetch so a deep-linked case outside the current filter still opens.
+  const { data: fetchedCaseData } = useQuery({
+    queryKey: ['age-review-case', selectedCaseId],
+    queryFn: () => api.getAgeReviewCase(selectedCaseId!),
+    enabled: !!selectedCaseId && !inFilteredList,
+    staleTime: 30_000,
+  });
+  const selectedCase = inFilteredList ?? fetchedCaseData?.case ?? null;
+
+  // Resolve a ?pubkey= hand-off to that pubkey's active case, then normalize the
+  // URL to ?case=. Active cases are already loaded, so no extra fetch is needed.
+  useEffect(() => {
+    if (!pubkeyParam) return;
+    const match = activeData?.cases?.find(c => c.pubkey === pubkeyParam);
+    if (match) setSelectedCaseId(match.id);
+  }, [pubkeyParam, activeData?.cases, setSelectedCaseId]);
 
   const activeCounts = useMemo(() => {
     if (!activeData?.cases) return { total: 0, urgent: 0 };

--- a/src/components/AgeReview.tsx
+++ b/src/components/AgeReview.tsx
@@ -103,12 +103,27 @@ export function AgeReview() {
   const selectedCase = inFilteredList ?? fetchedCaseData?.case ?? null;
 
   // Resolve a ?pubkey= hand-off to that pubkey's active case, then normalize the
-  // URL to ?case=. Active cases are already loaded, so no extra fetch is needed.
+  // URL to ?case=. Prefer the already-loaded active list; fall back to a direct
+  // lookup for a case created just before the 30s-cached list refetches.
+  const pubkeyMatch = pubkeyParam
+    ? activeData?.cases?.find(c => c.pubkey === pubkeyParam) ?? null
+    : null;
+  const { data: pubkeyLookup, isFetching: pubkeyFetching } = useQuery({
+    queryKey: ['age-review-active-case', pubkeyParam],
+    queryFn: () => api.getActiveAgeReviewCase(pubkeyParam!),
+    enabled: !!pubkeyParam && !pubkeyMatch,
+    staleTime: 30_000,
+  });
+  const pubkeyResolvedId = pubkeyMatch?.id ?? pubkeyLookup?.case?.id ?? null;
   useEffect(() => {
-    if (!pubkeyParam) return;
-    const match = activeData?.cases?.find(c => c.pubkey === pubkeyParam);
-    if (match) setSelectedCaseId(match.id);
-  }, [pubkeyParam, activeData?.cases, setSelectedCaseId]);
+    if (pubkeyParam && pubkeyResolvedId) setSelectedCaseId(pubkeyResolvedId);
+  }, [pubkeyParam, pubkeyResolvedId, setSelectedCaseId]);
+
+  // A ?pubkey= that resolves to no active case (already cleared/verified, or
+  // still being created) gets an explicit empty state, not a blank panel — but
+  // only once the active list has loaded and the fallback lookup has settled.
+  const pubkeyUnresolved = !!pubkeyParam && !pubkeyResolvedId
+    && activeData !== undefined && !pubkeyFetching;
 
   const activeCounts = useMemo(() => {
     if (!activeData?.cases) return { total: 0, urgent: 0 };
@@ -248,6 +263,10 @@ export function AgeReview() {
 
   const detailContent = selectedCase ? (
     <AgeReviewDetail caseData={selectedCase} />
+  ) : pubkeyUnresolved ? (
+    <div className="flex items-center justify-center h-full p-6 text-center text-sm text-muted-foreground">
+      No active age-review case for this account. It may already be resolved (for example a verified minor), or the case is still being created — refresh in a moment.
+    </div>
   ) : (
     <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
       Select a case to view details
@@ -258,7 +277,7 @@ export function AgeReview() {
     return (
       <Card className="h-full flex flex-col overflow-hidden">
         {listContent}
-        <Sheet open={!!selectedCase} onOpenChange={() => setSelectedCaseId(null)}>
+        <Sheet open={!!selectedCase || pubkeyUnresolved} onOpenChange={() => setSelectedCaseId(null)}>
           <SheetContent side="bottom" className="h-[80vh] p-0">
             {detailContent}
           </SheetContent>

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -1092,6 +1092,7 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
               <UserActions
                 pubkey={context.reportedUser.pubkey}
                 context="report"
+                reportCategory={category}
                 isBanned={isUserBanned ?? undefined}
                 isSuspended={moderationStatus.isUserSuspended ?? undefined}
                 onActionComplete={handleActionComplete}

--- a/src/components/UserActions.test.tsx
+++ b/src/components/UserActions.test.tsx
@@ -75,6 +75,32 @@ describe('UserActions', () => {
     expect(screen.getByRole('button', { name: /Ban User/i })).toBeInTheDocument();
   });
 
+  it('hides the bulk content actions for an NS-underageUser report (enforcement runs through the case)', () => {
+    renderWithProvider(<UserActions pubkey={PUBKEY} context="report" reportCategory="NS-underageUser" />);
+    expect(screen.queryByRole('button', { name: /Age Restrict All/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Delete All Content/i })).not.toBeInTheDocument();
+    // The hand-off and the Ban escape hatch remain.
+    expect(screen.getByRole('button', { name: /Handle in Age Review/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Ban User/i })).toBeInTheDocument();
+  });
+
+  it('keeps the bulk content actions for a non-underage report', () => {
+    renderWithProvider(<UserActions pubkey={PUBKEY} context="report" reportCategory="NS-spam" />);
+    expect(screen.getByRole('button', { name: /Age Restrict All/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Delete All Content/i })).toBeInTheDocument();
+  });
+
+  it('routes to Age Review when a bulk action is guard-blocked (age_review_active)', async () => {
+    api.bulkModerate.mockRejectedValue(new ApiError('under age review', 409, 'Conflict', 'age_review_active'));
+    renderWithProvider(<UserActions pubkey={PUBKEY} />);
+    fireEvent.click(screen.getByRole('button', { name: /Age Restrict All/i }));
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith(`/age-review?pubkey=${PUBKEY}`));
+    // Routed, not surfaced as a failure.
+    expect(toast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Bulk action failed' }),
+    );
+  });
+
   it('navigates to the age-review flow when the hand-off is clicked', () => {
     renderWithProvider(<UserActions pubkey={PUBKEY} context="report" reportCategory="NS-underageUser" />);
     fireEvent.click(screen.getByRole('button', { name: /Handle in Age Review/i }));

--- a/src/components/UserActions.test.tsx
+++ b/src/components/UserActions.test.tsx
@@ -17,6 +17,12 @@ const api = vi.hoisted(() => ({
 }));
 const toast = vi.hoisted(() => vi.fn());
 
+const navigate = vi.hoisted(() => vi.fn());
+vi.mock('react-router-dom', async (orig) => ({
+  ...(await orig<typeof import('react-router-dom')>()),
+  useNavigate: () => navigate,
+}));
+
 vi.mock('@/hooks/useAdminApi', () => ({ useAdminApi: () => api }));
 vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast }) }));
 
@@ -56,6 +62,26 @@ describe('UserActions', () => {
     expect(screen.getByRole('button', { name: /Ban User/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Age Restrict All/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Delete All Content/i })).toBeInTheDocument();
+  });
+
+  it('shows the Age Review hand-off (not Suspend) for an NS-underageUser report', () => {
+    renderWithProvider(<UserActions pubkey={PUBKEY} context="report" reportCategory="NS-underageUser" />);
+    expect(screen.getByRole('button', { name: /Handle in Age Review/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Suspend User/i })).not.toBeInTheDocument();
+    // Ban stays available as the severe-action escape hatch.
+    expect(screen.getByRole('button', { name: /Ban User/i })).toBeInTheDocument();
+  });
+
+  it('navigates to the age-review flow when the hand-off is clicked', () => {
+    renderWithProvider(<UserActions pubkey={PUBKEY} context="report" reportCategory="NS-underageUser" />);
+    fireEvent.click(screen.getByRole('button', { name: /Handle in Age Review/i }));
+    expect(navigate).toHaveBeenCalledWith(`/age-review?pubkey=${PUBKEY}`);
+  });
+
+  it('keeps the generic Suspend for a non-underage report', () => {
+    renderWithProvider(<UserActions pubkey={PUBKEY} context="report" reportCategory="NS-spam" />);
+    expect(screen.getByRole('button', { name: /Suspend User/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Handle in Age Review/i })).not.toBeInTheDocument();
   });
 
   it('renders unsuspend and ban when user is suspended', () => {

--- a/src/components/UserActions.test.tsx
+++ b/src/components/UserActions.test.tsx
@@ -14,6 +14,7 @@ const api = vi.hoisted(() => ({
   unbanPubkey: vi.fn(),
   suspendPubkey: vi.fn(),
   unsuspendPubkey: vi.fn(),
+  getActiveAgeReviewCase: vi.fn(),
   logDecision: vi.fn(),
 }));
 const toast = vi.hoisted(() => vi.fn());
@@ -44,6 +45,7 @@ beforeEach(() => {
   api.unbanPubkey.mockResolvedValue({ success: true });
   api.suspendPubkey.mockResolvedValue({ success: true });
   api.unsuspendPubkey.mockResolvedValue({ success: true });
+  api.getActiveAgeReviewCase.mockResolvedValue({ success: true, case: null });
   api.logDecision.mockResolvedValue(undefined);
 });
 
@@ -90,6 +92,13 @@ describe('UserActions', () => {
     renderWithProvider(<UserActions pubkey={PUBKEY} />);
     fireEvent.click(screen.getByRole('button', { name: /Suspend User/i }));
     await waitFor(() => expect(navigate).toHaveBeenCalledWith(`/age-review?pubkey=${PUBKEY}`));
+  });
+
+  it('warns about evidence when banning an account with an open age-review case', async () => {
+    api.getActiveAgeReviewCase.mockResolvedValue({ success: true, case: { id: 'case-1' } });
+    renderWithProvider(<UserActions pubkey={PUBKEY} />);
+    fireEvent.click(screen.getByRole('button', { name: /Ban User/i }));
+    expect(await screen.findByText(/under age review/i)).toBeInTheDocument();
   });
 
   it('renders unsuspend and ban when user is suspended', () => {

--- a/src/components/UserActions.test.tsx
+++ b/src/components/UserActions.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { UserActions } from './UserActions';
+import { ApiError } from '@/lib/adminApi';
 
 // Stable mocks so async-flow tests can control enqueue + status polling and
 // assert on the same fn instances.
@@ -82,6 +83,13 @@ describe('UserActions', () => {
     renderWithProvider(<UserActions pubkey={PUBKEY} context="report" reportCategory="NS-spam" />);
     expect(screen.getByRole('button', { name: /Suspend User/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Handle in Age Review/i })).not.toBeInTheDocument();
+  });
+
+  it('routes to Age Review when a bare suspend is guard-blocked (age_review_active)', async () => {
+    api.suspendPubkey.mockRejectedValue(new ApiError('under age review', 409, 'Conflict', 'age_review_active'));
+    renderWithProvider(<UserActions pubkey={PUBKEY} />);
+    fireEvent.click(screen.getByRole('button', { name: /Suspend User/i }));
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith(`/age-review?pubkey=${PUBKEY}`));
   });
 
   it('renders unsuspend and ban when user is suspended', () => {

--- a/src/components/UserActions.test.tsx
+++ b/src/components/UserActions.test.tsx
@@ -101,6 +101,21 @@ describe('UserActions', () => {
     );
   });
 
+  it('routes a guard-blocked Delete All (confirm-dialog path) to Age Review too', async () => {
+    // Same enqueue.onError as the direct path, but through ConfirmDialog's
+    // startAsync: the rejection must not surface as a failure or crash the
+    // dialog — the moderator lands on the case.
+    api.bulkModerate.mockRejectedValue(new ApiError('under age review', 409, 'Conflict', 'age_review_active'));
+    renderWithProvider(<UserActions pubkey={PUBKEY} />);
+    fireEvent.click(screen.getByRole('button', { name: /Delete All Content/i }));
+    const dialog = screen.getByRole('alertdialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Confirm Delete' }));
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith(`/age-review?pubkey=${PUBKEY}`));
+    expect(toast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Bulk action failed' }),
+    );
+  });
+
   it('navigates to the age-review flow when the hand-off is clicked', () => {
     renderWithProvider(<UserActions pubkey={PUBKEY} context="report" reportCategory="NS-underageUser" />);
     fireEvent.click(screen.getByRole('button', { name: /Handle in Age Review/i }));

--- a/src/components/UserActions.tsx
+++ b/src/components/UserActions.tsx
@@ -31,12 +31,17 @@ export function UserActions({
   const api = useAdminApi();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const showBulkActions = context !== 'age-review';
 
   // An under-16 report must be worked through the Age Review flow, not the
   // generic Suspend/Unsuspend (which would enforce without advancing the case).
   // Exact category only: CSAM/child-safety are a separate, non-reversible path.
   const isUnderageReport = context === 'report' && reportCategory === UNDERAGE_REPORT_CATEGORY;
+
+  // Bulk content actions are hidden in the age-review context (the case screen
+  // has its own enforcement controls) and for an underage report (content
+  // enforcement runs through the case; the /api/bulk-moderate guard refuses it
+  // on an open case regardless). Ban stays as the severe-action escape hatch.
+  const showBulkActions = context !== 'age-review' && !isUnderageReport;
 
   // The worker guard refuses a bare suspend/unsuspend on an account under age
   // review (any context). Route the moderator to the case instead of surfacing
@@ -197,6 +202,10 @@ export function UserActions({
       onActionComplete?.();
     },
     onError: (error) => {
+      // A guard-refused enqueue (open age-review case) routes to the case, for
+      // the contexts where the buttons still render (Users tab, non-underage
+      // report on an account that also has an open case).
+      if (routeToAgeReviewIfGuarded(error)) return;
       // Covers both enqueue failure and a persistent status-poll failure
       // (the job may have started; error.message carries the specific reason).
       toast({ title: 'Bulk action failed', description: error.message, variant: 'destructive' });
@@ -229,7 +238,7 @@ export function UserActions({
                   Handle in Age Review
                 </Button>
               </TooltipTrigger>
-              <TooltipContent><p>This account was reported as under 16. Suspend and unsuspend run through the Age Review flow so the case, content age-restriction, and deadline stay in sync.</p></TooltipContent>
+              <TooltipContent><p>This account was reported as under 16. Account and content enforcement run through the Age Review flow so the case, content age-restriction, and deadline stay in sync.</p></TooltipContent>
             </Tooltip>
           ) : isSuspended ? (
             <Tooltip>

--- a/src/components/UserActions.tsx
+++ b/src/components/UserActions.tsx
@@ -5,11 +5,13 @@ import { useToast } from '@/hooks/useToast';
 import { useAdminApi } from '@/hooks/useAdminApi';
 import { useBulkModerateJob } from '@/hooks/useBulkModerateJob';
 import { ConfirmDialog } from './ConfirmDialog';
-import { UserX, UserCheck, ShieldAlert, Trash2, Pause, Play } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { UserX, UserCheck, ShieldAlert, Trash2, Pause, Play, ArrowRight } from 'lucide-react';
 
 interface UserActionsProps {
   pubkey: string;
   context?: 'report' | 'age-review' | 'users';
+  reportCategory?: string;
   isBanned?: boolean;
   isSuspended?: boolean;
   onActionComplete?: () => void;
@@ -18,6 +20,7 @@ interface UserActionsProps {
 export function UserActions({
   pubkey,
   context = 'users',
+  reportCategory,
   isBanned = false,
   isSuspended = false,
   onActionComplete,
@@ -25,7 +28,13 @@ export function UserActions({
   const { toast } = useToast();
   const api = useAdminApi();
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const showBulkActions = context !== 'age-review';
+
+  // An under-16 report must be worked through the Age Review flow, not the
+  // generic Suspend/Unsuspend (which would enforce without advancing the case).
+  // Exact category only: CSAM/child-safety are a separate, non-reversible path.
+  const isUnderageReport = context === 'report' && reportCategory === 'NS-underageUser';
 
   // Audit logging is a non-critical side effect. Fire-and-forget so a slow or
   // hung /api/decisions write can never stall the moderation action or leave the
@@ -180,7 +189,18 @@ export function UserActions({
         </Tooltip>
       ) : (
         <>
-          {isSuspended ? (
+          {isUnderageReport ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="outline" className="border-blue-500 text-blue-600 hover:bg-blue-50"
+                  onClick={() => navigate(`/age-review?pubkey=${pubkey}`)} disabled={anyPending}>
+                  <ArrowRight className="h-4 w-4 mr-1" />
+                  Handle in Age Review
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent><p>This account was reported as under 16. Suspend and unsuspend run through the Age Review flow so the case, content age-restriction, and deadline stay in sync.</p></TooltipContent>
+            </Tooltip>
+          ) : isSuspended ? (
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button variant="outline" className="border-green-500 text-green-600 hover:bg-green-50"

--- a/src/components/UserActions.tsx
+++ b/src/components/UserActions.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useToast } from '@/hooks/useToast';
@@ -48,6 +48,18 @@ export function UserActions({
     }
     return false;
   };
+
+  // Whether this account has an open age-review case, which changes the Ban
+  // copy (a ban purges content the review may still need). For an underage
+  // report we already know one exists; otherwise look it up. Ban is only shown
+  // when the account is not banned, so skip the lookup once banned.
+  const { data: activeAgeCase } = useQuery({
+    queryKey: ['age-review-active-case', pubkey],
+    queryFn: () => api.getActiveAgeReviewCase(pubkey),
+    enabled: !isBanned && !isUnderageReport,
+    staleTime: 30_000,
+  });
+  const hasActiveAgeCase = isUnderageReport || !!activeAgeCase?.case;
 
   // Audit logging is a non-critical side effect. Fire-and-forget so a slow or
   // hung /api/decisions write can never stall the moderation action or leave the
@@ -247,7 +259,9 @@ export function UserActions({
               </Button>
             }
             title="Ban User"
-            summary="Permanently ban this user and purge all their content from the relay. This destroys events across 16+ tables and cannot be fully reversed — unbanning allows new posts but does not restore purged content."
+            summary={hasActiveAgeCase
+              ? "This account is under age review. Banning purges all their content across 16+ tables and cannot be fully reversed, which destroys evidence the review may need. Resolve through the Age Review flow unless this is a separate severe violation (e.g. CSAM) that requires an immediate ban."
+              : "Permanently ban this user and purge all their content from the relay. This destroys events across 16+ tables and cannot be fully reversed — unbanning allows new posts but does not restore purged content."}
             confirmLabel="Ban User"
             pendingLabel="Banning..."
             onConfirm={async () => { await banUserMutation.mutateAsync(); }}

--- a/src/components/UserActions.tsx
+++ b/src/components/UserActions.tsx
@@ -4,6 +4,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { useToast } from '@/hooks/useToast';
 import { useAdminApi } from '@/hooks/useAdminApi';
 import { ApiError } from '@/lib/adminApi';
+import { UNDERAGE_REPORT_CATEGORY } from '@/lib/constants';
 import { useBulkModerateJob } from '@/hooks/useBulkModerateJob';
 import { ConfirmDialog } from './ConfirmDialog';
 import { useNavigate } from 'react-router-dom';
@@ -35,7 +36,7 @@ export function UserActions({
   // An under-16 report must be worked through the Age Review flow, not the
   // generic Suspend/Unsuspend (which would enforce without advancing the case).
   // Exact category only: CSAM/child-safety are a separate, non-reversible path.
-  const isUnderageReport = context === 'report' && reportCategory === 'NS-underageUser';
+  const isUnderageReport = context === 'report' && reportCategory === UNDERAGE_REPORT_CATEGORY;
 
   // The worker guard refuses a bare suspend/unsuspend on an account under age
   // review (any context). Route the moderator to the case instead of surfacing
@@ -43,7 +44,7 @@ export function UserActions({
   const routeToAgeReviewIfGuarded = (error: Error): boolean => {
     if (error instanceof ApiError && error.code === 'age_review_active') {
       toast({ title: 'This account is under age review', description: 'Opening it in the Age Review flow.' });
-      navigate(`/age-review?pubkey=${pubkey}`);
+      navigate(`/age-review?pubkey=${encodeURIComponent(pubkey)}`);
       return true;
     }
     return false;
@@ -51,12 +52,15 @@ export function UserActions({
 
   // Whether this account has an open age-review case, which changes the Ban
   // copy (a ban purges content the review may still need). For an underage
-  // report we already know one exists; otherwise look it up. Ban is only shown
-  // when the account is not banned, so skip the lookup once banned.
+  // report we already know one exists; otherwise look it up. Skipped once
+  // banned (no Ban button) and in the age-review context (already on the case).
+  // If the lookup errors we read only `data`, so hasActiveAgeCase stays false
+  // and the ban falls back to the generic copy — a non-critical enrichment that
+  // degrades quietly rather than blocking the action.
   const { data: activeAgeCase } = useQuery({
     queryKey: ['age-review-active-case', pubkey],
     queryFn: () => api.getActiveAgeReviewCase(pubkey),
-    enabled: !isBanned && !isUnderageReport,
+    enabled: !isBanned && !isUnderageReport && context !== 'age-review',
     staleTime: 30_000,
   });
   const hasActiveAgeCase = isUnderageReport || !!activeAgeCase?.case;
@@ -220,7 +224,7 @@ export function UserActions({
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button variant="outline" className="border-blue-500 text-blue-600 hover:bg-blue-50"
-                  onClick={() => navigate(`/age-review?pubkey=${pubkey}`)} disabled={anyPending}>
+                  onClick={() => navigate(`/age-review?pubkey=${encodeURIComponent(pubkey)}`)} disabled={anyPending}>
                   <ArrowRight className="h-4 w-4 mr-1" />
                   Handle in Age Review
                 </Button>

--- a/src/components/UserActions.tsx
+++ b/src/components/UserActions.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useToast } from '@/hooks/useToast';
 import { useAdminApi } from '@/hooks/useAdminApi';
+import { ApiError } from '@/lib/adminApi';
 import { useBulkModerateJob } from '@/hooks/useBulkModerateJob';
 import { ConfirmDialog } from './ConfirmDialog';
 import { useNavigate } from 'react-router-dom';
@@ -35,6 +36,18 @@ export function UserActions({
   // generic Suspend/Unsuspend (which would enforce without advancing the case).
   // Exact category only: CSAM/child-safety are a separate, non-reversible path.
   const isUnderageReport = context === 'report' && reportCategory === 'NS-underageUser';
+
+  // The worker guard refuses a bare suspend/unsuspend on an account under age
+  // review (any context). Route the moderator to the case instead of surfacing
+  // a raw error, so enforcement can't drift from the case out of band.
+  const routeToAgeReviewIfGuarded = (error: Error): boolean => {
+    if (error instanceof ApiError && error.code === 'age_review_active') {
+      toast({ title: 'This account is under age review', description: 'Opening it in the Age Review flow.' });
+      navigate(`/age-review?pubkey=${pubkey}`);
+      return true;
+    }
+    return false;
+  };
 
   // Audit logging is a non-critical side effect. Fire-and-forget so a slow or
   // hung /api/decisions write can never stall the moderation action or leave the
@@ -75,6 +88,7 @@ export function UserActions({
       onActionComplete?.();
     },
     onError: (error: Error) => {
+      if (routeToAgeReviewIfGuarded(error)) return;
       toast({ title: 'Failed to suspend user', description: error.message, variant: 'destructive' });
     },
   });
@@ -94,6 +108,7 @@ export function UserActions({
       onActionComplete?.();
     },
     onError: (error: Error) => {
+      if (routeToAgeReviewIfGuarded(error)) return;
       toast({ title: 'Failed to unsuspend user', description: error.message, variant: 'destructive' });
     },
   });

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -23,6 +23,7 @@ import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { UserDisplayName } from "@/components/UserIdentifier";
 import { CopyableId } from "@/components/CopyableId";
 import type { BannedPubkeyEntry } from "@/lib/adminApi";
+import { ApiError } from "@/lib/adminApi";
 
 interface UserManagementProps {
   selectedPubkey?: string;
@@ -235,7 +236,12 @@ export function UserManagement({ selectedPubkey }: UserManagementProps) {
       invalidateUserQueries();
       toast({ title: "User unsuspended successfully" });
     },
-    onError: (error: Error) => {
+    onError: (error: Error, variables: { pubkey: string }) => {
+      if (error instanceof ApiError && error.code === 'age_review_active') {
+        toast({ title: "This account is under age review", description: "Opening it in the Age Review flow." });
+        navigate(`/age-review?pubkey=${variables.pubkey}`);
+        return;
+      }
       toast({
         title: "Failed to unsuspend user",
         description: error.message,

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -239,7 +239,7 @@ export function UserManagement({ selectedPubkey }: UserManagementProps) {
     onError: (error: Error, variables: { pubkey: string }) => {
       if (error instanceof ApiError && error.code === 'age_review_active') {
         toast({ title: "This account is under age review", description: "Opening it in the Age Review flow." });
-        navigate(`/age-review?pubkey=${variables.pubkey}`);
+        navigate(`/age-review?pubkey=${encodeURIComponent(variables.pubkey)}`);
         return;
       }
       toast({

--- a/src/hooks/useAdminApi.ts
+++ b/src/hooks/useAdminApi.ts
@@ -129,6 +129,8 @@ export function useAdminApi() {
       adminApi.getAgeReviewFunnel(apiUrl, ageBand),
     getAgeReviewCase: (caseId: string) =>
       adminApi.getAgeReviewCase(apiUrl, caseId),
+    getActiveAgeReviewCase: (pubkey: string) =>
+      adminApi.getActiveAgeReviewCase(apiUrl, pubkey),
     getAccountStatus: (pubkey: string) =>
       adminApi.getAccountStatus(apiUrl, pubkey),
     updateAgeReviewCase: (caseId: string, updates: Record<string, unknown>) =>

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -1046,12 +1046,17 @@ export async function getAgeReviewCase(
   return apiRequest<AgeReviewCaseResponse>(apiUrl, `/api/age-review/cases/${caseId}`, 'GET');
 }
 
+export interface ActiveAgeReviewCaseResponse {
+  success: boolean;
+  case: import('../../shared/age-review').AgeReviewCase | null;
+}
+
 /** Active (non-terminal) age-review case for a pubkey, or null. Read-only. */
 export async function getActiveAgeReviewCase(
   apiUrl: string,
   pubkey: string,
-): Promise<{ success: boolean; case: import('../../shared/age-review').AgeReviewCase | null }> {
-  return apiRequest(apiUrl, `/api/age-review/active-case?pubkey=${pubkey}`, 'GET');
+): Promise<ActiveAgeReviewCaseResponse> {
+  return apiRequest<ActiveAgeReviewCaseResponse>(apiUrl, `/api/age-review/active-case?pubkey=${encodeURIComponent(pubkey)}`, 'GET');
 }
 
 /** Keycast-backed account status for moderators: surfaces the durable

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -267,10 +267,20 @@ export async function callRelayRpc<T = unknown>(
   }, label, { mutates });
 
   if (!response.ok) {
+    // Parse a structured error body so callers can branch on `code`
+    // (e.g. the age-review guard's 'age_review_active') instead of an opaque
+    // "HTTP 409:" message. Non-JSON bodies fall back to the status line.
+    let parsed: { error?: string; code?: string } | undefined;
+    try {
+      parsed = await response.json() as typeof parsed;
+    } catch {
+      // empty or non-JSON body; keep the status-line fallback
+    }
     throw new ApiError(
-      `HTTP ${response.status}: ${response.statusText}`,
+      parsed?.error || `HTTP ${response.status}: ${response.statusText}`,
       response.status,
-      response.statusText
+      response.statusText,
+      parsed?.code,
     );
   }
 

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -1046,6 +1046,14 @@ export async function getAgeReviewCase(
   return apiRequest<AgeReviewCaseResponse>(apiUrl, `/api/age-review/cases/${caseId}`, 'GET');
 }
 
+/** Active (non-terminal) age-review case for a pubkey, or null. Read-only. */
+export async function getActiveAgeReviewCase(
+  apiUrl: string,
+  pubkey: string,
+): Promise<{ success: boolean; case: import('../../shared/age-review').AgeReviewCase | null }> {
+  return apiRequest(apiUrl, `/api/age-review/active-case?pubkey=${pubkey}`, 'GET');
+}
+
 /** Keycast-backed account status for moderators: surfaces the durable
  * `verified_minor` flag (approved protected minor 13-15). A keycast blip returns
  * `{ success: false }` (HTTP 200), so callers degrade to "status unavailable". */

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -64,6 +64,11 @@ export const HIGH_PRIORITY_CATEGORIES = [
   'NS-underageUser', 'NS-childSafety',
 ];
 
+// The exact report category that opens an age-review case (ReportWatcher gates
+// on this same literal). Distinct from HIGH_PRIORITY_CATEGORIES: CSAM /
+// child-safety are a separate, non-reversible path, not age review.
+export const UNDERAGE_REPORT_CATEGORY = 'NS-underageUser';
+
 // Helper to get label with fallback
 export function getCategoryLabel(category: string): string {
   return CATEGORY_LABELS[category] || category;

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -171,6 +171,14 @@ describe('handleGetActiveAgeReviewCase', () => {
     expect(body.case).toBeNull();
   });
 
+  it("returns null when the pubkey's only case is terminal (cleared)", async () => {
+    const c = makeCase({ state: 'cleared' });
+    const res = await handleGetActiveAgeReviewCase(c.pubkey, makeEnv(createMockDb([c])), corsHeaders);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean; case: AgeReviewCase | null };
+    expect(body.case).toBeNull();
+  });
+
   it('rejects an invalid pubkey', async () => {
     const res = await handleGetActiveAgeReviewCase('not-a-pubkey', makeEnv(createMockDb([])), corsHeaders);
     expect(res.status).toBe(400);

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   handleGetAgeReviewCases,
   handleGetAgeReviewCase,
+  handleGetActiveAgeReviewCase,
   handleUpdateAgeReviewCase,
   handleGetModerationStatus,
   handleParentContact,
@@ -147,6 +148,32 @@ describe('handleGetAgeReviewCase', () => {
     const db = createMockDb([]);
     const res = await handleGetAgeReviewCase('nonexistent', makeEnv(db), corsHeaders);
     expect(res.status).toBe(404);
+  });
+});
+
+// -- handleGetActiveAgeReviewCase ---------------------------------------------
+
+describe('handleGetActiveAgeReviewCase', () => {
+  it('returns the active case for a pubkey', async () => {
+    const c = makeCase({ state: 'restricted_pending_user_response' });
+    const res = await handleGetActiveAgeReviewCase(c.pubkey, makeEnv(createMockDb([c])), corsHeaders);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean; case: AgeReviewCase | null };
+    expect(body.success).toBe(true);
+    expect(body.case?.id).toBe(c.id);
+  });
+
+  it('returns a null case when the pubkey has no active case', async () => {
+    const res = await handleGetActiveAgeReviewCase('a'.repeat(64), makeEnv(createMockDb([])), corsHeaders);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean; case: AgeReviewCase | null };
+    expect(body.success).toBe(true);
+    expect(body.case).toBeNull();
+  });
+
+  it('rejects an invalid pubkey', async () => {
+    const res = await handleGetActiveAgeReviewCase('not-a-pubkey', makeEnv(createMockDb([])), corsHeaders);
+    expect(res.status).toBe(400);
   });
 });
 

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -127,10 +127,14 @@ export async function handleGetActiveAgeReviewCase(
   env: AgeReviewEnv,
   corsHeaders: Record<string, string>,
 ): Promise<Response> {
-  if (!env.DB) return json({ success: false, error: 'Database not configured' }, 500, corsHeaders);
-  if (!/^[0-9a-f]{64}$/i.test(pubkey)) {
+  // Pubkeys are canonical lowercase hex and the stored column is case-sensitive,
+  // so validate case-sensitively (a mixed-case value would pass a case-
+  // insensitive check but miss the lowercased row). Validate before the DB
+  // check so a malformed pubkey is a 400, not a 500.
+  if (!/^[0-9a-f]{64}$/.test(pubkey)) {
     return json({ success: false, error: 'Invalid pubkey' }, 400, corsHeaders);
   }
+  if (!env.DB) return json({ success: false, error: 'Database not configured' }, 500, corsHeaders);
   const row = await getActiveAgeReviewCase(pubkey, env);
   return json({ success: true, case: row }, 200, corsHeaders);
 }

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -116,6 +116,43 @@ export async function getActiveAgeReviewCase(
 }
 
 /**
+ * Refuse-and-route guard shared by the interactive enforcement endpoints
+ * (relay-rpc suspend/unsuspend, bulk-moderate enqueue): if the pubkey has an
+ * open (non-terminal) age-review case, returns a structured 409
+ * (`age_review_active` + caseId/state) that the frontend turns into a redirect
+ * to the case; returns null when nothing blocks the action.
+ *
+ * Fails open: the guard is a safety net (the report hand-off is the primary
+ * path), so a transient D1 error must not block core moderation — log and
+ * proceed. A malformed pubkey also skips the guard (no point querying; the
+ * caller's own validation produces the 400). Age-review's own enforcement
+ * calls the nip86 helpers / runBulkModeration directly, so it never hits the
+ * guarded endpoints.
+ */
+export async function ageReviewActiveGuard(
+  pubkey: string,
+  env: AgeReviewEnv,
+  corsHeaders: Record<string, string>,
+  error: string,
+): Promise<Response | null> {
+  if (!/^[0-9a-f]{64}$/.test(pubkey) || !env.DB) return null;
+  let activeCase: AgeReviewCase | null = null;
+  try {
+    activeCase = await getActiveAgeReviewCase(pubkey, env);
+  } catch (err) {
+    console.error('[ageReviewActiveGuard] lookup failed; proceeding:', err);
+  }
+  if (!activeCase) return null;
+  return json({
+    success: false,
+    error,
+    code: 'age_review_active',
+    caseId: activeCase.id,
+    state: activeCase.state,
+  }, 409, corsHeaders);
+}
+
+/**
  * GET /api/age-review/active-case?pubkey=<hex>
  *
  * Returns the active (non-terminal) age-review case for a pubkey, or null.

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -97,6 +97,44 @@ export async function handleGetAgeReviewCase(
   return json({ success: true, case: row }, 200, corsHeaders);
 }
 
+/**
+ * Returns the single active (non-terminal) age-review case for a pubkey, or
+ * null. ReportWatcher guarantees at most one active case per pubkey, so this is
+ * unambiguous. Shared by the by-pubkey lookup endpoint and the relay-RPC guard.
+ */
+export async function getActiveAgeReviewCase(
+  pubkey: string,
+  env: AgeReviewEnv,
+): Promise<AgeReviewCase | null> {
+  if (!env.DB) return null;
+  const row = await env.DB.prepare(`
+    SELECT * FROM age_review_cases
+    WHERE pubkey = ? AND state NOT IN (${TERMINAL_STATES.map(() => '?').join(',')})
+    LIMIT 1
+  `).bind(pubkey, ...TERMINAL_STATES).first<AgeReviewCase>();
+  return row ?? null;
+}
+
+/**
+ * GET /api/age-review/active-case?pubkey=<hex>
+ *
+ * Returns the active (non-terminal) age-review case for a pubkey, or null.
+ * Read-only. Powers the report hand-off deep-link, the Ban warning, and the
+ * relay-RPC guard-response rendering.
+ */
+export async function handleGetActiveAgeReviewCase(
+  pubkey: string,
+  env: AgeReviewEnv,
+  corsHeaders: Record<string, string>,
+): Promise<Response> {
+  if (!env.DB) return json({ success: false, error: 'Database not configured' }, 500, corsHeaders);
+  if (!/^[0-9a-f]{64}$/i.test(pubkey)) {
+    return json({ success: false, error: 'Invalid pubkey' }, 400, corsHeaders);
+  }
+  const row = await getActiveAgeReviewCase(pubkey, env);
+  return json({ success: true, case: row }, 200, corsHeaders);
+}
+
 export async function handleUpdateAgeReviewCase(
   request: Request,
   caseId: string,

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -743,6 +743,7 @@ describe('bulk-moderate age-review guard', () => {
     const body = await response.json() as { code: string; caseId: string; state: string };
     expect(body.code).toBe('age_review_active');
     expect(body.caseId).toBe('case-b1');
+    expect(body.state).toBe('restricted_pending_user_response');
     // The guard short-circuits before any job is created or enqueued.
     expect(executed.some((sql) => sql.includes('INSERT INTO bulk_jobs'))).toBe(false);
     expect(send).not.toHaveBeenCalled();

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -683,3 +683,109 @@ describe('GET /api/account-status/:pubkey', () => {
     expect(response.status).toBe(401);
   });
 });
+
+describe('bulk-moderate age-review guard', () => {
+  const VALID_PUBKEY = 'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234';
+
+  // Generic mock DB: tolerates ensureSchemaOnce's DDL and the enqueue INSERT,
+  // records every executed statement's SQL, and answers the guard's
+  // age_review_cases lookup with `caseRow` only when it is non-terminal
+  // (mirroring the WHERE state NOT IN (cleared, denied_closed) filter).
+  // `lookupThrows` simulates a transient D1 failure on that lookup only.
+  function makeBulkEnv(
+    caseRow: { id: string; state: string } | null,
+    opts: { lookupThrows?: boolean } = {},
+  ) {
+    const active = caseRow && !['cleared', 'denied_closed'].includes(caseRow.state) ? caseRow : null;
+    const executed: string[] = [];
+    const send = vi.fn(async () => {});
+    const statement = (sql: string) => ({
+      bind: () => statement(sql),
+      run: async () => { executed.push(sql); return { success: true, meta: { changes: 1 } }; },
+      first: async () => {
+        if (sql.includes('age_review_cases')) {
+          if (opts.lookupThrows) throw new Error('D1 unavailable');
+          return active;
+        }
+        return null;
+      },
+      all: async () => ({ results: [] }),
+    });
+    const env = {
+      ALLOWED_ORIGINS: 'https://app.divine.video',
+      RELAY_URL: 'wss://relay.divine.video',
+      ADMIN_API_KEY: 'test-admin-key',
+      NOSTR_NSEC: TEST_NSEC,
+      DB: { prepare: statement },
+      BULK_QUEUE: { send },
+    } as never;
+    return { env, executed, send };
+  }
+
+  function enqueueRequest(body: object): Request {
+    return new Request('https://api-relay-prod.divine.video/api/bulk-moderate', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Admin-Key': 'test-admin-key',
+        Origin: 'https://app.divine.video',
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it('refuses a bulk action when the target has an active age-review case', async () => {
+    const { env, executed, send } = makeBulkEnv({ id: 'case-b1', state: 'restricted_pending_user_response' });
+    const response = await worker.fetch(
+      enqueueRequest({ pubkey: VALID_PUBKEY, action: 'age-restrict-all' }), env, ctx,
+    );
+    expect(response.status).toBe(409);
+    const body = await response.json() as { code: string; caseId: string; state: string };
+    expect(body.code).toBe('age_review_active');
+    expect(body.caseId).toBe('case-b1');
+    // The guard short-circuits before any job is created or enqueued.
+    expect(executed.some((sql) => sql.includes('INSERT INTO bulk_jobs'))).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('refuses delete-all the same way (no destructive job on an open case)', async () => {
+    const { env, send } = makeBulkEnv({ id: 'case-b2', state: 'submitted_for_review' });
+    const response = await worker.fetch(
+      enqueueRequest({ pubkey: VALID_PUBKEY, action: 'delete-all' }), env, ctx,
+    );
+    expect(response.status).toBe(409);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('proceeds when the only age-review case is terminal (cleared)', async () => {
+    const { env, send } = makeBulkEnv({ id: 'case-b3', state: 'cleared' });
+    const response = await worker.fetch(
+      enqueueRequest({ pubkey: VALID_PUBKEY, action: 'age-restrict-all' }), env, ctx,
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json() as { success: boolean; jobId: string };
+    expect(body.success).toBe(true);
+    expect(body.jobId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails open when the case lookup throws (transient D1 error must not block moderation)', async () => {
+    const { env, send } = makeBulkEnv({ id: 'case-b4', state: 'restricted_pending_user_response' }, { lookupThrows: true });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const response = await worker.fetch(
+      enqueueRequest({ pubkey: VALID_PUBKEY, action: 'age-restrict-all' }), env, ctx,
+    );
+    expect(response.status).toBe(200);
+    expect(send).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
+  });
+
+  it('leaves validation to the handler: malformed pubkey is a 400, not a guard error', async () => {
+    const { env, send } = makeBulkEnv({ id: 'case-b5', state: 'restricted_pending_user_response' });
+    const response = await worker.fetch(
+      enqueueRequest({ pubkey: 'not-a-pubkey', action: 'age-restrict-all' }), env, ctx,
+    );
+    expect(response.status).toBe(400);
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -227,8 +227,11 @@ describe('relay-rpc account-state side effects', () => {
     } as never;
   }
 
-  // Same env with a DB whose active-case lookup returns `caseRow` (or null).
-  function makeAccountStateEnvWithDb(caseRow: unknown) {
+  // Same env with a DB whose active-case lookup returns `caseRow` only when it
+  // is non-terminal, mirroring the guard query's WHERE state NOT IN
+  // (cleared, denied_closed). A terminal or null row resolves to null.
+  function makeAccountStateEnvWithDb(caseRow: { id: string; state: string } | null) {
+    const active = caseRow && !['cleared', 'denied_closed'].includes(caseRow.state) ? caseRow : null;
     return {
       ALLOWED_ORIGINS: 'https://app.divine.video',
       RELAY_URL: 'wss://relay.divine.video',
@@ -239,7 +242,7 @@ describe('relay-rpc account-state side effects', () => {
       KEYCAST_URL: 'https://login.divine.video',
       KEYCAST_SERVICE_TOKEN: 'keycast-token',
       DB: {
-        prepare: () => ({ bind: () => ({ first: async () => caseRow }) }),
+        prepare: () => ({ bind: () => ({ first: async () => active }) }),
       },
     } as never;
   }
@@ -433,6 +436,20 @@ describe('relay-rpc account-state side effects', () => {
     const kc = keycastCalls(fetchSpy);
     expect(kc).toHaveLength(1);
     expect(kc[0].status).toBe('suspended');
+
+    fetchSpy.mockRestore();
+  });
+
+  it('suspendpubkey proceeds when the only age-review case is terminal (cleared)', async () => {
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+    const env = makeAccountStateEnvWithDb({ id: 'case-x', state: 'cleared' });
+
+    const response = await callRelayRpc('suspendpubkey', [VALID_PUBKEY, 'policy'], env, testCtx);
+    expect(response.status).toBe(200);
+    await drain(waitUntil);
+    expect(keycastCalls(fetchSpy)).toHaveLength(1);
 
     fetchSpy.mockRestore();
   });

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -227,6 +227,23 @@ describe('relay-rpc account-state side effects', () => {
     } as never;
   }
 
+  // Same env with a DB whose active-case lookup returns `caseRow` (or null).
+  function makeAccountStateEnvWithDb(caseRow: unknown) {
+    return {
+      ALLOWED_ORIGINS: 'https://app.divine.video',
+      RELAY_URL: 'wss://relay.divine.video',
+      ADMIN_API_KEY: 'test-admin-key',
+      MODERATION_ADMIN_URL: 'https://moderation-api.divine.video',
+      SERVICE_API_TOKEN: 'test-token',
+      NOSTR_NSEC: TEST_NSEC,
+      KEYCAST_URL: 'https://login.divine.video',
+      KEYCAST_SERVICE_TOKEN: 'keycast-token',
+      DB: {
+        prepare: () => ({ bind: () => ({ first: async () => caseRow }) }),
+      },
+    } as never;
+  }
+
   // Routes a mocked fetch by URL so each backend can be asserted independently.
   function makeFetchSpy() {
     return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
@@ -365,6 +382,73 @@ describe('relay-rpc account-state side effects', () => {
     expect(kc[0].status).toBe('active');
     // unban lifts the Keycast ban but sends no DM (restore-on-unban DM tracked in #96)
     expect(await notifyBodies(fetchSpy)).toHaveLength(0);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('suspendpubkey is refused when the target has an active age-review case', async () => {
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+    const env = makeAccountStateEnvWithDb({ id: 'case-1', state: 'restricted_pending_user_response' });
+
+    const response = await callRelayRpc('suspendpubkey', [VALID_PUBKEY, 'policy'], env, testCtx);
+    expect(response.status).toBe(409);
+    const body = await response.json() as { code: string; caseId: string; state: string };
+    expect(body.code).toBe('age_review_active');
+    expect(body.caseId).toBe('case-1');
+
+    // The guard short-circuits before any enforcement side effect.
+    await drain(waitUntil);
+    expect(keycastCalls(fetchSpy)).toHaveLength(0);
+    expect(await notifyBodies(fetchSpy)).toHaveLength(0);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('unsuspendpubkey is refused when the target has an active age-review case', async () => {
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+    const env = makeAccountStateEnvWithDb({ id: 'case-2', state: 'restricted_pending_parental_consent' });
+
+    const response = await callRelayRpc('unsuspendpubkey', [VALID_PUBKEY], env, testCtx);
+    expect(response.status).toBe(409);
+    const body = await response.json() as { code: string };
+    expect(body.code).toBe('age_review_active');
+    expect(keycastCalls(fetchSpy)).toHaveLength(0);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('suspendpubkey proceeds normally when the target has no active age-review case', async () => {
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+    const env = makeAccountStateEnvWithDb(null);
+
+    const response = await callRelayRpc('suspendpubkey', [VALID_PUBKEY, 'policy'], env, testCtx);
+    expect(response.status).toBe(200);
+    await drain(waitUntil);
+    const kc = keycastCalls(fetchSpy);
+    expect(kc).toHaveLength(1);
+    expect(kc[0].status).toBe('suspended');
+
+    fetchSpy.mockRestore();
+  });
+
+  it('banpubkey is not gated by an active age-review case (severe-action escape hatch)', async () => {
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+    const env = makeAccountStateEnvWithDb({ id: 'case-3', state: 'restricted_pending_user_response' });
+
+    const response = await callRelayRpc('banpubkey', [VALID_PUBKEY, 'csam'], env, testCtx);
+    expect(response.status).toBe(200);
+    await drain(waitUntil);
+    const kc = keycastCalls(fetchSpy);
+    expect(kc).toHaveLength(1);
+    expect(kc[0].status).toBe('banned');
 
     fetchSpy.mockRestore();
   });

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -17,6 +17,7 @@ import {
   handleGetAgeReviewCases,
   handleGetAgeReviewCase,
   handleGetActiveAgeReviewCase,
+  getActiveAgeReviewCase,
   handleGetAgeReviewFunnel,
   handleUpdateAgeReviewCase,
   handleCreateMinorAccount,
@@ -941,6 +942,31 @@ async function handleRelayRpc(
 
   if (!body.method) {
     return jsonResponse({ success: false, error: 'Missing method' }, 400, corsHeaders);
+  }
+
+  // Age-review guard: a bare suspend/unsuspend on a pubkey with an open
+  // (non-terminal) age-review case must not half-enforce (Suspend orphans the
+  // case) or silently lift the hold (Unsuspend skips verification). Refuse and
+  // route the moderator to the case; Restrict/Clear live in the age-review flow.
+  // Age-review's own enforcement calls the nip86 helpers directly, and internal
+  // moderation/bulk callers use ban*/unban* only, so neither reaches this guard.
+  if (body.method === 'suspendpubkey' || body.method === 'unsuspendpubkey') {
+    const target = body.params?.[0] ? String(body.params[0]) : '';
+    if (target && env.DB) {
+      const activeCase = await getActiveAgeReviewCase(target, env);
+      if (activeCase) {
+        return new Response(JSON.stringify({
+          success: false,
+          error: 'This account is under age review. Restrict or clear it from the Age Review flow.',
+          code: 'age_review_active',
+          caseId: activeCase.id,
+          state: activeCase.state,
+        }), {
+          status: 409,
+          headers: { 'Content-Type': 'application/json', ...corsHeaders },
+        });
+      }
+    }
   }
 
   // Use shared NIP-86 RPC utility

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -528,7 +528,13 @@ export default {
         // imposed, delete-all destroys evidence the review may need). Refuse
         // and route to the case; Ban remains the severe-action escape hatch.
         // Peeks at the body on a clone so malformed/invalid requests still get
-        // the handler's own 400s.
+        // the handler's own 400s. Two accepted edges: (1) the guard runs
+        // before action validation, so a well-formed pubkey with an open case
+        // gets this 409 even if the action name is invalid — accurate, since
+        // every bulk action on that account is refused; (2) the check is
+        // enqueue-time only — a case opened while a chunked job is already
+        // draining does not abort it (aborting mid-job would leave
+        // half-applied state; the job was legitimate when it started).
         let peeked: { pubkey?: string } | undefined;
         try {
           peeked = await request.clone().json() as { pubkey?: string };

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -953,7 +953,16 @@ async function handleRelayRpc(
   if (body.method === 'suspendpubkey' || body.method === 'unsuspendpubkey') {
     const target = body.params?.[0] ? String(body.params[0]) : '';
     if (target && env.DB) {
-      const activeCase = await getActiveAgeReviewCase(target, env);
+      // Fail open: this guard is a safety net (the report hand-off is the
+      // primary path), so a transient D1 error must not block core moderation.
+      // On lookup failure we log and proceed rather than 500 the suspend. This
+      // matches the !env.DB branch above, which also proceeds.
+      let activeCase = null;
+      try {
+        activeCase = await getActiveAgeReviewCase(target, env);
+      } catch (err) {
+        console.error('[handleRelayRpc] age-review guard lookup failed; proceeding:', err);
+      }
       if (activeCase) {
         return new Response(JSON.stringify({
           success: false,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -16,6 +16,7 @@ import { suspendUser, unsuspendUser, banUser } from './keycast-client';
 import {
   handleGetAgeReviewCases,
   handleGetAgeReviewCase,
+  handleGetActiveAgeReviewCase,
   handleGetAgeReviewFunnel,
   handleUpdateAgeReviewCase,
   handleCreateMinorAccount,
@@ -558,6 +559,11 @@ export default {
       if (path === '/api/age-review/cases' && request.method === 'GET') {
         if (env.DB) await ensureSchemaOnce(env.DB);
         return handleGetAgeReviewCases(request, env, corsHeaders);
+      }
+      if (path === '/api/age-review/active-case' && request.method === 'GET') {
+        if (env.DB) await ensureSchemaOnce(env.DB);
+        const pubkey = new URL(request.url).searchParams.get('pubkey') || '';
+        return handleGetActiveAgeReviewCase(pubkey, env, corsHeaders);
       }
       if (path.startsWith('/api/age-review/cases/') && request.method === 'GET') {
         if (env.DB) await ensureSchemaOnce(env.DB);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -17,7 +17,7 @@ import {
   handleGetAgeReviewCases,
   handleGetAgeReviewCase,
   handleGetActiveAgeReviewCase,
-  getActiveAgeReviewCase,
+  ageReviewActiveGuard,
   handleGetAgeReviewFunnel,
   handleUpdateAgeReviewCase,
   handleCreateMinorAccount,
@@ -522,6 +522,22 @@ export default {
       // Bulk moderation (server-side iteration for batch operations)
       if (path === '/api/bulk-moderate' && request.method === 'POST') {
         if (env.DB) await ensureSchemaOnce(env.DB);
+        // Age-review guard: bulk content actions on an account with an open
+        // case must not run out of band (age-restrict half-enforces without
+        // advancing the case, un-age-restrict lifts restrictions the case
+        // imposed, delete-all destroys evidence the review may need). Refuse
+        // and route to the case; Ban remains the severe-action escape hatch.
+        // Peeks at the body on a clone so malformed/invalid requests still get
+        // the handler's own 400s.
+        let peeked: { pubkey?: string } | undefined;
+        try {
+          peeked = await request.clone().json() as { pubkey?: string };
+        } catch { /* not JSON; the handler returns the 400 */ }
+        if (typeof peeked?.pubkey === 'string') {
+          const guarded = await ageReviewActiveGuard(peeked.pubkey, env, corsHeaders,
+            'This account is under age review. Content enforcement runs through the Age Review flow.');
+          if (guarded) return guarded;
+        }
         return handleBulkModerateEnqueue(request, env, corsHeaders);
       }
 
@@ -952,30 +968,9 @@ async function handleRelayRpc(
   // moderation/bulk callers use ban*/unban* only, so neither reaches this guard.
   if (body.method === 'suspendpubkey' || body.method === 'unsuspendpubkey') {
     const target = body.params?.[0] ? String(body.params[0]) : '';
-    if (target && env.DB) {
-      // Fail open: this guard is a safety net (the report hand-off is the
-      // primary path), so a transient D1 error must not block core moderation.
-      // On lookup failure we log and proceed rather than 500 the suspend. This
-      // matches the !env.DB branch above, which also proceeds.
-      let activeCase = null;
-      try {
-        activeCase = await getActiveAgeReviewCase(target, env);
-      } catch (err) {
-        console.error('[handleRelayRpc] age-review guard lookup failed; proceeding:', err);
-      }
-      if (activeCase) {
-        return new Response(JSON.stringify({
-          success: false,
-          error: 'This account is under age review. Restrict or clear it from the Age Review flow.',
-          code: 'age_review_active',
-          caseId: activeCase.id,
-          state: activeCase.state,
-        }), {
-          status: 409,
-          headers: { 'Content-Type': 'application/json', ...corsHeaders },
-        });
-      }
-    }
+    const guarded = await ageReviewActiveGuard(target, env, corsHeaders,
+      'This account is under age review. Restrict or clear it from the Age Review flow.');
+    if (guarded) return guarded;
   }
 
   // Use shared NIP-86 RPC utility


### PR DESCRIPTION
## What and why

An `NS-underageUser` report shows up in the report queue with the same generic Suspend / Unsuspend / Ban panel every report gets. Using the generic **Suspend** there enforces at the relay but never advances the age-review case, so the case is orphaned (stays `open_reported`), the app reports the user `active`, media is hidden but not age-restricted, and no tracking ticket is created. The generic **Unsuspend** has no age-case check, so it can lift a suspected-minor hold with no verification. This routes moderators into the Age Review flow and guards the generic actions so enforcement can't drift from the case.

Closes #151. Independent of the casing fix (#149 / PR #150).

## How it works

- **Report hand-off:** on an `NS-underageUser` report (that exact category, not the CSAM/high-priority bundle), the Suspend/Unsuspend controls are replaced with "Handle in Age Review", which deep-links to the case, and the bulk content actions (Age Restrict All / Delete All Content) are hidden — content enforcement runs through the case. Ban stays, with an evidence-preservation warning when an open case exists. If `?pubkey=` resolves to no active case (e.g. an already-cleared verified minor), the moderator gets an explicit empty state, not a blank panel.
- **Worker guard:** a bare `suspendpubkey`/`unsuspendpubkey` on a pubkey with an open (non-terminal) age-review case is refused with a structured `age_review_active` response (caseId + state). The same refusal now covers `/api/bulk-moderate` (bulk age-restrict / un-age-restrict / delete-all), so the Users tab and direct API calls can't drift content enforcement from the case either; both guards share one helper so the contract can't diverge. It informs and routes; it does not auto-translate the action into a case transition. Scoped to the interactive path — age-review's own enforcement calls the nip86 helpers and `runBulkModeration` directly, and internal moderation callers use `ban*`/`unban*` only. The lookup fails open on a transient DB error (logs + proceeds) so it can't block core moderation. The bulk check is enqueue-time only: a case opened while an already-legitimate chunked job is draining does not abort it (documented in the route comment).
- **Guard-response routing:** any context (Users tab, a non-underage report on an account that also has an open case) that hits either guard — suspend/unsuspend or a bulk action — routes the moderator to the case instead of showing a raw error.
- **Deep-link:** case selection is URL-driven (`?case=`); `?pubkey=` resolves to the active case (from the loaded list, or a by-pubkey fallback fetch for a just-created case), with a fallback fetch so a case outside the current filter still opens.

## Commits (each independently reviewable)

1. read-only by-pubkey active-case lookup endpoint
2. worker guard on bare suspend/unsuspend
3. `NS-underageUser` report hand-off
4. URL-driven case selection + deep-link resolution
5. route guard-blocked suspend/unsuspend to the case
6. warn before banning an account under age review
7. review follow-up: guard fails open on DB error; validate pubkey before the DB check; terminal-state test coverage
8. review follow-up: explicit empty state for `?pubkey=` with no active case; polish (shared category constant, param encoding, ban-lookup gating, named response type)
9. review follow-up: route bulk content actions through the case — hide the bulk buttons on an underage report, refuse `/api/bulk-moderate` on an open case (shared fail-open guard helper), and route the refusal to the case
10. review follow-up: pin the bulk-guard contract edges (409 `state` field, Delete All confirm-dialog path, documented accepted guard edges)

## Testing

- Worker: typecheck clean; `test:run` 279 passed; `test:d1` 16 passed (endpoint + guard + terminal-state + bulk-guard tests).
- Frontend: tsc clean; eslint clean; vitest 157 passed; `vite build` clean (hand-off, guard-routing, Ban-warning, bulk-hide, bulk-guard-routing tests).
- Three picky code-review passes (backend + frontend + the bulk-guard follow-up), all findings resolved.

## Out of scope

- In-app screen casing fix (#149 / PR #150).
- `AGE_REVIEW_RESTRICTED` user DM backstop (deferred).
- Moderator-initiable parent outreach (dropped; user self-serve is intentional).
- Mid-job re-check for a case opened while a chunked bulk job is draining (accepted edge, documented at the route).
- Lowercasing/normalizing a mixed-case pubkey before the guard lookup (pre-existing behavior; worth verifying relay-side case handling separately).
