### PR TITLE
fix(ui): error boundaries so a render exception can't white-screen the admin UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NostrLoginProvider } from '@nostrify/react/login';
 import { AppProvider } from '@/components/AppProvider';
 import { AppConfig } from '@/contexts/AppContext';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import AppRouter from './AppRouter';
 
 const queryClient = new QueryClient({
@@ -30,21 +31,25 @@ const defaultConfig: AppConfig = {
 
 export function App() {
   return (
-    <AppProvider storageKey="nostr:app-config-v2" defaultConfig={defaultConfig}>
-      <QueryClientProvider client={queryClient}>
-        <NostrLoginProvider storageKey='nostr:login'>
-          <NostrProvider>
-            <TooltipProvider>
-              <Toaster />
-              <Sonner />
-              <Suspense>
-                <AppRouter />
-              </Suspense>
-            </TooltipProvider>
-          </NostrProvider>
-        </NostrLoginProvider>
-      </QueryClientProvider>
-    </AppProvider>
+    // Outermost on purpose: the fallback must not depend on any provider below,
+    // so a crash anywhere in the tree still renders the error card (#158).
+    <ErrorBoundary>
+      <AppProvider storageKey="nostr:app-config-v2" defaultConfig={defaultConfig}>
+        <QueryClientProvider client={queryClient}>
+          <NostrLoginProvider storageKey='nostr:login'>
+            <NostrProvider>
+              <TooltipProvider>
+                <Toaster />
+                <Sonner />
+                <Suspense>
+                  <AppRouter />
+                </Suspense>
+              </TooltipProvider>
+            </NostrProvider>
+          </NostrLoginProvider>
+        </QueryClientProvider>
+      </AppProvider>
+    </ErrorBoundary>
   );
 }
 

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,217 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MockInstance } from 'vitest';
+import { ErrorBoundary } from './ErrorBoundary';
+
+function Bomb(): never {
+  throw new Error('render exploded');
+}
+
+function MaybeBomb({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error('render exploded');
+  return <div>report body</div>;
+}
+
+// Always-throwing child that counts render attempts, so tests can assert
+// whether a boundary reset actually re-executed the crashing subtree.
+function makeCountingBomb() {
+  let attempts = 0;
+  function CountingBomb(): never {
+    attempts++;
+    throw new Error('render exploded');
+  }
+  return { CountingBomb, attempts: () => attempts };
+}
+
+// React logs caught render errors to console.error; silence them so test
+// output stays pristine while still letting us assert the boundary's own log.
+let consoleError: MockInstance;
+
+beforeEach(() => {
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleError.mockRestore();
+});
+
+describe('ErrorBoundary', () => {
+  it('renders children when nothing throws', () => {
+    render(
+      <ErrorBoundary>
+        <div>healthy content</div>
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('healthy content')).toBeInTheDocument();
+    expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the default error card with a reload affordance instead of a blank page (app-root shape)', () => {
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reload/i })).toBeInTheDocument();
+  });
+
+  // Note: the reload button's window.location.reload() call is not click-tested —
+  // jsdom's location.reload is unforgeable (cannot be spied or stubbed), and
+  // invoking the real one prints "Not implemented: navigation" noise. Presence is
+  // asserted above; the actual reload is a one-line browser API call.
+
+  it('degrades a crashing subtree to the custom fallback while siblings survive (ReportDetail shape)', () => {
+    render(
+      <div>
+        <div>reports list</div>
+        <ErrorBoundary fallback={<div>this report failed to render</div>}>
+          <Bomb />
+        </ErrorBoundary>
+      </div>
+    );
+
+    expect(screen.getByText('reports list')).toBeInTheDocument();
+    expect(screen.getByText('this report failed to render')).toBeInTheDocument();
+    expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument();
+  });
+
+  it('does not re-execute a crashing child when rerendered with value-equal resetKeys', () => {
+    // Reports.tsx passes a fresh array literal every render and re-renders on
+    // a 15s poll — a comparator that resets on reference inequality would
+    // re-run the hostile crashing render on every tick. Count executions.
+    const { CountingBomb, attempts } = makeCountingBomb();
+
+    const { rerender } = render(
+      <ErrorBoundary resetKeys={['report-a']} fallback={<div>failed</div>}>
+        <CountingBomb />
+      </ErrorBoundary>
+    );
+    const attemptsAfterMount = attempts();
+
+    rerender(
+      <ErrorBoundary resetKeys={['report-a']} fallback={<div>failed</div>}>
+        <CountingBomb />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('failed')).toBeInTheDocument();
+    expect(attempts()).toBe(attemptsAfterMount);
+  });
+
+  it('re-catches and settles on the fallback when reset children still throw (Try again on a still-broken report)', () => {
+    const { CountingBomb, attempts } = makeCountingBomb();
+
+    const { rerender } = render(
+      <ErrorBoundary resetKeys={[0]} fallback={<div>failed</div>}>
+        <CountingBomb />
+      </ErrorBoundary>
+    );
+    const attemptsAfterMount = attempts();
+
+    rerender(
+      <ErrorBoundary resetKeys={[1]} fallback={<div>failed</div>}>
+        <CountingBomb />
+      </ErrorBoundary>
+    );
+
+    // The reset re-attempted the children, re-caught the throw, and settled
+    // back on the fallback — completing at all proves the reset/rethrow
+    // cycle terminates instead of looping to 'Maximum update depth exceeded'.
+    expect(screen.getByText('failed')).toBeInTheDocument();
+    expect(attempts()).toBeGreaterThan(attemptsAfterMount);
+  });
+
+  it('passes a reset callback to a function fallback that recovers once the child is fixed', () => {
+    const { CountingBomb } = makeCountingBomb();
+    const fallback = (reset: () => void) => <button onClick={reset}>retry</button>;
+
+    const { rerender } = render(
+      <ErrorBoundary fallback={fallback}>
+        <CountingBomb />
+      </ErrorBoundary>
+    );
+    expect(screen.getByRole('button', { name: 'retry' })).toBeInTheDocument();
+
+    // Child fixed, but no resetKeys change — still on the fallback until reset.
+    rerender(
+      <ErrorBoundary fallback={fallback}>
+        <div>healthy now</div>
+      </ErrorBoundary>
+    );
+    expect(screen.getByRole('button', { name: 'retry' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'retry' }));
+    expect(screen.getByText('healthy now')).toBeInTheDocument();
+  });
+
+  it('re-catches when reset is clicked while the child still throws', () => {
+    const { CountingBomb, attempts } = makeCountingBomb();
+
+    render(
+      <ErrorBoundary fallback={reset => <button onClick={reset}>retry</button>}>
+        <CountingBomb />
+      </ErrorBoundary>
+    );
+    const attemptsAfterMount = attempts();
+
+    fireEvent.click(screen.getByRole('button', { name: 'retry' }));
+
+    expect(screen.getByRole('button', { name: 'retry' })).toBeInTheDocument();
+    expect(attempts()).toBeGreaterThan(attemptsAfterMount);
+  });
+
+  it('recovers when resetKeys change (selecting a different report)', () => {
+    const { rerender } = render(
+      <ErrorBoundary resetKeys={['report-a']} fallback={<div>failed</div>}>
+        <MaybeBomb shouldThrow={true} />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('failed')).toBeInTheDocument();
+
+    rerender(
+      <ErrorBoundary resetKeys={['report-b']} fallback={<div>failed</div>}>
+        <MaybeBomb shouldThrow={false} />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('report body')).toBeInTheDocument();
+  });
+
+  it('stays on the fallback when resetKeys are unchanged', () => {
+    const { rerender } = render(
+      <ErrorBoundary resetKeys={['report-a']} fallback={<div>failed</div>}>
+        <MaybeBomb shouldThrow={true} />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('failed')).toBeInTheDocument();
+
+    rerender(
+      <ErrorBoundary resetKeys={['report-a']} fallback={<div>failed</div>}>
+        <MaybeBomb shouldThrow={true} />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('failed')).toBeInTheDocument();
+    expect(screen.queryByText('report body')).not.toBeInTheDocument();
+  });
+
+  it('logs the caught error with its component stack (componentDidCatch)', () => {
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>
+    );
+
+    // Match the boundary's own log, not React's built-in error logging —
+    // React 18 logs the caught Error itself, so a looser assertion would
+    // stay green even if componentDidCatch were deleted.
+    const boundaryLog = consoleError.mock.calls.find(
+      args => args[0] === 'ErrorBoundary caught a render error:'
+    );
+    expect(boundaryLog).toBeDefined();
+    expect(boundaryLog![1]).toBeInstanceOf(Error);
+    expect((boundaryLog![1] as Error).message).toBe('render exploded');
+    expect(String(boundaryLog![2])).toContain('Bomb');
+  });
+});

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,94 @@
+// ABOUTME: React error boundary so a render exception (e.g. from hostile event
+// ABOUTME: data) degrades to an error card instead of white-screening the app
+
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /**
+   * Scoped fallback UI; omit to get the default full-page error card. The
+   * function form receives a reset callback for a "try again" affordance
+   * that re-attempts the children (and re-catches if they still throw).
+   */
+  fallback?: ReactNode | ((reset: () => void) => ReactNode);
+  /**
+   * When any value here changes (compared by Object.is), a caught error is
+   * cleared and children render again — e.g. pass the selected report id so
+   * picking a different report recovers from a crashed one.
+   */
+  resetKeys?: readonly unknown[];
+}
+
+interface ErrorBoundaryState {
+  // Boolean rather than the thrown value: render code can throw anything,
+  // including null/undefined, which a `error !== null` check would miss.
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('ErrorBoundary caught a render error:', error, info.componentStack);
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps) {
+    if (this.state.hasError && resetKeysChanged(prevProps.resetKeys, this.props.resetKeys)) {
+      this.setState({ hasError: false });
+    }
+  }
+
+  /** Clear a caught error and re-attempt the children. Safe to call when
+   * healthy (no-op), so consumers can invoke it on generic gestures like
+   * re-selecting the current item. */
+  reset = () => {
+    if (this.state.hasError) {
+      this.setState({ hasError: false });
+    }
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (typeof this.props.fallback === 'function') {
+        return this.props.fallback(this.reset);
+      }
+      // Default fallback inline (not a sibling component: react-refresh wants
+      // component-only files, and a class boundary can't fast-refresh anyway).
+      // Kept dependency-light so the fallback itself cannot throw: no context,
+      // no providers — it must render even when the crash was in a provider.
+      return (
+        this.props.fallback ?? (
+          <div className="min-h-screen flex items-center justify-center p-4">
+            <div className="w-full max-w-md rounded-lg border p-6 text-center space-y-3">
+              <AlertTriangle className="h-8 w-8 mx-auto text-destructive" />
+              <h1 className="text-lg font-semibold">Something went wrong</h1>
+              <p className="text-sm text-muted-foreground">
+                The admin UI hit an unexpected error while rendering. Reload
+                the page to recover; details are in the browser console.
+              </p>
+              <Button onClick={() => window.location.reload()}>
+                Reload page
+              </Button>
+            </div>
+          </div>
+        )
+      );
+    }
+    return this.props.children;
+  }
+}
+
+function resetKeysChanged(
+  prev: readonly unknown[] | undefined,
+  next: readonly unknown[] | undefined
+): boolean {
+  if (prev === next) return false;
+  if (!prev || !next || prev.length !== next.length) return true;
+  return prev.some((value, i) => !Object.is(value, next[i]));
+}

--- a/src/components/ReportDetailErrorFallback.test.tsx
+++ b/src/components/ReportDetailErrorFallback.test.tsx
@@ -46,6 +46,19 @@ describe('ReportDetailErrorFallback', () => {
     expect(screen.getByText('HOSTILE-NonCanonical-Id')).toBeInTheDocument();
   });
 
+  it('survives non-array tags without crashing the fallback itself', () => {
+    render(
+      <ReportDetailErrorFallback
+        report={{ ...makeReport([]), tags: null as unknown as string[][] }}
+        onRetry={() => {}}
+        onDismiss={() => {}}
+      />
+    );
+
+    expect(screen.getByText(REPORT_ID)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+
   it('survives a non-string report id without crashing the fallback itself', () => {
     const onRetry = vi.fn();
     render(

--- a/src/components/ReportDetailErrorFallback.test.tsx
+++ b/src/components/ReportDetailErrorFallback.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { NostrEvent } from '@nostrify/nostrify';
+import { ReportDetailErrorFallback } from './ReportDetailErrorFallback';
+
+const REPORT_ID = 'a'.repeat(64);
+const TARGET_EVENT_ID = 'c'.repeat(64);
+const TARGET_PUBKEY = 'd'.repeat(64);
+
+function makeReport(tags: string[][]): NostrEvent {
+  return {
+    id: REPORT_ID,
+    pubkey: 'b'.repeat(64),
+    created_at: 1750000000,
+    kind: 1984,
+    tags,
+    content: 'spam',
+    sig: 'e'.repeat(128),
+  };
+}
+
+describe('ReportDetailErrorFallback', () => {
+  it('shows full untruncated identifiers from the report event', () => {
+    render(
+      <ReportDetailErrorFallback
+        report={makeReport([['e', TARGET_EVENT_ID, 'spam'], ['p', TARGET_PUBKEY, 'spam']])}
+        onRetry={() => {}}
+        onDismiss={() => {}}
+      />
+    );
+
+    expect(screen.getByText(REPORT_ID)).toBeInTheDocument();
+    expect(screen.getByText(TARGET_EVENT_ID)).toBeInTheDocument();
+    expect(screen.getByText(TARGET_PUBKEY)).toBeInTheDocument();
+  });
+
+  it("shows the report's own id VERBATIM when it is not canonical hex — a case-folded copy would fail lookups", () => {
+    render(
+      <ReportDetailErrorFallback
+        report={{ ...makeReport([]), id: 'HOSTILE-NonCanonical-Id' }}
+        onRetry={() => {}}
+        onDismiss={() => {}}
+      />
+    );
+
+    expect(screen.getByText('HOSTILE-NonCanonical-Id')).toBeInTheDocument();
+  });
+
+  it('survives a non-string report id without crashing the fallback itself', () => {
+    const onRetry = vi.fn();
+    render(
+      <ReportDetailErrorFallback
+        report={{ ...makeReport([]), id: null as unknown as string }}
+        onRetry={onRetry}
+        onDismiss={() => {}}
+      />
+    );
+
+    expect(screen.getByText(/failed to render/i)).toBeInTheDocument();
+    expect(screen.queryByText(/report id/i)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('accepts uppercase hex from reporter-authored tags and displays it lowercased', () => {
+    render(
+      <ReportDetailErrorFallback
+        report={makeReport([['e', TARGET_EVENT_ID.toUpperCase()]])}
+        onRetry={() => {}}
+        onDismiss={() => {}}
+      />
+    );
+
+    expect(screen.getByText(TARGET_EVENT_ID)).toBeInTheDocument();
+  });
+
+  it('omits identifiers that are not valid 64-char hex (reporter-authored tags)', () => {
+    render(
+      <ReportDetailErrorFallback
+        report={makeReport([['e', 'not-a-hex-id'], ['p', 'F'.repeat(9999)]])}
+        onRetry={() => {}}
+        onDismiss={() => {}}
+      />
+    );
+
+    expect(screen.getByText(REPORT_ID)).toBeInTheDocument();
+    expect(screen.queryByText(/target event/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/target pubkey/i)).not.toBeInTheDocument();
+    expect(screen.queryByText('not-a-hex-id')).not.toBeInTheDocument();
+  });
+
+  it('retries via the Try again button', () => {
+    const onRetry = vi.fn();
+    render(
+      <ReportDetailErrorFallback report={makeReport([])} onRetry={onRetry} onDismiss={() => {}} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('dismisses via the Dismiss button', () => {
+    const onDismiss = vi.fn();
+    render(
+      <ReportDetailErrorFallback report={makeReport([])} onRetry={() => {}} onDismiss={onDismiss} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it('renders without a report (crash before selection): retry only, no ids, no dismiss', () => {
+    const onRetry = vi.fn();
+    render(<ReportDetailErrorFallback report={null} onRetry={onRetry} onDismiss={() => {}} />);
+
+    expect(screen.getByText(/failed to render/i)).toBeInTheDocument();
+    expect(screen.queryByText(/report id/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /dismiss/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/ReportDetailErrorFallback.tsx
+++ b/src/components/ReportDetailErrorFallback.tsx
@@ -1,0 +1,64 @@
+// ABOUTME: Degraded-mode UI for a report whose detail pane crashed during render
+// ABOUTME: (hostile event data): full target identifiers + retry/dismiss (#158)
+
+import { AlertTriangle, RotateCcw, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { getReportTargetIds, isHex64 } from '@/lib/constants';
+import type { NostrEvent } from '@nostrify/nostrify';
+
+interface ReportDetailErrorFallbackProps {
+  /** The selected report event — it rendered in the list, so showing its
+   * fields is useful; IdentifierRow still guards every value individually. */
+  report: NostrEvent | null;
+  onRetry: () => void;
+  onDismiss: () => void;
+}
+
+// Target ids arrive pre-validated by getReportTargetIds; report.id is
+// whatever the worker returned (normally relay-verified, but this is the
+// degraded path — trust nothing). Valid hex lowercases to NIP-01 canonical
+// form; anything else renders VERBATIM, because a case-folded copy of a
+// non-canonical id would silently fail relay/D1/log lookups. Non-strings
+// are dropped — the crash fallback must never crash itself.
+function IdentifierRow({ label, value }: { label: string; value: string | undefined }) {
+  if (typeof value !== 'string') return null;
+  return (
+    <p className="text-xs font-mono break-all text-left">
+      <span className="text-muted-foreground select-none">{label}: </span>
+      {isHex64(value) ? value.toLowerCase() : value}
+    </p>
+  );
+}
+
+export function ReportDetailErrorFallback({ report, onRetry, onDismiss }: ReportDetailErrorFallbackProps) {
+  const targetIds = report ? getReportTargetIds(report) : null;
+  return (
+    <div className="flex h-full flex-col items-center justify-center space-y-3 p-8 text-center">
+      <AlertTriangle className="h-6 w-6 text-destructive" />
+      <p className="font-medium">This report failed to render</p>
+      <p className="text-sm text-muted-foreground">
+        It may contain malformed event data. The identifiers below are from the
+        report event itself; the crash details are in the browser console.
+      </p>
+      {report && (
+        <div className="w-full max-w-xl space-y-1 rounded border bg-muted/30 p-3">
+          <IdentifierRow label="report id" value={report.id} />
+          <IdentifierRow label="target event" value={targetIds?.eventId} />
+          <IdentifierRow label="target pubkey" value={targetIds?.pubkey} />
+        </div>
+      )}
+      <div className="flex items-center gap-2">
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          <RotateCcw className="mr-1 h-3 w-3" />
+          Try again
+        </Button>
+        {report && (
+          <Button variant="ghost" size="sm" onClick={onDismiss}>
+            <X className="mr-1 h-3 w-3" />
+            Dismiss
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Reports.test.tsx
+++ b/src/components/Reports.test.tsx
@@ -1,0 +1,87 @@
+// ABOUTME: Integration test for #158's acceptance wiring in Reports: a crashing
+// ABOUTME: ReportDetail degrades to the inline fallback while the list survives
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MockInstance } from 'vitest';
+import TestApp from '@/test/TestApp';
+import { Reports } from './Reports';
+
+// Stand-in for a detail pane crashed by hostile event data — always throws,
+// counting attempts so tests can observe boundary resets re-running it.
+const detailRender = vi.hoisted(() => ({ attempts: 0 }));
+vi.mock('@/components/ReportDetail', () => ({
+  ReportDetail: () => {
+    detailRender.attempts++;
+    throw new Error('hostile report data');
+  },
+}));
+
+const REPORT = {
+  id: 'a'.repeat(64),
+  pubkey: 'b'.repeat(64),
+  created_at: 1751000000,
+  kind: 1984,
+  tags: [['e', 'c'.repeat(64), 'spam'], ['p', 'd'.repeat(64), 'spam']],
+  content: 'comment spam',
+  sig: 'e'.repeat(128),
+};
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+let consoleError: MockInstance;
+
+beforeEach(() => {
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input instanceof Request ? input.url : input);
+    if (url.includes('/api/reports')) return jsonResponse({ success: true, events: [REPORT] });
+    if (url.includes('/api/resolution-labels')) return jsonResponse({ success: true, events: [] });
+    if (url.includes('/api/decisions')) return jsonResponse({ success: true, decisions: [] });
+    if (url.includes('/api/relay-rpc')) return jsonResponse({ success: true, result: [] });
+    return jsonResponse({ success: true });
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  consoleError.mockRestore();
+});
+
+describe('Reports crash degradation (#158)', () => {
+  it('degrades a crashing detail pane to the inline fallback while the list stays usable, and a row click retries', async () => {
+    render(
+      <TestApp>
+        <Reports relayUrl="wss://relay.example" />
+      </TestApp>
+    );
+
+    // Data loaded, mocked ReportDetail threw, scoped boundary caught it.
+    expect(await screen.findByText(/this report failed to render/i)).toBeInTheDocument();
+
+    // The list pane survived alongside the fallback: the report row rendered.
+    const row = await screen.findByText(/1 report$/);
+    expect(screen.getByText(/1 pending/i)).toBeInTheDocument();
+
+    // Clicking the report row re-attempts the detail render (boundary reset)
+    // and, with the report now selected, the fallback surfaces its full ids.
+    const attemptsBefore = detailRender.attempts;
+    fireEvent.click(row);
+    await waitFor(() => expect(detailRender.attempts).toBeGreaterThan(attemptsBefore));
+    expect(await screen.findByText('c'.repeat(64))).toBeInTheDocument();
+    expect(screen.getByText('d'.repeat(64))).toBeInTheDocument();
+    expect(screen.getByText(/this report failed to render/i)).toBeInTheDocument();
+
+    // Re-clicking the SAME row is also a retry: resetKeys don't change, so
+    // this exercises the explicit boundary reset in handleSelectReport.
+    const attemptsBeforeSameRow = detailRender.attempts;
+    fireEvent.click(row);
+    await waitFor(() => expect(detailRender.attempts).toBeGreaterThan(attemptsBeforeSameRow));
+    expect(screen.getByText(/this report failed to render/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/Reports.test.tsx
+++ b/src/components/Reports.test.tsx
@@ -27,6 +27,18 @@ const REPORT = {
   sig: 'e'.repeat(128),
 };
 
+// Hostile/malformed shape: tags is not an array. One bad report must not be
+// able to take down the whole queue (#161 review).
+const MALFORMED_REPORT = {
+  id: 'f'.repeat(64),
+  pubkey: 'b'.repeat(64),
+  created_at: 1751000100,
+  kind: 1984,
+  tags: null,
+  content: 'malformed report',
+  sig: 'e'.repeat(128),
+};
+
 function jsonResponse(body: unknown) {
   return new Response(JSON.stringify(body), {
     status: 200,
@@ -40,7 +52,7 @@ beforeEach(() => {
   consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
   vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input instanceof Request ? input.url : input);
-    if (url.includes('/api/reports')) return jsonResponse({ success: true, events: [REPORT] });
+    if (url.includes('/api/reports')) return jsonResponse({ success: true, events: [REPORT, MALFORMED_REPORT] });
     if (url.includes('/api/resolution-labels')) return jsonResponse({ success: true, events: [] });
     if (url.includes('/api/decisions')) return jsonResponse({ success: true, decisions: [] });
     if (url.includes('/api/relay-rpc')) return jsonResponse({ success: true, result: [] });
@@ -64,9 +76,13 @@ describe('Reports crash degradation (#158)', () => {
     // Data loaded, mocked ReportDetail threw, scoped boundary caught it.
     expect(await screen.findByText(/this report failed to render/i)).toBeInTheDocument();
 
-    // The list pane survived alongside the fallback: the report row rendered.
+    // The list pane survived alongside the fallback. The payload included a
+    // report with non-array tags: ingestion normalizes it (no crash, queue
+    // intact); target-less, it is skipped from the grouped view per existing
+    // consolidation semantics but stays reachable in the individual view.
     const row = await screen.findByText(/1 report$/);
     expect(screen.getByText(/1 pending/i)).toBeInTheDocument();
+    expect(screen.getByText('All (2)')).toBeInTheDocument();
 
     // Clicking the report row re-attempts the detail render (boundary reset)
     // and, with the report now selected, the fallback surfaces its full ids.

--- a/src/components/Reports.tsx
+++ b/src/components/Reports.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Displays kind 1984 reports with split-pane layout and consolidation
 // ABOUTME: Groups multiple reports on same target, shows count and all reporters
 
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -42,11 +42,33 @@ import {
 } from "lucide-react";
 import { nip19 } from "nostr-tools";
 import { ReportDetail } from "@/components/ReportDetail";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { ReportDetailErrorFallback } from "@/components/ReportDetailErrorFallback";
 import { useAdminApi } from "@/hooks/useAdminApi";
 import { AUTO_HIDE_ACTIONS, CATEGORY_LABELS, HIGH_PRIORITY_CATEGORIES, getReportCategory } from "@/lib/constants";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import type { NostrEvent } from "@nostrify/nostrify";
+
+// Scoped fallback for the reports-list pane (#158): list rows render
+// reporter-authored content too, and without a boundary a row crash escalates
+// to the app-root card, whose Reload would deterministically re-crash.
+function ReportsListErrorFallback({ onRetry }: { onRetry: () => void }) {
+  return (
+    <Card className="lg:col-span-2 flex h-full flex-col items-center justify-center space-y-3 overflow-hidden p-8 text-center">
+      <AlertTriangle className="h-6 w-6 text-destructive" />
+      <p className="font-medium">The reports list failed to render</p>
+      <p className="text-sm text-muted-foreground">
+        A report in the queue may contain malformed data. Details are in the
+        browser console.
+      </p>
+      <Button variant="outline" size="sm" onClick={onRetry}>
+        <RefreshCw className="mr-1 h-3 w-3" />
+        Try again
+      </Button>
+    </Card>
+  );
+}
 
 // Sort options for moderation queue
 type SortOption = 'reports' | 'newest' | 'oldest' | 'category' | 'reporters';
@@ -87,6 +109,12 @@ interface ConsolidatedReport {
   oldestReport: NostrEvent;
 }
 
+// Deliberately presence-based (a valueless ["e"] still yields an event target)
+// rather than delegating to getReportTargetIds: returning null here would drop
+// malformed reports from the consolidated queue entirely, and useReportContext/
+// ReportDetail carry identical copies the detail pane relies on. TODO(#160):
+// consolidate all report-target extraction sites behind shared helpers with
+// agreed semantics.
 function getReportTarget(event: NostrEvent): ReportTarget | null {
   const eTag = event.tags.find(t => t[0] === 'e');
   if (eTag) return { type: 'event', value: eTag[1] };
@@ -333,6 +361,7 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
   const queryClient = useQueryClient();
   const isMobile = useIsMobile();
   const [selectedReport, setSelectedReport] = useState<NostrEvent | null>(null);
+  const detailBoundaryRef = useRef<ErrorBoundary | null>(null);
   const [viewMode, setViewMode] = useState<'consolidated' | 'individual'>('consolidated');
   const [hideResolved, setHideResolved] = useState(true);
   const [showPendingReview, setShowPendingReview] = useState(false);
@@ -739,6 +768,10 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
 
   // Update URL when report selection changes
   const handleSelectReport = (report: NostrEvent | null) => {
+    // Re-clicking the already-selected report's row is a natural retry
+    // gesture after a crash, but it doesn't change resetKeys — clear the
+    // boundary explicitly (no-op when the pane is healthy).
+    detailBoundaryRef.current?.reset();
     setSelectedReport(report);
     if (report) {
       navigate(`/reports/${report.id}`, { replace: true });
@@ -746,6 +779,9 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
       navigate('/reports', { replace: true });
     }
   };
+  // One dismiss handler shared by the healthy detail pane and its crash
+  // fallback, so the two paths cannot drift.
+  const dismissDetail = () => handleSelectReport(null);
 
   // Wait for both reports AND decisions to load before rendering
   // This prevents auto-hidden CSAM from briefly appearing in default view
@@ -779,10 +815,42 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
     );
   }
 
+  // Built once and rendered in both the desktop pane and the mobile sheet so
+  // the two views cannot drift. Reports render attacker-authored event data:
+  // a crashing report degrades to the inline fallback (with the target's
+  // identifiers and retry/dismiss) while the reports list stays usable (#158).
+  const reportDetailPane = (
+    <ErrorBoundary
+      ref={detailBoundaryRef}
+      resetKeys={[selectedReport?.id]}
+      fallback={reset => (
+        <ReportDetailErrorFallback
+          report={selectedReport}
+          onRetry={reset}
+          onDismiss={dismissDetail}
+        />
+      )}
+    >
+      <ReportDetail
+        report={selectedReport}
+        allReportsForTarget={
+          selectedReport
+            ? consolidated.find(c =>
+                c.reports.some(r => r.id === selectedReport.id)
+              )?.reports
+            : undefined
+        }
+        allReports={reports || []}
+        onDismiss={dismissDetail}
+      />
+    </ErrorBoundary>
+  );
+
   return (
     <>
       <div className="grid grid-cols-1 lg:grid-cols-5 gap-4 h-full">
         {/* Left Pane - Report List */}
+        <ErrorBoundary fallback={reset => <ReportsListErrorFallback onRetry={reset} />}>
         <Card className="lg:col-span-2 h-full overflow-hidden flex flex-col">
         <CardHeader className="pb-3 shrink-0">
           <div className="flex items-center justify-between">
@@ -997,22 +1065,12 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
           </ScrollArea>
         </CardContent>
       </Card>
+        </ErrorBoundary>
 
         {/* Right Pane - Report Detail (Desktop) */}
         {!isMobile && (
           <Card className="lg:col-span-3 overflow-hidden h-full">
-            <ReportDetail
-              report={selectedReport}
-              allReportsForTarget={
-                selectedReport
-                  ? consolidated.find(c =>
-                      c.reports.some(r => r.id === selectedReport.id)
-                    )?.reports
-                  : undefined
-              }
-              allReports={reports || []}
-              onDismiss={() => handleSelectReport(null)}
-            />
+            {reportDetailPane}
           </Card>
         )}
       </div>
@@ -1021,18 +1079,7 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
       {isMobile && (
         <Sheet open={!!selectedReport} onOpenChange={(open) => !open && handleSelectReport(null)}>
           <SheetContent side="right" className="!w-full !max-w-[100vw] pt-10 px-0 pb-0 overflow-y-auto">
-            <ReportDetail
-              report={selectedReport}
-              allReportsForTarget={
-                selectedReport
-                  ? consolidated.find(c =>
-                      c.reports.some(r => r.id === selectedReport.id)
-                    )?.reports
-                  : undefined
-              }
-              allReports={reports || []}
-              onDismiss={() => handleSelectReport(null)}
-            />
+            {reportDetailPane}
           </SheetContent>
         </Sheet>
       )}

--- a/src/lib/adminApi.test.ts
+++ b/src/lib/adminApi.test.ts
@@ -1221,9 +1221,49 @@ describe('adminApi', () => {
 
       await expect(fetchReports(API_URL)).rejects.toThrow('HTTP 502');
     });
+
+    it('normalizes malformed tags and drops non-object events (raw payload is untrusted)', async () => {
+      const events = [
+        { id: 'r1', kind: 1984, pubkey: 'pk1', created_at: 100, content: '', sig: '' }, // tags missing
+        { id: 'r2', kind: 1984, pubkey: 'pk2', created_at: 200, tags: null, content: '', sig: '' },
+        { id: 'r3', kind: 1984, pubkey: 'pk3', created_at: 300, tags: 'junk', content: '', sig: '' },
+        { id: 'r4', kind: 1984, pubkey: 'pk4', created_at: 400, tags: [['e', 'ok'], 'rogue', [42, 'x'], ['p', 'ok2']], content: '', sig: '' },
+        null,
+        'not an event',
+      ];
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, events }),
+      });
+
+      const result = await fetchReports(API_URL);
+
+      // Sorted newest-first; every survivor has fully validated string[][] tags
+      expect(result.map(e => e.id)).toEqual(['r4', 'r3', 'r2', 'r1']);
+      expect(result.map(e => e.tags)).toEqual([
+        [['e', 'ok'], ['p', 'ok2']],
+        [],
+        [],
+        [],
+      ]);
+    });
   });
 
   describe('fetchResolutionLabels', () => {
+    it('normalizes malformed tags in label events too', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          events: [{ id: 'l1', kind: 1985, pubkey: 'pk', created_at: 1, tags: null, content: '', sig: '' }],
+        }),
+      });
+
+      const result = await fetchResolutionLabels(API_URL);
+      expect(result[0].tags).toEqual([]);
+    });
+
     it('should call /api/resolution-labels and return events', async () => {
       const events = [
         { id: 'label1', kind: 1985, pubkey: 'pk1', created_at: 100, tags: [['L', 'moderation/resolution']], content: '', sig: '' },

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -356,16 +356,34 @@ export async function listSuspendedPubkeys(apiUrl: string): Promise<BannedPubkey
   });
 }
 
+// Shape guard at the ingestion boundary: the worker's JSON is cast, not
+// validated, and everything downstream (report consolidation, category
+// parsing, the crash fallback) assumes `tags` is string[][]. Without this,
+// one malformed or hostile report crashes the whole reports list — a single
+// bad event hiding the entire moderation queue (#161 review). Same
+// element-level validation as parseRepostedEvent in lib/nip18.
+function sanitizeRelayEvents(events: unknown): NostrEvent[] {
+  if (!Array.isArray(events)) return [];
+  return events
+    .filter((e): e is NostrEvent => !!e && typeof e === 'object')
+    .map(e => ({
+      ...e,
+      tags: Array.isArray(e.tags)
+        ? e.tags.filter((t): t is string[] => Array.isArray(t) && t.every(x => typeof x === 'string'))
+        : [],
+    }));
+}
+
 // Fetch reports via server-side relay query (replaces browser WebSocket)
 export async function fetchReports(apiUrl: string): Promise<NostrEvent[]> {
   const data = await apiRequest<{ success: boolean; events: NostrEvent[] }>(apiUrl, '/api/reports', 'GET');
-  return (data.events || []).sort((a: NostrEvent, b: NostrEvent) => b.created_at - a.created_at);
+  return sanitizeRelayEvents(data.events).sort((a, b) => b.created_at - a.created_at);
 }
 
 // Fetch resolution labels via server-side relay query (replaces browser WebSocket)
 export async function fetchResolutionLabels(apiUrl: string): Promise<NostrEvent[]> {
   const data = await apiRequest<{ success: boolean; events: NostrEvent[] }>(apiUrl, '/api/resolution-labels', 'GET');
-  return data.events || [];
+  return sanitizeRelayEvents(data.events);
 }
 
 // Publish a NIP-32 label (kind 1985)

--- a/src/lib/constants.test.ts
+++ b/src/lib/constants.test.ts
@@ -91,4 +91,11 @@ describe('getReportTargetIds', () => {
     expect(getReportTargetIds({ tags: [['e', 'junk'], ['p', 'a'.repeat(63)]] }))
       .toEqual({ eventId: undefined, pubkey: undefined });
   });
+
+  it('tolerates non-array tags — the crash fallback must never crash itself', () => {
+    expect(getReportTargetIds({ tags: null as unknown as string[][] }))
+      .toEqual({ eventId: undefined, pubkey: undefined });
+    expect(getReportTargetIds({} as { tags: string[][] }))
+      .toEqual({ eventId: undefined, pubkey: undefined });
+  });
 });

--- a/src/lib/constants.test.ts
+++ b/src/lib/constants.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { CATEGORY_LABELS, getReportCategory } from './constants';
+import { CATEGORY_LABELS, getReportCategory, getReportTargetIds, isHex64 } from './constants';
 
 describe('CATEGORY_LABELS', () => {
   it('maps the divine-mobile NIP-32 labels to existing display labels', () => {
@@ -40,5 +40,55 @@ describe('getReportCategory', () => {
         ['l', 'NS-spam', 'social.nos.ontology'],
       ],
     })).toBe('spam');
+  });
+});
+
+describe('isHex64', () => {
+  it('accepts lowercase, uppercase, and mixed-case 64-char hex', () => {
+    expect(isHex64('a'.repeat(64))).toBe(true);
+    expect(isHex64('F'.repeat(64))).toBe(true);
+    expect(isHex64('aB3'.repeat(21) + 'c')).toBe(true);
+  });
+
+  it('rejects wrong lengths, non-hex characters, and non-strings', () => {
+    expect(isHex64('a'.repeat(63))).toBe(false);
+    expect(isHex64('a'.repeat(65))).toBe(false);
+    expect(isHex64('g'.repeat(64))).toBe(false);
+    expect(isHex64('')).toBe(false);
+    expect(isHex64(undefined)).toBe(false);
+    expect(isHex64(42)).toBe(false);
+    expect(isHex64(null)).toBe(false);
+  });
+});
+
+describe('getReportTargetIds', () => {
+  it('extracts the first e and p tag values', () => {
+    expect(getReportTargetIds({
+      tags: [
+        ['e', 'c'.repeat(64), 'spam'],
+        ['e', 'f'.repeat(64)],
+        ['p', 'd'.repeat(64), 'spam'],
+      ],
+    })).toEqual({ eventId: 'c'.repeat(64), pubkey: 'd'.repeat(64) });
+  });
+
+  it('returns undefined fields for missing or valueless tags', () => {
+    expect(getReportTargetIds({ tags: [] })).toEqual({ eventId: undefined, pubkey: undefined });
+    expect(getReportTargetIds({ tags: [['e'], ['p']] })).toEqual({ eventId: undefined, pubkey: undefined });
+  });
+
+  it('skips valueless or junk-valued tags so they do not mask later valid ones', () => {
+    expect(getReportTargetIds({
+      tags: [['e'], ['e', 'c'.repeat(64)], ['p'], ['p', 'd'.repeat(64)]],
+    })).toEqual({ eventId: 'c'.repeat(64), pubkey: 'd'.repeat(64) });
+
+    expect(getReportTargetIds({
+      tags: [['e', ''], ['e', 'c'.repeat(64)], ['p', 'junk'], ['p', 'd'.repeat(64)]],
+    })).toEqual({ eventId: 'c'.repeat(64), pubkey: 'd'.repeat(64) });
+  });
+
+  it('returns undefined when no tag value is a well-formed 64-hex id', () => {
+    expect(getReportTargetIds({ tags: [['e', 'junk'], ['p', 'a'.repeat(63)]] }))
+      .toEqual({ eventId: undefined, pubkey: undefined });
   });
 });

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -110,3 +110,24 @@ export function buildReasonString(categoryKey: string, note?: string): string {
   const label = getCategoryLabel(categoryKey);
   return note?.trim() ? `${label}: ${note.trim()}` : label;
 }
+
+// Nostr event ids, pubkeys, and sha256 hashes are 64 hex chars. NIP-01
+// canonical form is lowercase, but user-authored tag values may arrive
+// uppercase — accept either and let display sites lowercase for consistency.
+// Case-insensitive to match the existing inline checks in UserManagement/
+// EventsList; TODO(#160): migrate those inline regexes to this helper.
+export function isHex64(value: unknown): value is string {
+  return typeof value === 'string' && /^[0-9a-f]{64}$/i.test(value);
+}
+
+// A kind-1984 report's target ids: the first e/p tag values that are
+// well-formed 64-hex ids (NIP-56). Tags are reporter-authored, so valueless
+// or junk-valued tags (["e"], ["e", ""]) are skipped rather than allowed to
+// mask a later valid tag of the same name. Returned ids are validated but
+// not case-normalized — lowercase at display sites.
+export function getReportTargetIds(event: { tags: string[][] }): { eventId?: string; pubkey?: string } {
+  return {
+    eventId: event.tags.find(t => t[0] === 'e' && isHex64(t[1]))?.[1],
+    pubkey: event.tags.find(t => t[0] === 'p' && isHex64(t[1]))?.[1],
+  };
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -126,8 +126,11 @@ export function isHex64(value: unknown): value is string {
 // mask a later valid tag of the same name. Returned ids are validated but
 // not case-normalized — lowercase at display sites.
 export function getReportTargetIds(event: { tags: string[][] }): { eventId?: string; pubkey?: string } {
+  // Runtime guard despite the type: this feeds the crash fallback, which must
+  // never crash itself, and raw payload shapes are normalized elsewhere.
+  const tags = Array.isArray(event.tags) ? event.tags : [];
   return {
-    eventId: event.tags.find(t => t[0] === 'e' && isHex64(t[1]))?.[1],
-    pubkey: event.tags.find(t => t[0] === 'p' && isHex64(t[1]))?.[1],
+    eventId: tags.find(t => t[0] === 'e' && isHex64(t[1]))?.[1],
+    pubkey: tags.find(t => t[0] === 'p' && isHex64(t[1]))?.[1],
   };
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,7 +32,16 @@ export default defineConfig(() => {
     // worktree under `.worktrees/*/node_modules` (a full repo checkout) from
     // being globbed and running ~20k third-party package tests. We additionally
     // exclude the worktrees' own source and the separately-tested `worker/`.
-    exclude: [...configDefaults.exclude, '**/.worktrees/**', 'worker/**'],
+    // `.claude/worktrees/` is where Claude Code sessions place their worktrees:
+    // without the exclude, a main-clone test run collects a worktree's test
+    // files but resolves their `@/` imports against the main clone's src/,
+    // failing on any symbol that exists only on the worktree's branch.
+    exclude: [
+      ...configDefaults.exclude,
+      '**/.worktrees/**',
+      '**/.claude/worktrees/**',
+      'worker/**',
+    ],
     onConsoleLog(log) {
       return !log.includes("React Router Future Flag Warning");
     },


### PR DESCRIPTION
Closes #158

## What

follow-up out of #157's review loop: there was no React ErrorBoundary anywhere in src/, so any uncaught render exception unmounted the entire app — white screen, no recovery except reload. the report surfaces render attacker-authored event data, which made that class of crash a moderation-blocking failure on exactly the pages used to review hostile accounts. #157 closed one concrete vector (hostile inner-repost JSON reaching MediaPreview); this closes the class's blast radius.

- **`ErrorBoundary`** (new) — dependency-free class component (React has no hook equivalent). `fallback` takes a node or the render-prop form `(reset) => node`; `resetKeys` clears a caught error when the selection changes. error state is a boolean rather than the thrown value, so a hostile `throw null` can't trick the boundary into re-rendering the crashing subtree.
- **app root** — boundary wraps everything in `App.tsx`, outermost on purpose so the fallback can't depend on a provider that may itself have crashed. fallback: a centered card — warning icon, "Something went wrong", one line of guidance, and a Reload page button.
- **report detail** — the desktop pane and mobile sheet share one `reportDetailPane` element (deduplicated from two verbatim copies) inside a scoped boundary. a crashing report degrades to an inline fallback while the reports list stays usable; selecting a different report, re-clicking the same row, and the fallback's Try again all retry (the same-row click goes through a boundary reset ref, since resetKeys can't see a same-id selection).
- **`ReportDetailErrorFallback`** (new) — degraded mode is an action path, not a dead end: an inline card in the detail pane showing "This report failed to render" with the full untruncated report id, target event id, and target pubkey in a monospace block, plus Try again and Dismiss buttons. target ids go through validated extraction (the tags are reporter-authored — possibly the very garbage that crashed the render); a non-canonical report id renders verbatim, because a case-folded copy would silently fail relay/D1/log lookups; non-strings are dropped — the crash fallback must never crash itself.
- **reports list** — also boundary-wrapped: a hostile list row degrades to an inline "The reports list failed to render" card with a retry button, in the same grid cell, instead of escalating to the app-root card whose reload would deterministically re-crash.
- **`isHex64` / `getReportTargetIds`** in `src/lib/constants.ts` — shared and validated (junk or valueless tags can't mask a later valid id). TODO(#160) tracks consolidating the three legacy extraction copies and inline hex regexes onto shared helpers.
- **`vite.config.ts`** — excludes `**/.claude/worktrees/**` from vitest collection. found during this PR's own development: a session worktree under `.claude/worktrees/` breaks `npm run test` in the main clone (collection descends into the worktree's `worker/test/*.d1.test.ts` and fails resolving miniflare, and `@/` imports resolve against the wrong src/). verified empirically in both directions.

## Design notes

- during review i migrated the queue's `getReportTarget` onto the shared helper and reverted it: presence-based extraction is load-bearing for queue visibility (a malformed report must stay triageable), and `useReportContext`/`ReportDetail` carry identical copies the detail pane relies on. consolidating all four sites with agreed semantics is #160, deliberately not this PR.
- no moderation action buttons inside the crash fallback: identifiers + the surviving list are the action path; pulling action machinery into the degraded path risks the fallback itself throwing.
- `window.location.reload()` isn't click-tested — jsdom's location is unforgeable; covered by the browser verification below.
- the list-pane wrap has no dedicated crash test (row components live inside Reports.tsx and can't be module-mocked); the boundary component itself is heavily tested and the wiring is declarative.

## Verification

- tsc clean, eslint clean, 187 frontend tests pass (25 new). mutation-verified four ways: a reference-only resetKeys comparator, a deleted componentDidCatch, a removed boundary wrap, and a removed reset-ref line each fail the suite.
- `Reports.test.tsx` integration test locks the acceptance wiring: mocked always-throwing ReportDetail + stubbed worker API → inline fallback, surviving list, both retry gestures, full identifiers.
- exercised end-to-end in a real browser with temporary render throws: a crashing report degrades to the inline fallback (identifiers populated, Try again and Dismiss both working, deep-link URL cleared on dismiss) with the reports list fully interactive beside it; an app-level crash renders the root error card instead of a blank page, and its reload button reloads. the fallback markup is small and fully visible in the diff.
- worktree exclusion verified empirically: a fake nested worktree is not collected; all tests still list cleanly.
