### PR TITLE
fix(reports): surface reported-user comments and activity drill-down on report detail

### DIFF
--- a/src/components/EventDetail.tsx
+++ b/src/components/EventDetail.tsx
@@ -675,7 +675,7 @@ export function EventDetail({ event, onSelectEvent, onSelectPubkey, onViewReport
                   <div className="flex gap-4 text-xs text-muted-foreground p-2 bg-muted/50 rounded">
                     <span className="flex items-center gap-1">
                       <FileText className="h-3 w-3" />
-                      {userStats.data.postCount} posts
+                      {userStats.data.postCount} events
                     </span>
                     <span className="flex items-center gap-1">
                       <Flag className="h-3 w-3" />
@@ -848,7 +848,7 @@ export function EventDetail({ event, onSelectEvent, onSelectPubkey, onViewReport
               <div className="flex gap-4 text-xs text-muted-foreground pt-2 border-t">
                 <span className="flex items-center gap-1">
                   <FileText className="h-3 w-3" />
-                  {userStats.data.postCount} posts
+                  {userStats.data.postCount} events
                 </span>
                 <span className="flex items-center gap-1">
                   <Flag className="h-3 w-3" />

--- a/src/components/EventsList.tsx
+++ b/src/components/EventsList.tsx
@@ -754,10 +754,12 @@ export function EventsList({ relayUrl }: EventsListProps) {
     { value: '21', label: 'Video (21)' },
     { value: '22', label: 'Short Video (22)' },
     // Standard kinds
+    { value: '1111', label: 'Comments (1111)' },
     { value: '1', label: 'Text Notes (1)' },
     { value: '0', label: 'Profiles (0)' },
     { value: '3', label: 'Contacts (3)' },
     { value: '6', label: 'Reposts (6)' },
+    { value: '16', label: 'Generic Reposts (16)' },
     { value: '7', label: 'Reactions (7)' },
     { value: '1984', label: 'Reports (1984)' },
     { value: '1985', label: 'Labels (1985)' },

--- a/src/components/EventsList.tsx
+++ b/src/components/EventsList.tsx
@@ -754,8 +754,8 @@ export function EventsList({ relayUrl }: EventsListProps) {
     { value: '21', label: 'Video (21)' },
     { value: '22', label: 'Short Video (22)' },
     // Standard kinds
-    { value: '1111', label: 'Comments (1111)' },
     { value: '1', label: 'Text Notes (1)' },
+    { value: '1111', label: 'Comments (1111)' },
     { value: '0', label: 'Profiles (0)' },
     { value: '3', label: 'Contacts (3)' },
     { value: '6', label: 'Reposts (6)' },

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -25,6 +25,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useToast } from "@/hooks/useToast";
 import { ToastAction } from "@/components/ui/toast";
 import { useReportContext } from "@/hooks/useReportContext";
+import { isRepostKind } from "@/lib/nip18";
 import { useBannedEvent } from "@/hooks/useBannedEvent";
 import { useUserSummary } from "@/hooks/useUserSummary";
 import { useModerationStatus } from "@/hooks/useModerationStatus";
@@ -59,7 +60,7 @@ function getKindLabel(kind: number): string {
   if ([34235, 34236].includes(kind)) return 'Video';
   if (kind === 1111) return 'Comment';
   if (kind === 1) return 'Note';
-  if (kind === 6 || kind === 16) return 'Repost';
+  if (isRepostKind(kind)) return 'Repost';
   if (kind === 0) return 'Profile';
   return entry.name;
 }

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -807,8 +807,10 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
             isLoading={false}
             isFunnelcakeUser={context.reportedUser.isFunnelcakeUser}
             onViewActivity={reportedPubkey ? () => {
-              // Same drill-down the reporter rows get: Events tab filtered to this user (#156)
-              navigate(`/events?pubkey=${reportedPubkey}`);
+              // Same drill-down the reporter rows get: Events tab filtered to this
+              // user (#156). Encoded: the p tag comes from an attacker-authored
+              // 1984 event, so it isn't guaranteed to be clean hex.
+              navigate(`/events?pubkey=${encodeURIComponent(reportedPubkey)}`);
             } : undefined}
             onDeleteEvent={async (eventId) => {
               try {

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -110,6 +110,7 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
   const [dismissReason, setDismissReason] = useState("");
 
   const context = useReportContext(report);
+  const reportedPubkey = context.reportedUser.pubkey;
 
   // Banned event fallback: if thread found no event and target is an event ID, try management API
   const targetEventId = context.target?.type === 'event' ? context.target.value : undefined;
@@ -805,9 +806,9 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
             stats={context.userStats}
             isLoading={false}
             isFunnelcakeUser={context.reportedUser.isFunnelcakeUser}
-            onViewActivity={context.reportedUser.pubkey ? () => {
+            onViewActivity={reportedPubkey ? () => {
               // Same drill-down the reporter rows get: Events tab filtered to this user (#156)
-              navigate(`/events?pubkey=${context.reportedUser.pubkey}`);
+              navigate(`/events?pubkey=${reportedPubkey}`);
             } : undefined}
             onDeleteEvent={async (eventId) => {
               try {

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -805,6 +805,10 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
             stats={context.userStats}
             isLoading={false}
             isFunnelcakeUser={context.reportedUser.isFunnelcakeUser}
+            onViewActivity={context.reportedUser.pubkey ? () => {
+              // Same drill-down the reporter rows get: Events tab filtered to this user (#156)
+              navigate(`/events?pubkey=${context.reportedUser.pubkey}`);
+            } : undefined}
             onDeleteEvent={async (eventId) => {
               try {
                 await deleteEvent(eventId, 'Deleted from report review');

--- a/src/components/UserProfileCard.test.tsx
+++ b/src/components/UserProfileCard.test.tsx
@@ -2,7 +2,6 @@
 // ABOUTME: View Activity drill-down added for report review (#156)
 
 import { describe, it, expect, vi } from 'vitest';
-import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { NostrEvent } from '@nostrify/nostrify';
 import { UserProfileCard } from './UserProfileCard';
@@ -35,7 +34,7 @@ function post(kind: number, content: string, idByte: string): NostrEvent {
 const RECENT: NostrEvent[] = [
   post(21, 'a video', '1'),
   post(1111, 'scam comment text', '2'),
-  post(16, JSON.stringify({ content: 'inner reposted text', kind: 34236 }), '3'),
+  post(16, JSON.stringify({ content: 'inner reposted text', kind: 34236, pubkey: 'b'.repeat(64) }), '3'),
   post(1, 'plain note', '4'),
   post(30023, 'long form', '5'),
 ];
@@ -68,8 +67,12 @@ describe('UserProfileCard', () => {
     render(<UserProfileCard pubkey={PUBKEY} stats={stats(RECENT)} />);
 
     expect(screen.getByText(/inner reposted text/)).toBeInTheDocument();
-    expect(screen.getByText(/reposted:/)).toBeInTheDocument();
     expect(screen.queryByText(/"kind":34236/)).not.toBeInTheDocument();
+    // Attribution: full inner pubkey surfaced via tooltip (never truncated)
+    expect(screen.getByText(/reposted:/)).toHaveAttribute(
+      'title',
+      `Reposted from pubkey ${'b'.repeat(64)}`
+    );
   });
 
   it('shows View Activity only when onViewActivity is provided, and fires it', () => {

--- a/src/components/UserProfileCard.test.tsx
+++ b/src/components/UserProfileCard.test.tsx
@@ -18,13 +18,13 @@ vi.mock('@/components/MediaPreview', () => ({
 
 const PUBKEY = 'a'.repeat(64);
 
-function post(kind: number, content: string, idByte: string): NostrEvent {
+function post(kind: number, content: string, idByte: string, tags: string[][] = []): NostrEvent {
   return {
     id: idByte.repeat(64),
     pubkey: PUBKEY,
     kind,
     content,
-    tags: [],
+    tags,
     created_at: 1_750_000_000,
     sig: 'f'.repeat(128),
   };
@@ -58,7 +58,7 @@ describe('UserProfileCard', () => {
     expect(screen.getByText('Comment')).toBeInTheDocument(); // kind 1111
     expect(screen.getByText('Repost')).toBeInTheDocument(); // kind 16
     expect(screen.getByText('Note')).toBeInTheDocument(); // kind 1 only
-    expect(screen.getByText('Kind 30023')).toBeInTheDocument(); // generic fallback
+    expect(screen.getByText('Long-form Article')).toBeInTheDocument(); // named via getKindName
     // Exactly one "Note" badge: non-1 kinds must not fall through to it
     expect(screen.getAllByText('Note')).toHaveLength(1);
   });
@@ -73,6 +73,14 @@ describe('UserProfileCard', () => {
       'title',
       `Reposted from pubkey ${'b'.repeat(64)}`
     );
+  });
+
+  it('identifies the target event for an empty-content repost', () => {
+    const emptyRepost = post(16, '', '6', [['e', 'c'.repeat(64)]]);
+    render(<UserProfileCard pubkey={PUBKEY} stats={stats([emptyRepost])} />);
+
+    expect(screen.getByText('Repost')).toBeInTheDocument();
+    expect(screen.getByText(`reposted event ${'c'.repeat(64)}`)).toBeInTheDocument();
   });
 
   it('shows View Activity only when onViewActivity is provided, and fires it', () => {

--- a/src/components/UserProfileCard.test.tsx
+++ b/src/components/UserProfileCard.test.tsx
@@ -1,0 +1,87 @@
+// ABOUTME: Tests UserProfileCard's recent-content badge mapping and the
+// ABOUTME: View Activity drill-down added for report review (#156)
+
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { NostrEvent } from '@nostrify/nostrify';
+import { UserProfileCard } from './UserProfileCard';
+import type { UserStats } from '@/hooks/useUserStats';
+
+vi.mock('@/hooks/useAdminApi', () => ({
+  useApiUrl: () => 'https://api.example.test',
+}));
+
+// Media preview fetches/renders remote content; irrelevant to badge mapping
+vi.mock('@/components/MediaPreview', () => ({
+  InlineMediaPreview: () => null,
+}));
+
+const PUBKEY = 'a'.repeat(64);
+
+function post(kind: number, content: string, idByte: string): NostrEvent {
+  return {
+    id: idByte.repeat(64),
+    pubkey: PUBKEY,
+    kind,
+    content,
+    tags: [],
+    created_at: 1_750_000_000,
+    sig: 'f'.repeat(128),
+  };
+}
+
+// Keep to 5 posts — RecentPostsSection shows slice(0, 5) before "Show all"
+const RECENT: NostrEvent[] = [
+  post(21, 'a video', '1'),
+  post(1111, 'scam comment text', '2'),
+  post(16, JSON.stringify({ content: 'inner reposted text', kind: 34236 }), '3'),
+  post(1, 'plain note', '4'),
+  post(30023, 'long form', '5'),
+];
+
+function stats(recentPosts: NostrEvent[]): UserStats {
+  return {
+    postCount: recentPosts.length,
+    reportCount: 0,
+    labelCount: 0,
+    recentPosts,
+    existingLabels: [],
+    previousReports: [],
+  };
+}
+
+describe('UserProfileCard', () => {
+  it('maps recent-content kinds to the right badges (no kind mislabeled as text note)', () => {
+    render(<UserProfileCard pubkey={PUBKEY} stats={stats(RECENT)} />);
+
+    expect(screen.getByText('Video')).toBeInTheDocument(); // kind 21
+    expect(screen.getByText('Comment')).toBeInTheDocument(); // kind 1111
+    expect(screen.getByText('Repost')).toBeInTheDocument(); // kind 16
+    expect(screen.getByText('Note')).toBeInTheDocument(); // kind 1 only
+    expect(screen.getByText('Kind 30023')).toBeInTheDocument(); // generic fallback
+    // Exactly one "Note" badge: non-1 kinds must not fall through to it
+    expect(screen.getAllByText('Note')).toHaveLength(1);
+  });
+
+  it('renders repost inner content with a label instead of raw NIP-18 JSON', () => {
+    render(<UserProfileCard pubkey={PUBKEY} stats={stats(RECENT)} />);
+
+    expect(screen.getByText(/inner reposted text/)).toBeInTheDocument();
+    expect(screen.getByText(/reposted:/)).toBeInTheDocument();
+    expect(screen.queryByText(/"kind":34236/)).not.toBeInTheDocument();
+  });
+
+  it('shows View Activity only when onViewActivity is provided, and fires it', () => {
+    const onViewActivity = vi.fn();
+
+    const { rerender } = render(
+      <UserProfileCard pubkey={PUBKEY} stats={stats(RECENT)} onViewActivity={onViewActivity} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /view activity/i }));
+    expect(onViewActivity).toHaveBeenCalledTimes(1);
+
+    rerender(<UserProfileCard pubkey={PUBKEY} stats={stats(RECENT)} />);
+    expect(screen.queryByRole('button', { name: /view activity/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/UserProfileCard.tsx
+++ b/src/components/UserProfileCard.tsx
@@ -14,6 +14,7 @@ import { InlineMediaPreview } from "@/components/MediaPreview";
 import type { NostrEvent, NostrMetadata } from "@nostrify/nostrify";
 import type { UserStats } from "@/hooks/useUserStats";
 import { getProfileUrl, getPublicEventUrl } from "@/lib/constants";
+import { isRepostKind, parseRepostedEvent } from "@/lib/nip18";
 
 // Label category colors
 const LABEL_COLORS: Record<string, string> = {
@@ -241,20 +242,6 @@ export function UserProfileCard({ profile, pubkey, stats, isLoading, onDeleteEve
 }
 
 // Separate component for recent posts with expand/collapse
-/** Extract the inner content from a NIP-18 repost (kind 6/16), whose content
- *  field is the stringified JSON of the reposted event (or empty). */
-function repostedContent(content: string): string {
-  try {
-    const inner: unknown = JSON.parse(content);
-    if (inner && typeof inner === 'object' && typeof (inner as { content?: unknown }).content === 'string') {
-      return (inner as { content: string }).content;
-    }
-    return '';
-  } catch {
-    return '';
-  }
-}
-
 function RecentPostsSection({
   posts,
   onDeleteEvent,
@@ -291,20 +278,32 @@ function RecentPostsSection({
           {visiblePosts.map(post => {
             // Kind 6/16 content is the stringified JSON of the reposted event
             // (NIP-18) — surface the inner content, labeled, instead of raw JSON.
-            const isRepost = post.kind === 6 || post.kind === 16;
-            const displayContent = isRepost ? repostedContent(post.content) : post.content;
+            const isRepost = isRepostKind(post.kind);
+            const inner = isRepost ? parseRepostedEvent(post.content) : null;
+            const displayContent = isRepost ? (inner?.content ?? '') : post.content;
             return (
               <div key={post.id} className="p-3 bg-muted rounded-lg space-y-2 overflow-hidden">
                 {/* Post content */}
                 {displayContent && (
                   <p className="text-sm whitespace-pre-wrap break-all line-clamp-4">
-                    {isRepost && <span className="text-muted-foreground italic">reposted: </span>}
+                    {isRepost && (
+                      <span
+                        className="text-muted-foreground italic"
+                        title={inner?.pubkey ? `Reposted from pubkey ${inner.pubkey}` : undefined}
+                      >
+                        reposted:{' '}
+                      </span>
+                    )}
                     {displayContent}
                   </p>
                 )}
 
-                {/* Media preview - uses InlineMediaPreview for admin proxy fallback */}
-                <InlineMediaPreview content={displayContent} tags={post.tags} />
+                {/* Media preview - uses InlineMediaPreview for admin proxy fallback.
+                    Reposts pass the inner event's content+tags so its media resolves. */}
+                <InlineMediaPreview
+                  content={displayContent}
+                  tags={isRepost ? (inner?.tags ?? []) : post.tags}
+                />
 
                 {/* Timestamp, kind, link, and delete */}
                 <div className="flex items-center justify-between text-xs text-muted-foreground">
@@ -358,7 +357,7 @@ function RecentPostsSection({
               className="w-full"
               onClick={() => setShowAll(!showAll)}
             >
-              {showAll ? 'Show less' : `Show ${posts.length - 5} more posts`}
+              {showAll ? 'Show less' : `Show ${posts.length - 5} more events`}
             </Button>
           )}
         </div>

--- a/src/components/UserProfileCard.tsx
+++ b/src/components/UserProfileCard.tsx
@@ -9,7 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useApiUrl } from "@/hooks/useAdminApi";
-import { User, FileText, Flag, Tag, CheckCircle, ChevronDown, ChevronUp, Copy, Check, ArrowUpRight, Trash2, Globe, ExternalLink, Video, MessageSquare } from "lucide-react";
+import { User, FileText, Flag, Tag, CheckCircle, ChevronDown, ChevronUp, Copy, Check, ArrowUpRight, Trash2, Globe, ExternalLink, Video, MessageSquare, Activity, Repeat } from "lucide-react";
 import { InlineMediaPreview } from "@/components/MediaPreview";
 import type { NostrEvent, NostrMetadata } from "@nostrify/nostrify";
 import type { UserStats } from "@/hooks/useUserStats";
@@ -42,10 +42,12 @@ interface UserProfileCardProps {
   stats?: UserStats;
   isLoading?: boolean;
   onDeleteEvent?: (eventId: string) => void;
+  /** Navigate to an in-app view of all events authored by this user (#156) */
+  onViewActivity?: () => void;
   isFunnelcakeUser?: boolean;
 }
 
-export function UserProfileCard({ profile, pubkey, stats, isLoading, onDeleteEvent, isFunnelcakeUser = false }: UserProfileCardProps) {
+export function UserProfileCard({ profile, pubkey, stats, isLoading, onDeleteEvent, onViewActivity, isFunnelcakeUser = false }: UserProfileCardProps) {
   const [copied, setCopied] = useState(false);
   const apiUrl = useApiUrl();
 
@@ -197,6 +199,18 @@ export function UserProfileCard({ profile, pubkey, stats, isLoading, onDeleteEve
             <Tag className="h-4 w-4 text-muted-foreground" />
             <span>{stats?.labelCount || 0} labels</span>
           </div>
+          {onViewActivity && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="ml-auto h-7 gap-1 text-xs"
+              onClick={onViewActivity}
+              title="View all events by this user in the Events tab"
+            >
+              <Activity className="h-3 w-3" />
+              View Activity
+            </Button>
+          )}
         </div>
 
         {/* Existing Labels */}
@@ -294,6 +308,8 @@ function RecentPostsSection({
                       <Badge variant="default" className="text-xs gap-1 bg-green-600" title="Short-form video — visible in Divine apps"><Video className="h-3 w-3" />Video</Badge>
                     ) : post.kind === 1111 ? (
                       <Badge variant="outline" className="text-xs gap-1 text-green-600 border-green-300 bg-green-50" title="Comment (kind 1111) — visible in Divine apps when attached to a video"><MessageSquare className="h-3 w-3" />Comment</Badge>
+                    ) : (post.kind === 16 || post.kind === 6) ? (
+                      <Badge variant="outline" className="text-xs gap-1 text-blue-600 border-blue-300 bg-blue-50" title="Repost — boosts another user's content into feeds"><Repeat className="h-3 w-3" />Repost</Badge>
                     ) : (
                       <Badge variant="outline" className="text-xs gap-1 text-amber-600 border-amber-300 bg-amber-50" title="Text note (kind 1) — not visible in Divine apps. Only visible via external Nostr clients."><Globe className="h-3 w-3" />Note</Badge>
                     )}

--- a/src/components/UserProfileCard.tsx
+++ b/src/components/UserProfileCard.tsx
@@ -15,7 +15,7 @@ import type { NostrEvent, NostrMetadata } from "@nostrify/nostrify";
 import type { UserStats } from "@/hooks/useUserStats";
 import { getProfileUrl, getPublicEventUrl } from "@/lib/constants";
 import { getKindName } from "@/lib/kindNames";
-import { isRepostKind, parseRepostedEvent } from "@/lib/nip18";
+import { getRepostTargetId, isRepostKind, parseRepostedEvent } from "@/lib/nip18";
 
 // Label category colors
 const LABEL_COLORS: Record<string, string> = {
@@ -300,7 +300,7 @@ function RecentPostsSection({
                 )}
                 {/* NIP-18 allows empty repost content — at least identify the target event */}
                 {isRepost && !displayContent && (() => {
-                  const targetId = post.tags.find(t => t[0] === 'e')?.[1];
+                  const targetId = getRepostTargetId(post.tags);
                   return targetId ? (
                     <p className="text-xs text-muted-foreground italic break-all">
                       reposted event {targetId}

--- a/src/components/UserProfileCard.tsx
+++ b/src/components/UserProfileCard.tsx
@@ -336,12 +336,12 @@ function RecentPostsSection({
                       <Badge variant="default" className="text-xs gap-1 bg-green-600" title="Video (NIP-71) — visible in Divine apps"><Video className="h-3 w-3" />Video</Badge>
                     ) : post.kind === 1111 ? (
                       <Badge variant="outline" className="text-xs gap-1 text-green-600 border-green-300 bg-green-50" title="Comment (kind 1111) — visible in Divine apps when attached to a video"><MessageSquare className="h-3 w-3" />Comment</Badge>
-                    ) : (post.kind === 16 || post.kind === 6) ? (
+                    ) : isRepost ? (
                       <Badge variant="outline" className="text-xs gap-1 text-blue-600 border-blue-300 bg-blue-50" title="Repost — boosts another user's content into feeds"><Repeat className="h-3 w-3" />Repost</Badge>
                     ) : post.kind === 1 ? (
                       <Badge variant="outline" className="text-xs gap-1 text-amber-600 border-amber-300 bg-amber-50" title="Text note (kind 1) — not visible in Divine apps. Only visible via external Nostr clients."><Globe className="h-3 w-3" />Note</Badge>
                     ) : (
-                      <Badge variant="outline" className="text-xs gap-1 text-amber-600 border-amber-300 bg-amber-50" title={`${getKindName(post.kind)} (kind ${post.kind}) — not shown as content in Divine apps`}><Globe className="h-3 w-3" />{getKindName(post.kind)}</Badge>
+                      <Badge variant="outline" className="text-xs gap-1 text-amber-600 border-amber-300 bg-amber-50" title={`${getKindName(post.kind)} — not shown as content in Divine apps`}><Globe className="h-3 w-3" />{getKindName(post.kind)}</Badge>
                     )}
                     {onDeleteEvent && (
                       <Button

--- a/src/components/UserProfileCard.tsx
+++ b/src/components/UserProfileCard.tsx
@@ -186,10 +186,10 @@ export function UserProfileCard({ profile, pubkey, stats, isLoading, onDeleteEve
         )}
 
         {/* Stats */}
-        <div className="flex gap-4 text-sm">
+        <div className="flex flex-wrap items-center gap-4 text-sm">
           <div className="flex items-center gap-1">
             <FileText className="h-4 w-4 text-muted-foreground" />
-            <span>{stats?.postCount || 0} posts</span>
+            <span>{stats?.postCount || 0} events</span>
           </div>
           <div className="flex items-center gap-1">
             <Flag className="h-4 w-4 text-muted-foreground" />
@@ -241,6 +241,20 @@ export function UserProfileCard({ profile, pubkey, stats, isLoading, onDeleteEve
 }
 
 // Separate component for recent posts with expand/collapse
+/** Extract the inner content from a NIP-18 repost (kind 6/16), whose content
+ *  field is the stringified JSON of the reposted event (or empty). */
+function repostedContent(content: string): string {
+  try {
+    const inner: unknown = JSON.parse(content);
+    if (inner && typeof inner === 'object' && typeof (inner as { content?: unknown }).content === 'string') {
+      return (inner as { content: string }).content;
+    }
+    return '';
+  } catch {
+    return '';
+  }
+}
+
 function RecentPostsSection({
   posts,
   onDeleteEvent,
@@ -275,17 +289,22 @@ function RecentPostsSection({
       {expanded && (
         <div className="space-y-3">
           {visiblePosts.map(post => {
+            // Kind 6/16 content is the stringified JSON of the reposted event
+            // (NIP-18) — surface the inner content, labeled, instead of raw JSON.
+            const isRepost = post.kind === 6 || post.kind === 16;
+            const displayContent = isRepost ? repostedContent(post.content) : post.content;
             return (
               <div key={post.id} className="p-3 bg-muted rounded-lg space-y-2 overflow-hidden">
                 {/* Post content */}
-                {post.content && (
+                {displayContent && (
                   <p className="text-sm whitespace-pre-wrap break-all line-clamp-4">
-                    {post.content}
+                    {isRepost && <span className="text-muted-foreground italic">reposted: </span>}
+                    {displayContent}
                   </p>
                 )}
 
                 {/* Media preview - uses InlineMediaPreview for admin proxy fallback */}
-                <InlineMediaPreview content={post.content} tags={post.tags} />
+                <InlineMediaPreview content={displayContent} tags={post.tags} />
 
                 {/* Timestamp, kind, link, and delete */}
                 <div className="flex items-center justify-between text-xs text-muted-foreground">
@@ -304,14 +323,16 @@ function RecentPostsSection({
                         );
                       } catch { return null; }
                     })()}
-                    {(post.kind === 34235 || post.kind === 34236) ? (
-                      <Badge variant="default" className="text-xs gap-1 bg-green-600" title="Short-form video — visible in Divine apps"><Video className="h-3 w-3" />Video</Badge>
+                    {(post.kind === 21 || post.kind === 22 || post.kind === 34235 || post.kind === 34236) ? (
+                      <Badge variant="default" className="text-xs gap-1 bg-green-600" title="Video (NIP-71) — visible in Divine apps"><Video className="h-3 w-3" />Video</Badge>
                     ) : post.kind === 1111 ? (
                       <Badge variant="outline" className="text-xs gap-1 text-green-600 border-green-300 bg-green-50" title="Comment (kind 1111) — visible in Divine apps when attached to a video"><MessageSquare className="h-3 w-3" />Comment</Badge>
                     ) : (post.kind === 16 || post.kind === 6) ? (
                       <Badge variant="outline" className="text-xs gap-1 text-blue-600 border-blue-300 bg-blue-50" title="Repost — boosts another user's content into feeds"><Repeat className="h-3 w-3" />Repost</Badge>
-                    ) : (
+                    ) : post.kind === 1 ? (
                       <Badge variant="outline" className="text-xs gap-1 text-amber-600 border-amber-300 bg-amber-50" title="Text note (kind 1) — not visible in Divine apps. Only visible via external Nostr clients."><Globe className="h-3 w-3" />Note</Badge>
+                    ) : (
+                      <Badge variant="outline" className="text-xs gap-1 text-amber-600 border-amber-300 bg-amber-50" title={`Kind ${post.kind} — not shown as content in Divine apps`}><Globe className="h-3 w-3" />Kind {post.kind}</Badge>
                     )}
                     {onDeleteEvent && (
                       <Button

--- a/src/components/UserProfileCard.tsx
+++ b/src/components/UserProfileCard.tsx
@@ -14,6 +14,7 @@ import { InlineMediaPreview } from "@/components/MediaPreview";
 import type { NostrEvent, NostrMetadata } from "@nostrify/nostrify";
 import type { UserStats } from "@/hooks/useUserStats";
 import { getProfileUrl, getPublicEventUrl } from "@/lib/constants";
+import { getKindName } from "@/lib/kindNames";
 import { isRepostKind, parseRepostedEvent } from "@/lib/nip18";
 
 // Label category colors
@@ -297,6 +298,15 @@ function RecentPostsSection({
                     {displayContent}
                   </p>
                 )}
+                {/* NIP-18 allows empty repost content — at least identify the target event */}
+                {isRepost && !displayContent && (() => {
+                  const targetId = post.tags.find(t => t[0] === 'e')?.[1];
+                  return targetId ? (
+                    <p className="text-xs text-muted-foreground italic break-all">
+                      reposted event {targetId}
+                    </p>
+                  ) : null;
+                })()}
 
                 {/* Media preview - uses InlineMediaPreview for admin proxy fallback.
                     Reposts pass the inner event's content+tags so its media resolves. */}
@@ -331,7 +341,7 @@ function RecentPostsSection({
                     ) : post.kind === 1 ? (
                       <Badge variant="outline" className="text-xs gap-1 text-amber-600 border-amber-300 bg-amber-50" title="Text note (kind 1) — not visible in Divine apps. Only visible via external Nostr clients."><Globe className="h-3 w-3" />Note</Badge>
                     ) : (
-                      <Badge variant="outline" className="text-xs gap-1 text-amber-600 border-amber-300 bg-amber-50" title={`Kind ${post.kind} — not shown as content in Divine apps`}><Globe className="h-3 w-3" />Kind {post.kind}</Badge>
+                      <Badge variant="outline" className="text-xs gap-1 text-amber-600 border-amber-300 bg-amber-50" title={`${getKindName(post.kind)} (kind ${post.kind}) — not shown as content in Divine apps`}><Globe className="h-3 w-3" />{getKindName(post.kind)}</Badge>
                     )}
                     {onDeleteEvent && (
                       <Button

--- a/src/hooks/useThread.ts
+++ b/src/hooks/useThread.ts
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import type { NostrEvent } from "@nostrify/nostrify";
 import { NRelay1 } from "@nostrify/nostrify";
 import { fetchFunnelcakeEvent } from "@/lib/funnelcakeApi";
+import { isRepostKind } from "@/lib/nip18";
 
 export type FetchSource = 'rest' | 'local-relay' | 'external-relay' | 'banned-fallback';
 
@@ -21,8 +22,6 @@ export interface ThreadResult {
   triedExternalRelay?: string;
 }
 
-// Kind 6 = repost of kind 1, Kind 16 = generic repost
-const REPOST_KINDS = [6, 16];
 
 /**
  * One-shot fetch from an external relay via WebSocket.
@@ -110,7 +109,7 @@ export function useThread(
 
       // Check if this is a repost and fetch the original
       let repostedEvent: NostrEvent | null = null;
-      const isRepost = REPOST_KINDS.includes(event.kind);
+      const isRepost = isRepostKind(event.kind);
 
       if (isRepost) {
         const originalEventTag = event.tags.find(t => t[0] === 'e');

--- a/src/hooks/useThread.ts
+++ b/src/hooks/useThread.ts
@@ -22,7 +22,6 @@ export interface ThreadResult {
   triedExternalRelay?: string;
 }
 
-
 /**
  * One-shot fetch from an external relay via WebSocket.
  * Opens a connection, sends one REQ, waits for EVENT or EOSE, then closes.

--- a/src/hooks/useUserStats.ts
+++ b/src/hooks/useUserStats.ts
@@ -38,8 +38,10 @@ export function useUserStats(pubkey: string | undefined) {
       const [recentPosts, existingLabels, previousReports] = await Promise.all([
         // User's recent posts (text notes, video events, and other content)
         // Video kinds per NIP-71: 21 (Video), 22 (Short Video), 34235 (Addressable Video), 34236 (Addressable Short Video)
+        // 1111 (NIP-22 comments) and 16 (generic reposts) matter for moderation:
+        // comment-spam accounts often have no other content (#156)
         nostr.query(
-          [{ kinds: [1, 21, 22, 1063, 1064, 20, 30023, 34235, 34236], authors: [pubkey], limit: 20 }],
+          [{ kinds: [1, 16, 21, 22, 1063, 1064, 20, 1111, 30023, 34235, 34236], authors: [pubkey], limit: 20 }],
           { signal: combinedSignal }
         ),
         // Labels against this user

--- a/src/hooks/useUserStats.ts
+++ b/src/hooks/useUserStats.ts
@@ -38,10 +38,10 @@ export function useUserStats(pubkey: string | undefined) {
       const [recentPosts, existingLabels, previousReports] = await Promise.all([
         // User's recent posts (text notes, video events, and other content)
         // Video kinds per NIP-71: 21 (Video), 22 (Short Video), 34235 (Addressable Video), 34236 (Addressable Short Video)
-        // 1111 (NIP-22 comments) and 16 (generic reposts) matter for moderation:
+        // 1111 (NIP-22 comments) and 6/16 (reposts) matter for moderation:
         // comment-spam accounts often have no other content (#156)
         nostr.query(
-          [{ kinds: [1, 16, 21, 22, 1063, 1064, 20, 1111, 30023, 34235, 34236], authors: [pubkey], limit: 20 }],
+          [{ kinds: [1, 6, 16, 21, 22, 1063, 1064, 20, 1111, 30023, 34235, 34236], authors: [pubkey], limit: 20 }],
           { signal: combinedSignal }
         ),
         // Labels against this user
@@ -57,7 +57,7 @@ export function useUserStats(pubkey: string | undefined) {
       ]);
 
       return {
-        postCount: recentPosts.length, // Note: This is just recent, not total
+        postCount: recentPosts.length, // Recent authored events of any queried kind (posts, comments, reposts) — not a total
         reportCount: previousReports.length,
         labelCount: existingLabels.length,
         recentPosts: recentPosts.sort((a, b) => b.created_at - a.created_at),

--- a/src/hooks/useUserSummary.ts
+++ b/src/hooks/useUserSummary.ts
@@ -33,8 +33,12 @@ export function useUserSummary(
           pubkey,
           recentPosts: recentPosts.slice(0, 10).map(e => ({
             // Reposts send the inner (reposted) text, not the raw NIP-18 JSON —
-            // the worker slices to 200 chars, which would otherwise all be hex noise
-            content: isRepostKind(e.kind) ? (parseRepostedEvent(e.content)?.content ?? '') : e.content,
+            // the worker slices to 200 chars, which would otherwise all be hex
+            // noise. Empty/unparseable reposts fall back to the target event id.
+            content: isRepostKind(e.kind)
+              ? (parseRepostedEvent(e.content)?.content
+                || `[reposted event ${e.tags.find(t => t[0] === 'e')?.[1] ?? 'unknown'}]`)
+              : e.content,
             created_at: e.created_at,
             // Kind lets the summarizer distinguish authored posts from
             // comments (1111) and reposts of others' content (6/16) — see #156

--- a/src/hooks/useUserSummary.ts
+++ b/src/hooks/useUserSummary.ts
@@ -33,6 +33,9 @@ export function useUserSummary(
           recentPosts: recentPosts.slice(0, 10).map(e => ({
             content: e.content,
             created_at: e.created_at,
+            // Kind lets the summarizer distinguish authored posts from
+            // comments (1111) and reposts of others' content (6/16) — see #156
+            kind: e.kind,
           })),
           existingLabels: existingLabels?.map(e => ({
             tags: e.tags,

--- a/src/hooks/useUserSummary.ts
+++ b/src/hooks/useUserSummary.ts
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import type { NostrEvent } from "@nostrify/nostrify";
 import { getApiHeaders } from "@/lib/adminApi";
 import { useApiUrl } from "@/hooks/useAdminApi";
+import { isRepostKind, parseRepostedEvent } from "@/lib/nip18";
 
 interface SummaryResponse {
   summary: string;
@@ -31,7 +32,9 @@ export function useUserSummary(
         body: JSON.stringify({
           pubkey,
           recentPosts: recentPosts.slice(0, 10).map(e => ({
-            content: e.content,
+            // Reposts send the inner (reposted) text, not the raw NIP-18 JSON —
+            // the worker slices to 200 chars, which would otherwise all be hex noise
+            content: isRepostKind(e.kind) ? (parseRepostedEvent(e.content)?.content ?? '') : e.content,
             created_at: e.created_at,
             // Kind lets the summarizer distinguish authored posts from
             // comments (1111) and reposts of others' content (6/16) — see #156

--- a/src/hooks/useUserSummary.ts
+++ b/src/hooks/useUserSummary.ts
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import type { NostrEvent } from "@nostrify/nostrify";
 import { getApiHeaders } from "@/lib/adminApi";
 import { useApiUrl } from "@/hooks/useAdminApi";
-import { isRepostKind, parseRepostedEvent } from "@/lib/nip18";
+import { getRepostTargetId, isRepostKind, parseRepostedEvent } from "@/lib/nip18";
 
 interface SummaryResponse {
   summary: string;
@@ -37,7 +37,7 @@ export function useUserSummary(
             // noise. Empty/unparseable reposts fall back to the target event id.
             content: isRepostKind(e.kind)
               ? (parseRepostedEvent(e.content)?.content
-                || `[reposted event ${e.tags.find(t => t[0] === 'e')?.[1] ?? 'unknown'}]`)
+                || `[reposted event ${getRepostTargetId(e.tags) ?? 'unknown'}]`)
               : e.content,
             created_at: e.created_at,
             // Kind lets the summarizer distinguish authored posts from

--- a/src/lib/kindNames.ts
+++ b/src/lib/kindNames.ts
@@ -20,6 +20,7 @@ export const KIND_NAMES: Record<number, { name: string; description: string; nip
   14: { name: 'DM (NIP-17)', description: 'Direct message (NIP-17 style)', nip: 'NIP-17' },
   16: { name: 'Generic Repost', description: 'Repost of any event kind', nip: 'NIP-18' },
   17: { name: 'Reaction to Website', description: 'Reaction to external URL', nip: 'NIP-25' },
+  20: { name: 'Picture', description: 'Picture-first post (images via imeta tags)', nip: 'NIP-68' },
 
   // Channels
   40: { name: 'Channel Creation', description: 'Create a public channel', nip: 'NIP-28' },

--- a/src/lib/nip18.test.ts
+++ b/src/lib/nip18.test.ts
@@ -42,4 +42,10 @@ describe('parseRepostedEvent', () => {
       pubkey: '',
     });
   });
+
+  it('drops non-array elements inside tags', () => {
+    expect(
+      parseRepostedEvent(JSON.stringify({ content: 'x', tags: [['e', 'abc'], 'rogue', 42] }))
+    ).toEqual({ content: 'x', tags: [['e', 'abc']], pubkey: '' });
+  });
 });

--- a/src/lib/nip18.test.ts
+++ b/src/lib/nip18.test.ts
@@ -1,0 +1,45 @@
+// ABOUTME: Tests NIP-18 repost parsing edge cases (empty/malformed/non-event JSON)
+
+import { describe, it, expect } from 'vitest';
+import { isRepostKind, parseRepostedEvent } from './nip18';
+
+describe('isRepostKind', () => {
+  it('matches kinds 6 and 16 only', () => {
+    expect(isRepostKind(6)).toBe(true);
+    expect(isRepostKind(16)).toBe(true);
+    expect(isRepostKind(1)).toBe(false);
+    expect(isRepostKind(1111)).toBe(false);
+  });
+});
+
+describe('parseRepostedEvent', () => {
+  it('extracts content, tags, and pubkey from a serialized event', () => {
+    const inner = { content: 'hello', tags: [['e', 'abc']], pubkey: 'f'.repeat(64), kind: 34236 };
+    expect(parseRepostedEvent(JSON.stringify(inner))).toEqual({
+      content: 'hello',
+      tags: [['e', 'abc']],
+      pubkey: 'f'.repeat(64),
+    });
+  });
+
+  it('returns null for empty or malformed content', () => {
+    expect(parseRepostedEvent('')).toBeNull();
+    expect(parseRepostedEvent('not json')).toBeNull();
+    expect(parseRepostedEvent('null')).toBeNull();
+    expect(parseRepostedEvent('42')).toBeNull();
+    expect(parseRepostedEvent('"string"')).toBeNull();
+  });
+
+  it('returns null when inner content is missing or not a string', () => {
+    expect(parseRepostedEvent(JSON.stringify({ tags: [] }))).toBeNull();
+    expect(parseRepostedEvent(JSON.stringify({ content: 42 }))).toBeNull();
+  });
+
+  it('defaults tags/pubkey when absent or wrong-typed', () => {
+    expect(parseRepostedEvent(JSON.stringify({ content: 'x', tags: 'nope', pubkey: 5 }))).toEqual({
+      content: 'x',
+      tags: [],
+      pubkey: '',
+    });
+  });
+});

--- a/src/lib/nip18.test.ts
+++ b/src/lib/nip18.test.ts
@@ -48,4 +48,10 @@ describe('parseRepostedEvent', () => {
       parseRepostedEvent(JSON.stringify({ content: 'x', tags: [['e', 'abc'], 'rogue', 42] }))
     ).toEqual({ content: 'x', tags: [['e', 'abc']], pubkey: '' });
   });
+
+  it('drops tags containing non-string members (would crash media preview)', () => {
+    expect(
+      parseRepostedEvent(JSON.stringify({ content: 'x', tags: [['imeta', 42], ['e', 'abc'], [null]] }))
+    ).toEqual({ content: 'x', tags: [['e', 'abc']], pubkey: '' });
+  });
 });

--- a/src/lib/nip18.test.ts
+++ b/src/lib/nip18.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Tests NIP-18 repost parsing edge cases (empty/malformed/non-event JSON)
 
 import { describe, it, expect } from 'vitest';
-import { isRepostKind, parseRepostedEvent } from './nip18';
+import { getRepostTargetId, isRepostKind, parseRepostedEvent } from './nip18';
 
 describe('isRepostKind', () => {
   it('matches kinds 6 and 16 only', () => {
@@ -9,6 +9,14 @@ describe('isRepostKind', () => {
     expect(isRepostKind(16)).toBe(true);
     expect(isRepostKind(1)).toBe(false);
     expect(isRepostKind(1111)).toBe(false);
+  });
+});
+
+describe('getRepostTargetId', () => {
+  it('returns the first e-tag value, or undefined when absent', () => {
+    expect(getRepostTargetId([['p', 'x'], ['e', 'abc'], ['e', 'def']])).toBe('abc');
+    expect(getRepostTargetId([['p', 'x']])).toBeUndefined();
+    expect(getRepostTargetId([])).toBeUndefined();
   });
 });
 

--- a/src/lib/nip18.ts
+++ b/src/lib/nip18.ts
@@ -24,7 +24,8 @@ export function parseRepostedEvent(content: string): RepostedEvent | null {
     if (typeof o.content !== 'string') return null;
     return {
       content: o.content,
-      tags: Array.isArray(o.tags) ? (o.tags as string[][]) : [],
+      // Element-level check too: a hostile inner event can put non-arrays in tags
+      tags: Array.isArray(o.tags) ? (o.tags.filter(Array.isArray) as string[][]) : [],
       pubkey: typeof o.pubkey === 'string' ? o.pubkey : '',
     };
   } catch {

--- a/src/lib/nip18.ts
+++ b/src/lib/nip18.ts
@@ -11,6 +11,11 @@ export interface RepostedEvent {
   pubkey: string;
 }
 
+/** The reposted event's id from a repost's `e` tag (NIP-18 says it MUST exist). */
+export function getRepostTargetId(tags: string[][]): string | undefined {
+  return tags.find(t => t[0] === 'e')?.[1];
+}
+
 /**
  * Parse the inner (reposted) event out of a NIP-18 repost's content.
  * Returns null when content is empty, malformed JSON, or not event-shaped —

--- a/src/lib/nip18.ts
+++ b/src/lib/nip18.ts
@@ -24,8 +24,12 @@ export function parseRepostedEvent(content: string): RepostedEvent | null {
     if (typeof o.content !== 'string') return null;
     return {
       content: o.content,
-      // Element-level check too: a hostile inner event can put non-arrays in tags
-      tags: Array.isArray(o.tags) ? (o.tags.filter(Array.isArray) as string[][]) : [],
+      // Full element validation: hostile inner JSON can put non-arrays in tags,
+      // or non-strings inside a tag — either would crash consumers like
+      // MediaPreview that call string methods on tag members.
+      tags: Array.isArray(o.tags)
+        ? o.tags.filter((t): t is string[] => Array.isArray(t) && t.every(x => typeof x === 'string'))
+        : [],
       pubkey: typeof o.pubkey === 'string' ? o.pubkey : '',
     };
   } catch {

--- a/src/lib/nip18.ts
+++ b/src/lib/nip18.ts
@@ -1,0 +1,33 @@
+// ABOUTME: NIP-18 repost helpers — kind 6/16 events carry the reposted event
+// ABOUTME: as stringified JSON in their content field (or empty content)
+
+export function isRepostKind(kind: number): boolean {
+  return kind === 6 || kind === 16;
+}
+
+export interface RepostedEvent {
+  content: string;
+  tags: string[][];
+  pubkey: string;
+}
+
+/**
+ * Parse the inner (reposted) event out of a NIP-18 repost's content.
+ * Returns null when content is empty, malformed JSON, or not event-shaped —
+ * callers should treat that as "no inner content to show".
+ */
+export function parseRepostedEvent(content: string): RepostedEvent | null {
+  try {
+    const inner: unknown = JSON.parse(content);
+    if (!inner || typeof inner !== 'object') return null;
+    const o = inner as Record<string, unknown>;
+    if (typeof o.content !== 'string') return null;
+    return {
+      content: o.content,
+      tags: Array.isArray(o.tags) ? (o.tags as string[][]) : [],
+      pubkey: typeof o.pubkey === 'string' ? o.pubkey : '',
+    };
+  } catch {
+    return null;
+  }
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1031,7 +1031,7 @@ async function handleSummarizeUser(
   try {
     const body = await request.json() as {
       pubkey: string;
-      recentPosts: Array<{ content: string; created_at: number }>;
+      recentPosts: Array<{ content: string; created_at: number; kind?: number }>;
       existingLabels: Array<{ tags: string[][]; created_at: number }>;
       reportHistory: Array<{ content: string; tags: string[][]; created_at: number }>;
     };
@@ -1045,9 +1045,15 @@ async function handleSummarizeUser(
       });
     }
 
-    // Build context for Claude
+    // Build context for Claude. Label comments and reposts so the model
+    // doesn't attribute reposted text as the user's own authored posts (#156).
     const postSummary = body.recentPosts
-      .map(p => `- "${p.content.slice(0, 200)}"`)
+      .map(p => {
+        const label = p.kind === 1111 ? '(comment) '
+          : (p.kind === 6 || p.kind === 16) ? "(repost of another user's event) "
+          : '';
+        return `- ${label}"${p.content.slice(0, 200)}"`;
+      })
       .join('\n');
 
     const labelSummary = body.existingLabels

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1061,7 +1061,7 @@ async function handleSummarizeUser(
     // Build context for Claude. Label comments and reposts so the model
     // doesn't attribute reposted text as the user's own authored posts (#156).
     const postSummary = body.recentPosts
-      .map(p => formatRecentPostLine(p))
+      .map(formatRecentPostLine)
       .join('\n');
 
     const labelSummary = body.existingLabels

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1023,6 +1023,19 @@ async function handleRelayRpc(
   });
 }
 
+/**
+ * One prompt line per recent event for the user-summary context. Kind labels
+ * keep the model from attributing comments/reposted text as authored posts
+ * (#156); kind is optional for backward compatibility with older clients.
+ * Exported for tests.
+ */
+export function formatRecentPostLine(p: { content: string; kind?: number }): string {
+  const label = p.kind === 1111 ? '(comment) '
+    : (p.kind === 6 || p.kind === 16) ? "(repost of another user's event) "
+    : '';
+  return `- ${label}"${p.content.slice(0, 200)}"`;
+}
+
 async function handleSummarizeUser(
   request: Request,
   env: Env,
@@ -1048,12 +1061,7 @@ async function handleSummarizeUser(
     // Build context for Claude. Label comments and reposts so the model
     // doesn't attribute reposted text as the user's own authored posts (#156).
     const postSummary = body.recentPosts
-      .map(p => {
-        const label = p.kind === 1111 ? '(comment) '
-          : (p.kind === 6 || p.kind === 16) ? "(repost of another user's event) "
-          : '';
-        return `- ${label}"${p.content.slice(0, 200)}"`;
-      })
+      .map(p => formatRecentPostLine(p))
       .join('\n');
 
     const labelSummary = body.existingLabels

--- a/worker/src/summarize-user.test.ts
+++ b/worker/src/summarize-user.test.ts
@@ -1,0 +1,28 @@
+// ABOUTME: Tests the user-summary prompt line formatting (kind labeling, #156)
+
+import { describe, it, expect } from 'vitest';
+import { formatRecentPostLine } from './index';
+
+describe('formatRecentPostLine', () => {
+  it('labels kind-1111 comments', () => {
+    expect(formatRecentPostLine({ content: 'scam text', kind: 1111 }))
+      .toBe('- (comment) "scam text"');
+  });
+
+  it('labels kind-6 and kind-16 reposts', () => {
+    expect(formatRecentPostLine({ content: 'boosted', kind: 16 }))
+      .toBe('- (repost of another user\'s event) "boosted"');
+    expect(formatRecentPostLine({ content: 'boosted', kind: 6 }))
+      .toBe('- (repost of another user\'s event) "boosted"');
+  });
+
+  it('leaves other kinds and missing kind unlabeled (backward compatible)', () => {
+    expect(formatRecentPostLine({ content: 'a note', kind: 1 })).toBe('- "a note"');
+    expect(formatRecentPostLine({ content: 'a note' })).toBe('- "a note"');
+  });
+
+  it('truncates content to 200 chars', () => {
+    const line = formatRecentPostLine({ content: 'x'.repeat(300), kind: 1 });
+    expect(line).toBe(`- "${'x'.repeat(200)}"`);
+  });
+});


### PR DESCRIPTION
Closes #156

## What

a report about an account whose only activity was comment spam showed an empty "Recent Content on Relay" section, with no way to reach the reported user's activity from the report. this connects existing patterns to the reports context — no new views — then hardens the paths it opened. follow-ups spun out: #158 (ErrorBoundary), #159 (BannedUserCard sibling gap), both assigned and in progress.

### the fix (#156)

- **`useUserStats`**: adds `1111` (NIP-22 comments) and `6`/`16` (reposts) to the recent-posts author query. the report page's `UserProfileCard` already had the comment badge rendering (shipped in #47); it just never received comments. zero extra round-trips — same parallel relay subscription, same limit/timeout bounds.
- **`ReportDetail`**: the reported user gets the same in-app drill-down the reporter rows already have — "View Activity" → `/events?pubkey=<reported>` (encoded: the p tag is attacker-authored, unlike the signature-verified reporter pubkey).
- **`EventsList`**: `Comments (1111)` and `Generic Reposts (16)` kind-filter presets.

### hardening + correctness that fell out of self-review (5 adversarial rounds)

- **new `src/lib/nip18.ts`** — shared `isRepostKind` / `parseRepostedEvent` / `getRepostTargetId`, defensively typed with **full element-level tag validation**: hostile inner-repost JSON like `tags:[["imeta",42]]` previously reached MediaPreview's `part.startsWith()` and would white-screen the admin app on exactly the page used to review the hostile account. consumed by `UserProfileCard`, `useUserSummary`, and `useThread` (replacing its local `REPOST_KINDS`).
- **badge chain made exhaustive**: kinds 21/22 were mislabeled "Text note (kind 1) — not visible in Divine apps" (moderation-relevant misstatement); now Video 21/22/34235/34236, Comment 1111, Repost via `isRepostKind`, Note for kind 1 only, `getKindName()` fallback otherwise. kind 20 Picture added to kindNames (verified against NIP-68).
- **repost rendering**: labeled inner content instead of raw NIP-18 JSON, media preview uses the inner event's content+tags, full inner pubkey in the attribution tooltip, empty-content reposts identify their target event id.
- **AI summary integrity**: `/api/summarize-user` payload now carries `kind`; the worker labels comments/reposts in the prompt (extracted `formatRecentPostLine`, backward compatible with kind-less payloads) and receives inner repost text instead of 200 chars of serialized-event hex.
- **labels**: "N posts" → "N events" where the count now includes comments/reposts.

## API choice

funnelcake has no REST endpoint for events authored by a pubkey, and its GraphQL `events(filter: {authors, kinds})` ships behind `GRAPHQL_ENABLED` (currently 404 on prod + staging) — see the note on #156. so this stays on the existing client relay query, which works in production today.

## Verification

- tsc clean (frontend + worker), eslint clean on all changed files
- **174 frontend tests** (16 new: nip18 edge cases incl. the crash vector, UserProfileCard badge mapping / repost handling / View Activity, worker prompt formatting) + **283 worker tests**
- verified against a live case: a comment-only scam account's kind-1111 comments and kind-16 reposts now appear in the report card query results
- deploy note: worker KV summary cache (`summary:<pubkey>`, 1h TTL) means pre-deploy summaries keep the unlabeled prompt until expiry — self-heals within the hour