### PR TITLE
fix(zendesk): route resolved tickets to a group instead of the credential owner

### DIFF
--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -286,6 +286,7 @@ describe('handleUpdateAgeReviewCase', () => {
       ZENDESK_SUBDOMAIN: 'test',
       ZENDESK_API_TOKEN: 'tok',
       ZENDESK_EMAIL: 'agent@test.com',
+      ZENDESK_GROUP_ID: '15225535020687',
     }), corsHeaders);
     expect(res.status).toBe(200);
 
@@ -296,6 +297,9 @@ describe('handleUpdateAgeReviewCase', () => {
     const payload = JSON.parse(zendeskCall![1].body);
     expect(payload.ticket.status).toBe('solved');
     expect(payload.ticket.comment.body).toContain('cleared');
+    // Routes to the configured group (Trust & Safety), not a personal assignee.
+    expect(payload.ticket.group_id).toBe(15225535020687);
+    expect(payload.ticket.assignee_email).toBeUndefined();
 
     vi.unstubAllGlobals();
   });

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -31,6 +31,9 @@ export interface AgeReviewEnv extends BulkModerateEnv, KeycastEnv {
   ZENDESK_FIELD_CATEGORY?: string;
   ZENDESK_FIELD_ISSUE?: string;
   ZENDESK_FIELD_AGE_REVIEW_DEADLINE?: string;
+  // Group to route resolved tickets to (the Trust & Safety queue), instead of
+  // assigning the API credential's owner. Numeric Zendesk group id as a string.
+  ZENDESK_GROUP_ID?: string;
 }
 
 interface ZendeskClientConfig {
@@ -848,9 +851,13 @@ export async function syncAgeReviewTicketResolution(
     ticket: {
       comment: { body: noteLines.join('\n'), public: false },
       status: 'solved',
-      assignee_email: zendesk.email,
     },
   };
+
+  // Route to a group (Trust & Safety) rather than assigning the credential owner.
+  if (env.ZENDESK_GROUP_ID) {
+    (payload.ticket as Record<string, unknown>).group_id = Number(env.ZENDESK_GROUP_ID);
+  }
 
   // Required fields for solving (same pattern as addZendeskInternalNote in index.ts)
   if (env.ZENDESK_FIELD_CATEGORY && env.ZENDESK_FIELD_ISSUE) {

--- a/worker/src/zendesk-sync.test.ts
+++ b/worker/src/zendesk-sync.test.ts
@@ -247,7 +247,7 @@ describe('addZendeskInternalNote solve payload', () => {
     vi.restoreAllMocks();
   });
 
-  it('sends solved status, assignee, and required custom fields for resolution actions', async () => {
+  it('sends solved status, group routing, and required custom fields for resolution actions', async () => {
     const { db, sqlLog } = createMockDB();
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -259,7 +259,7 @@ describe('addZendeskInternalNote solve payload', () => {
     const targetEventId = 'ab13eb2c66bea4cd8f538798054d23a02d5dca879401be5045b8482590e2482c';
     const response = await worker.fetch(
       makeResolutionPublishRequest(targetEventId),
-      makeEnv({ DB: db }),
+      makeEnv({ DB: db, ZENDESK_GROUP_ID: '15225535020687' }),
       ctx,
     );
 
@@ -272,7 +272,9 @@ describe('addZendeskInternalNote solve payload', () => {
 
     const payload = JSON.parse(options.body as string);
     expect(payload.ticket.status).toBe('solved');
-    expect(payload.ticket.assignee_email).toBe('test@divine.video');
+    // Routes to the configured group (Trust & Safety), never a personal assignee.
+    expect(payload.ticket.group_id).toBe(15225535020687);
+    expect(payload.ticket.assignee_email).toBeUndefined();
     expect(payload.ticket.custom_fields).toEqual([
       { id: 14559549220879, value: 'trust___safety' },
       { id: 14560383908879, value: 'other_content_report' },

--- a/worker/src/zendesk-sync.ts
+++ b/worker/src/zendesk-sync.ts
@@ -7,6 +7,9 @@ export interface ZendeskSyncEnv {
   ZENDESK_EMAIL?: string | SecretStoreSecret;
   ZENDESK_FIELD_CATEGORY?: string;
   ZENDESK_FIELD_ISSUE?: string;
+  // Group to route resolved tickets to (the Trust & Safety queue), instead of
+  // assigning the API credential's owner. Numeric Zendesk group id as a string.
+  ZENDESK_GROUP_ID?: string;
   NOSTR_NSEC: string | SecretStoreSecret;
   RELAY_URL: string;
 }
@@ -98,7 +101,7 @@ export async function addZendeskInternalNote(
       ticket: {
         comment: { body: string; public: boolean };
         status?: string;
-        assignee_email?: string;
+        group_id?: number;
         custom_fields?: Array<{ id: number; value: string }>;
       };
     } = {
@@ -112,7 +115,10 @@ export async function addZendeskInternalNote(
 
     if (solve) {
       payload.ticket.status = 'solved';
-      payload.ticket.assignee_email = creds.email;
+      // Route resolved tickets to a group (Trust & Safety) instead of assigning
+      // the API credential's owner. This instance allows solving without an
+      // individual assignee, so the ticket lands unassigned in the queue.
+      if (env.ZENDESK_GROUP_ID) payload.ticket.group_id = Number(env.ZENDESK_GROUP_ID);
       payload.ticket.custom_fields = buildResolutionCustomFields(env);
     }
 

--- a/worker/wrangler.prod.toml
+++ b/worker/wrangler.prod.toml
@@ -100,6 +100,9 @@ ZENDESK_FIELD_CATEGORY = "14559549220879"
 ZENDESK_FIELD_ISSUE = "14560383908879"
 # Age review deadline date field — create in Zendesk admin, then set the ID here
 ZENDESK_FIELD_AGE_REVIEW_DEADLINE = "16123853180303"
+# Group that relay-manager-resolved tickets route to (Trust & Safety), so they
+# land unassigned in that queue instead of being assigned to the API credential's owner.
+ZENDESK_GROUP_ID = "15225535020687"
 # Keycast account suspension API
 KEYCAST_URL = "https://login.divine.video"
 


### PR DESCRIPTION
## What and why

When relay-manager resolves (solves) a Zendesk ticket, it assigned the ticket to the API credential's email, so every moderation/age-review ticket it auto-resolves landed on a personal admin account rather than a team queue. This instance permits solving without an individual assignee, so this drops the personal assignee and routes resolved tickets to a configurable group (`ZENDESK_GROUP_ID`), set to the **Trust & Safety** queue in prod.

Closes #154.

## Changes

- `worker/src/zendesk-sync.ts` (`addZendeskInternalNote` solve branch): drop `assignee_email = creds.email`; set `group_id` from `ZENDESK_GROUP_ID`.
- `worker/src/age-review.ts` (`syncAgeReviewTicketResolution`): same.
- `worker/wrangler.prod.toml`: `ZENDESK_GROUP_ID = "15225535020687"` (Trust & Safety group).
- Tests in both suites assert group routing and no personal assignee.

## Behavior

- With `ZENDESK_GROUP_ID` set: resolved tickets solve **unassigned, into that group's queue**.
- Unset (e.g. staging today): solve unassigned with no group — safe.

## Testing

- `npm run typecheck` clean
- `npm run test:run` 265 passed
- `npm run test:d1` 16 passed

## Out of scope / follow-up

- Bulk cleanup of the existing backlog of tickets already assigned to the credential owner (a separate Zendesk bulk update).
- Staging can be pointed at the appropriate group id if desired.
