### PR TITLE
feat(minor-safety): surface protected-minor protections in the age-review view

### DIFF
--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
@@ -338,7 +338,7 @@ describe('AgeReviewDetail', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('lists the applicable protections when verified_minor is true', async () => {
+  it('lists only shipped protections under "apply to this account" (adult lock, not the DM restriction)', async () => {
     getAccountStatus.mockResolvedValue({
       success: true,
       verified_minor: true,
@@ -347,21 +347,32 @@ describe('AgeReviewDetail', () => {
 
     renderDetail(makeCase());
 
-    expect(
-      await screen.findByText(/protections that apply to this account/i)
-    ).toBeInTheDocument();
-    // Content lock (#175): forced-hidden adult content + disabled 18+ toggle.
-    expect(screen.getByText(/adult content is hidden/i)).toBeInTheDocument();
-    expect(screen.getByText(/18\+ visibility toggle is disabled/i)).toBeInTheDocument();
-    // DM restriction (#176): pinned official accounts only (named by their
-    // canonical NIP-05 handles, not just impersonable display names), both
-    // directions, and honestly labeled as still rolling out until the client
-    // releases ship it.
-    expect(screen.getByText(/Divine HQ/)).toBeInTheDocument();
-    expect(screen.getByText(/_@divinehq\.divine\.video/)).toBeInTheDocument();
-    expect(screen.getByText(/moderation@divine\.video/)).toBeInTheDocument();
-    expect(screen.getByText(/blocked on send and hidden on receive/i)).toBeInTheDocument();
-    expect(screen.getByText(/rolling out/i)).toBeInTheDocument();
+    // Content lock (#175, shipped): forced-hidden adult content + disabled
+    // 18+ toggle — inside the applied-protections section.
+    const appliedHeading = await screen.findByText(/protections that apply to this account/i);
+    const appliedSection = appliedHeading.closest('div') as HTMLElement;
+    expect(within(appliedSection).getByText(/adult content is hidden/i)).toBeInTheDocument();
+    expect(within(appliedSection).getByText(/18\+ visibility toggle is disabled/i)).toBeInTheDocument();
+    // The DM restriction (#176) is not enforced by any released client yet,
+    // so it must NOT sit under the applied-protections heading.
+    expect(within(appliedSection).queryByText(/DM restriction/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the DM restriction in a separate rolling-out section, not as an applied protection', async () => {
+    getAccountStatus.mockResolvedValue({ success: true, verified_minor: true });
+
+    renderDetail(makeCase());
+
+    // Rolling-out section (#176): its heading carries the not-yet-enforced
+    // framing, and the row names the pinned accounts by canonical NIP-05
+    // handle (display names are impersonable), both directions.
+    const rolloutHeading = await screen.findByText(/rolling out/i);
+    expect(rolloutHeading).toHaveTextContent(/not yet enforced by released apps/i);
+    const rolloutSection = rolloutHeading.closest('div') as HTMLElement;
+    expect(within(rolloutSection).getByText(/DM restriction/i)).toBeInTheDocument();
+    expect(within(rolloutSection).getByText(/_@divinehq\.divine\.video/)).toBeInTheDocument();
+    expect(within(rolloutSection).getByText(/moderation@divine\.video/)).toBeInTheDocument();
+    expect(within(rolloutSection).getByText(/blocked on send and hidden on receive/i)).toBeInTheDocument();
   });
 
   it('frames the protections as policy-derived, not per-device confirmed', async () => {
@@ -390,6 +401,7 @@ describe('AgeReviewDetail', () => {
     expect(
       screen.queryByText(/protections that apply to this account/i)
     ).not.toBeInTheDocument();
+    expect(screen.queryByText(/rolling out/i)).not.toBeInTheDocument();
   });
 
   it('does not show the protections block when the account status is unavailable', async () => {
@@ -405,6 +417,7 @@ describe('AgeReviewDetail', () => {
     expect(
       screen.queryByText(/protections that apply to this account/i)
     ).not.toBeInTheDocument();
+    expect(screen.queryByText(/rolling out/i)).not.toBeInTheDocument();
   });
 
   it('shows status-unavailable when the account-status query rejects', async () => {

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -31,10 +31,6 @@ vi.mock('@/hooks/useAuthor', () => ({
   useAuthor: () => ({ data: undefined, isLoading: false }),
 }));
 
-vi.mock('@/hooks/useToast', () => ({
-  useToast: () => ({ toast }),
-}));
-
 function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
   return {
     id: 'case-1',
@@ -316,9 +312,11 @@ describe('AgeReviewDetail', () => {
   it('does not show the protected-minor badge when verified_minor is false', async () => {
     getAccountStatus.mockResolvedValue({ success: true, verified_minor: false });
 
-    renderDetail(makeCase());
+    const { queryClient } = renderDetail(makeCase());
 
-    await waitFor(() => expect(getAccountStatus).toHaveBeenCalled());
+    // Wait for query settlement, not just the fetch call — asserting against a
+    // still-loading tree would pass even if the gating were broken.
+    await waitFor(() => expect(queryClient.isFetching()).toBe(0));
     expect(
       screen.queryByText(/approved protected minor/i)
     ).not.toBeInTheDocument();

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -366,7 +366,7 @@ describe('AgeReviewDetail', () => {
     // Rolling-out section (#176): its heading carries the not-yet-enforced
     // framing, and the row names the pinned accounts by canonical NIP-05
     // handle (display names are impersonable), both directions.
-    const rolloutHeading = await screen.findByText(/rolling out/i);
+    const rolloutHeading = await screen.findByText(/rolling out \(not yet enforced/i);
     expect(rolloutHeading).toHaveTextContent(/not yet enforced by released apps/i);
     const rolloutSection = rolloutHeading.closest('div') as HTMLElement;
     expect(within(rolloutSection).getByText(/DM restriction/i)).toBeInTheDocument();
@@ -401,7 +401,7 @@ describe('AgeReviewDetail', () => {
     expect(
       screen.queryByText(/protections that apply to this account/i)
     ).not.toBeInTheDocument();
-    expect(screen.queryByText(/rolling out/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/rolling out \(not yet enforced/i)).not.toBeInTheDocument();
   });
 
   it('does not show the protections block when the account status is unavailable', async () => {
@@ -417,7 +417,7 @@ describe('AgeReviewDetail', () => {
     expect(
       screen.queryByText(/protections that apply to this account/i)
     ).not.toBeInTheDocument();
-    expect(screen.queryByText(/rolling out/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/rolling out \(not yet enforced/i)).not.toBeInTheDocument();
   });
 
   it('shows status-unavailable when the account-status query rejects', async () => {

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -71,11 +71,14 @@ function renderDetail(caseData: AgeReviewCase) {
     },
   });
 
-  return render(
+  const result = render(
     <QueryClientProvider client={queryClient}>
       <AgeReviewDetail caseData={caseData} />
     </QueryClientProvider>
   );
+  // Expose the client so absence tests can await query settlement instead of
+  // asserting against a possibly still-loading tree (vacuous pass).
+  return { ...result, queryClient };
 }
 
 describe('AgeReviewDetail', () => {
@@ -334,6 +337,75 @@ describe('AgeReviewDetail', () => {
     ).toBeInTheDocument();
     expect(
       screen.queryByText(/approved protected minor/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('lists the applicable protections when verified_minor is true', async () => {
+    getAccountStatus.mockResolvedValue({
+      success: true,
+      verified_minor: true,
+      verified_minor_at: '2026-06-30T12:00:00Z',
+    });
+
+    renderDetail(makeCase());
+
+    expect(
+      await screen.findByText(/protections that apply to this account/i)
+    ).toBeInTheDocument();
+    // Content lock (#175): forced-hidden adult content + disabled 18+ toggle.
+    expect(screen.getByText(/adult content is hidden/i)).toBeInTheDocument();
+    expect(screen.getByText(/18\+ visibility toggle is disabled/i)).toBeInTheDocument();
+    // DM restriction (#176): pinned official accounts only (named by their
+    // canonical NIP-05 handles, not just impersonable display names), both
+    // directions, and honestly labeled as still rolling out until the client
+    // releases ship it.
+    expect(screen.getByText(/Divine HQ/)).toBeInTheDocument();
+    expect(screen.getByText(/_@divinehq\.divine\.video/)).toBeInTheDocument();
+    expect(screen.getByText(/moderation@divine\.video/)).toBeInTheDocument();
+    expect(screen.getByText(/blocked on send and hidden on receive/i)).toBeInTheDocument();
+    expect(screen.getByText(/rolling out/i)).toBeInTheDocument();
+  });
+
+  it('frames the protections as policy-derived, not per-device confirmed', async () => {
+    getAccountStatus.mockResolvedValue({ success: true, verified_minor: true });
+
+    renderDetail(makeCase());
+
+    // The whole point of the honest framing: enforced by the apps per policy,
+    // never asserted as observed on the user's device.
+    expect(
+      await screen.findByText(/enforced client-side by the Divine apps/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/not confirmed per device/i)
+    ).toBeInTheDocument();
+  });
+
+  it('does not show the protections block when verified_minor is false', async () => {
+    getAccountStatus.mockResolvedValue({ success: true, verified_minor: false });
+
+    const { queryClient } = renderDetail(makeCase());
+
+    // Wait for query settlement, not just the fetch call — asserting against a
+    // still-loading tree would pass even if the gating were broken.
+    await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+    expect(
+      screen.queryByText(/protections that apply to this account/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not show the protections block when the account status is unavailable', async () => {
+    // A keycast blip must not read as "protected": the badge branch already
+    // shows "status unavailable"; the protections list must stay absent too.
+    getAccountStatus.mockResolvedValue({ success: false });
+
+    renderDetail(makeCase());
+
+    expect(
+      await screen.findByText(/protected-minor status unavailable/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/protections that apply to this account/i)
     ).not.toBeInTheDocument();
   });
 

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -26,6 +26,9 @@ import {
   AlertTriangle,
   Loader2,
   ExternalLink,
+  ShieldCheck,
+  EyeOff,
+  MessageSquareLock,
 } from "lucide-react";
 import { CopyableId } from "@/components/CopyableId";
 import { UserIdentifier } from "@/components/UserIdentifier";
@@ -203,6 +206,41 @@ export function AgeReviewDetail({ caseData: c }: Props) {
               </span>
             ) : null}
           </div>
+
+          {/* Protections that apply to an approved protected minor (#143).
+              POLICY-DERIVED from verified_minor: these are client-enforced
+              (the relay can't attribute NIP-17 DMs, and the content lock is
+              in-app), so there is no per-device signal to observe. We state
+              what policy applies and who enforces it — never "confirmed on
+              their device", which would be false assurance. */}
+          {accountStatus?.verified_minor ? (
+            <div className="rounded-md border p-2.5 space-y-1.5 text-xs">
+              <h4 className="flex items-center gap-1.5 font-medium">
+                <ShieldCheck className="h-3.5 w-3.5 text-emerald-600" />
+                Protections that apply to this account
+              </h4>
+              <div className="flex items-start gap-1.5 text-muted-foreground">
+                <EyeOff className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                <span>
+                  Adult content lock: adult content is hidden and the 18+ visibility toggle is disabled, so they cannot re-enable it.
+                </span>
+              </div>
+              {/* TODO(divinevideo/support-trust-safety#176): drop the
+                  "rolling out" caveat once the DM restriction ships in
+                  released mobile + web builds. Listing it without the caveat
+                  before then would assert a protection no released client
+                  enforces — the false assurance this block must never give. */}
+              <div className="flex items-start gap-1.5 text-muted-foreground">
+                <MessageSquareLock className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                <span>
+                  DM restriction (rolling out; not yet in released app versions): DMs limited to the pinned official accounts, Divine HQ (_@divinehq.divine.video) and Divine Moderation (moderation@divine.video); everything else is blocked on send and hidden on receive.
+                </span>
+              </div>
+              <div className="text-muted-foreground/80">
+                Derived from the approved protected-minor status above; enforced client-side by the Divine apps on supported versions. Not confirmed per device.
+              </div>
+            </div>
+          ) : null}
 
           {/* Deadline */}
           {!isTerminal && daysRemaining != null && (

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -214,30 +214,41 @@ export function AgeReviewDetail({ caseData: c }: Props) {
               what policy applies and who enforces it — never "confirmed on
               their device", which would be false assurance. */}
           {accountStatus?.verified_minor ? (
-            <div className="rounded-md border p-2.5 space-y-1.5 text-xs">
-              <h4 className="flex items-center gap-1.5 font-medium">
-                <ShieldCheck className="h-3.5 w-3.5 text-emerald-600" />
-                Protections that apply to this account
-              </h4>
-              <div className="flex items-start gap-1.5 text-muted-foreground">
-                <EyeOff className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-                <span>
-                  Adult content lock: adult content is hidden and the 18+ visibility toggle is disabled, so they cannot re-enable it.
-                </span>
+            <div className="rounded-md border p-2.5 space-y-2 text-xs">
+              {/* Shipped protections only. A row under this heading is read as
+                  protecting the teen TODAY, so nothing rollout-only may live
+                  here regardless of caveats — the heading's claim wins. */}
+              <div className="space-y-1.5">
+                <h4 className="flex items-center gap-1.5 font-medium">
+                  <ShieldCheck className="h-3.5 w-3.5 text-emerald-600" />
+                  Protections that apply to this account
+                </h4>
+                <div className="flex items-start gap-1.5 text-muted-foreground">
+                  <EyeOff className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                  <span>
+                    Adult content lock: adult content is hidden and the 18+ visibility toggle is disabled, so they cannot re-enable it.
+                  </span>
+                </div>
+                <div className="text-muted-foreground/80">
+                  Derived from the approved protected-minor status above; enforced client-side by the Divine apps on supported versions. Not confirmed per device.
+                </div>
               </div>
-              {/* TODO(divinevideo/support-trust-safety#176): drop the
-                  "rolling out" caveat once the DM restriction ships in
-                  released mobile + web builds. Listing it without the caveat
-                  before then would assert a protection no released client
-                  enforces — the false assurance this block must never give. */}
-              <div className="flex items-start gap-1.5 text-muted-foreground">
-                <MessageSquareLock className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-                <span>
-                  DM restriction (rolling out; not yet in released app versions): DMs limited to the pinned official accounts, Divine HQ (_@divinehq.divine.video) and Divine Moderation (moderation@divine.video); everything else is blocked on send and hidden on receive.
-                </span>
-              </div>
-              <div className="text-muted-foreground/80">
-                Derived from the approved protected-minor status above; enforced client-side by the Divine apps on supported versions. Not confirmed per device.
+              {/* TODO(divinevideo/support-trust-safety#176): move the DM
+                  restriction into the applied section above (and remove this
+                  one) once released mobile + web builds enforce it. Until
+                  then it lives under an explicit not-yet heading so a
+                  moderator can never mistake it for a live protection. */}
+              <div className="space-y-1.5 border-t pt-2">
+                <h4 className="flex items-center gap-1.5 font-medium text-muted-foreground">
+                  <Clock className="h-3.5 w-3.5" />
+                  Rolling out (not yet enforced by released apps)
+                </h4>
+                <div className="flex items-start gap-1.5 text-muted-foreground">
+                  <MessageSquareLock className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                  <span>
+                    DM restriction: DMs limited to the pinned official accounts, Divine HQ (_@divinehq.divine.video) and Divine Moderation (moderation@divine.video); everything else is blocked on send and hidden on receive.
+                  </span>
+                </div>
               </div>
             </div>
           ) : null}


### PR DESCRIPTION
## What and why

Closes #143. Part of the protected-minor safeguards epic (divinevideo/support-trust-safety#173).

The age-review case view shows the "Approved protected minor (13-15)" badge (#141, PR #142) but not what that approval actually protects the teen from. #141 deliberately left that out: the protections did not exist yet, and listing them would have given moderators false assurance. The content lock (support-trust-safety#175) has since shipped and the DM restriction (support-trust-safety#176) is in review on both clients, so this adds an honest display of the protections that apply.

## What it shows

When `verified_minor` is true, a small block renders under the badge row, split into two clearly separated sections so shipped protections are never mixed with rollout-only ones:

**Protections that apply to this account** (shipped only)

* Adult content lock: adult content is hidden and the 18+ visibility toggle is disabled, so they cannot re-enable it.
* Qualifier: derived from the approved protected-minor status above; enforced client-side by the Divine apps on supported versions. Not confirmed per device.

**Rolling out (not yet enforced by released apps)** (separate section below a divider, muted styling)

* DM restriction: DMs limited to the pinned official accounts, Divine HQ (`_@divinehq.divine.video`) and Divine Moderation (`moderation@divine.video`); everything else is blocked on send and hidden on receive.

Nothing else changes: the badge, the approval date, the "protected-minor status unavailable" fail-safe, and the non-minor empty state behave exactly as before, and the block never renders unless `verified_minor` is confirmed true.

## Design choice: policy-derived display

The protections are client-enforced and not per-device server-observable (NIP-17 gift-wraps are not relay-attributable; the content lock is in-app). Per the issue's recommended default, the display is policy-derived from `verified_minor`, and the copy is framed as "what policy applies to this account, enforced by the apps," never "confirmed active on their device." A reported-state design (clients reporting applied protections) was considered in the issue and deferred as a larger mechanism.

**Shipped vs rollout-only separation (from review):** the DM restriction is merged in no released client yet (divine-mobile#5754 and divine-web#474 are both open), and an inline caveat under the applied-protections heading still presents it as part of the current protection set. So the DM restriction now lives in its own "Rolling out (not yet enforced by released apps)" section, visually and semantically separate from the applied protections, with a `TODO(divinevideo/support-trust-safety#176)` in the code to move it into the applied section once the client releases ship. Tests assert the DOM separation, so the DM row cannot silently migrate back under the applied heading.

## Testing

* Structural tests pin the shipped/rollout separation: the applied section (queried via its heading) must contain the adult-lock copy and must NOT contain the DM restriction; the rollout section's heading must carry the not-yet-enforced framing and contain the DM row (NIP-05 handles asserted). Verified non-vacuous: moving the DM row back under the applied heading fails the test.
* Framing test pins the policy-derived copy ("enforced client-side by the Divine apps", "not confirmed per device"); absence tests cover `verified_minor` false and status-unavailable (both sections absent), awaiting query settlement (`isFetching() === 0`) so they cannot pass vacuously against a still-loading tree.
* Full gate: component tests 25/25, frontend suite 153 passed, eslint clean, tsc clean, vite build clean.
* Adversarial review loop run to an explicit CLEAN verdict on each round (initial, post-review restructure); all findings resolved (shipped/rollout split, NIP-05 handles instead of impersonable display names, h4 headings for screen-reader navigation, vacuous-pass test windows closed, anchored queries).

## Screenshots

No screenshot: rendering this state requires the full local stack plus a keycast-verified minor fixture. The exact rendered copy is quoted verbatim above; the block is a bordered `text-xs` card in the case header, matching the existing header idiom.

## Out of scope

* Any worker/D1 change (the existing `/api/account-status` endpoint already supplies `verified_minor`).
* Per-device/reported-state protection telemetry (issue lists it as the larger alternative).
* Parent-approved DM allowlist (future work under the epic).
