### PR TITLE
fix(users): banned-user card surfaces all moderation-relevant kinds, not just text notes

### DIFF
--- a/src/components/BannedUserCard.test.tsx
+++ b/src/components/BannedUserCard.test.tsx
@@ -135,28 +135,17 @@ describe('BannedUserCard', () => {
     expect(await screen.findByText(`reposted event ${target}`)).toBeInTheDocument();
   });
 
-  it('does not render raw base64 file contents for kind 1064 (unmerged NIP-95 draft)', async () => {
-    const base64Blob = 'QmFzZTY0RmlsZURhdGE='.repeat(20);
-    setAuthored([event(1064, base64Blob, '9')]);
-    renderCard();
-
-    fireEvent.click(await screen.findByRole('button', { name: /toggle details/i }));
-
-    expect(await screen.findByText('File Data')).toBeInTheDocument();
-    expect(screen.queryByText(new RegExp('QmFzZTY0'))).not.toBeInTheDocument();
-  });
-
-  it('does not render base64 smuggled through a repost of a kind-1064 event', async () => {
-    const target = 'c'.repeat(64);
+  it("shows a repost's readable inner text even when a kind claim tries to disguise it", async () => {
+    // A reposter could tag readable spam ['k','1064'] to try to hide it; the
+    // card must still surface the text (evidence), never blank it.
     setAuthored([
-      event(16, JSON.stringify({ content: 'QmFzZTY0RGF0YQ=='.repeat(10), kind: 1064 }), '9', [['e', target], ['k', '1064']]),
+      event(16, JSON.stringify({ content: 'FREE GIVEAWAY click my profile', pubkey: 'b'.repeat(64) }), '9', [['e', 'c'.repeat(64)], ['k', '1064']]),
     ]);
     renderCard();
 
     fireEvent.click(await screen.findByRole('button', { name: /toggle details/i }));
 
-    expect(await screen.findByText(`reposted event ${target}`)).toBeInTheDocument();
-    expect(screen.queryByText(new RegExp('QmFzZTY0'))).not.toBeInTheDocument();
+    expect(await screen.findByText(/FREE GIVEAWAY click my profile/)).toBeInTheDocument();
   });
 
   it('identifies a-tag-only addressable reposts (NIP-18 latest-version pattern)', async () => {

--- a/src/components/BannedUserCard.test.tsx
+++ b/src/components/BannedUserCard.test.tsx
@@ -1,0 +1,180 @@
+// ABOUTME: Tests BannedUserCard's recent-content query kinds and rendering —
+// ABOUTME: banned comment-spam accounts must not show "No posts found" (#159)
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { NostrEvent } from '@nostrify/nostrify';
+import { RECENT_CONTENT_KINDS } from '@/lib/constants';
+import { BannedUserCard } from './BannedUserCard';
+
+const relayQuery = vi.hoisted(() => ({ fn: vi.fn() }));
+vi.mock('@nostrify/react', () => ({
+  useNostr: () => ({ nostr: { query: relayQuery.fn } }),
+}));
+
+// Profile loading is useAuthor's concern (tested elsewhere); these tests
+// exercise the recent-content query and rendering.
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({ data: undefined, isLoading: false }),
+}));
+
+const PUBKEY = 'a'.repeat(64);
+
+const T = 1_750_000_000;
+
+function event(kind: number, content: string, idByte: string, tags: string[][] = [], created_at = T + kind): NostrEvent {
+  return {
+    id: idByte.repeat(64),
+    pubkey: PUBKEY,
+    kind,
+    content,
+    tags,
+    created_at,
+    sig: 'f'.repeat(128),
+  };
+}
+
+const AUTHORED: NostrEvent[] = [
+  event(1111, 'repetitive scam comment', '1'),
+  event(16, JSON.stringify({ content: 'inner reposted text', kind: 22, pubkey: 'b'.repeat(64) }), '2'),
+  event(1, 'plain note', '3'),
+];
+
+// Point the relay mock's content query at a specific fixture set (profiles
+// go through the mocked useAuthor, so every nostr.query call here is the
+// content query). Returns a copy — the component sorts its results, and a
+// shared-reference fixture would be mutated across tests.
+function setAuthored(events: NostrEvent[]) {
+  relayQuery.fn.mockImplementation(async () => [...events]);
+}
+
+function renderCard() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <BannedUserCard pubkey={PUBKEY} />
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  relayQuery.fn.mockReset();
+  setAuthored(AUTHORED);
+});
+
+describe('BannedUserCard', () => {
+  it('queries the shared moderation-relevant kinds, not just kind 1', async () => {
+    renderCard();
+
+    await waitFor(() => {
+      const postFilter = relayQuery.fn.mock.calls
+        .map(args => args[0]?.[0])
+        .find(f => f?.kinds && !f.kinds.includes(0));
+      expect(postFilter?.kinds).toEqual([...RECENT_CONTENT_KINDS]);
+      // The kinds this issue exists for must never fall out of the list
+      expect(postFilter?.kinds).toContain(1111);
+      expect(postFilter?.kinds).toContain(6);
+      expect(postFilter?.kinds).toContain(16);
+    });
+  });
+
+  it('shows a banned comment-only account\'s comments with the Comment badge', async () => {
+    renderCard();
+
+    fireEvent.click(await screen.findByRole('button', { name: /toggle details/i }));
+
+    expect(await screen.findByText('repetitive scam comment')).toBeInTheDocument();
+    expect(screen.getByText('Comment')).toBeInTheDocument();
+  });
+
+  it('renders reposts as labeled inner content, not raw NIP-18 JSON', async () => {
+    renderCard();
+
+    fireEvent.click(await screen.findByRole('button', { name: /toggle details/i }));
+
+    expect(await screen.findByText(/inner reposted text/)).toBeInTheDocument();
+    expect(screen.getByText('Repost')).toBeInTheDocument();
+    expect(screen.queryByText(/"content"/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/"pubkey"/)).not.toBeInTheDocument();
+  });
+
+  it('counts all authored events, labeled as events rather than posts', async () => {
+    renderCard();
+
+    expect(await screen.findByText(/3 events on relay/)).toBeInTheDocument();
+  });
+
+  it('shows the newest 3 events regardless of relay result order', async () => {
+    // Relay order deliberately scrambled and NOT newest-first
+    setAuthored([
+      event(1, 'ancient note', '4', [], T - 9999),
+      event(1, 'middle note', '5', [], T + 200),
+      event(1, 'newest note', '6', [], T + 300),
+      event(1, 'older note', '7', [], T + 100),
+    ]);
+    renderCard();
+
+    fireEvent.click(await screen.findByRole('button', { name: /toggle details/i }));
+
+    expect(await screen.findByText('newest note')).toBeInTheDocument();
+    expect(screen.getByText('middle note')).toBeInTheDocument();
+    expect(screen.getByText('older note')).toBeInTheDocument();
+    expect(screen.queryByText('ancient note')).not.toBeInTheDocument();
+  });
+
+  it('identifies the target of an empty-content repost (NIP-18 allows empty content)', async () => {
+    const target = 'c'.repeat(64);
+    setAuthored([event(6, '', '8', [['e', target]])]);
+    renderCard();
+
+    fireEvent.click(await screen.findByRole('button', { name: /toggle details/i }));
+
+    expect(await screen.findByText(`reposted event ${target}`)).toBeInTheDocument();
+  });
+
+  it('does not render raw base64 file contents for kind 1064 (unmerged NIP-95 draft)', async () => {
+    const base64Blob = 'QmFzZTY0RmlsZURhdGE='.repeat(20);
+    setAuthored([event(1064, base64Blob, '9')]);
+    renderCard();
+
+    fireEvent.click(await screen.findByRole('button', { name: /toggle details/i }));
+
+    expect(await screen.findByText('File Data')).toBeInTheDocument();
+    expect(screen.queryByText(new RegExp('QmFzZTY0'))).not.toBeInTheDocument();
+  });
+
+  it('does not render base64 smuggled through a repost of a kind-1064 event', async () => {
+    const target = 'c'.repeat(64);
+    setAuthored([
+      event(16, JSON.stringify({ content: 'QmFzZTY0RGF0YQ=='.repeat(10), kind: 1064 }), '9', [['e', target], ['k', '1064']]),
+    ]);
+    renderCard();
+
+    fireEvent.click(await screen.findByRole('button', { name: /toggle details/i }));
+
+    expect(await screen.findByText(`reposted event ${target}`)).toBeInTheDocument();
+    expect(screen.queryByText(new RegExp('QmFzZTY0'))).not.toBeInTheDocument();
+  });
+
+  it('identifies a-tag-only addressable reposts (NIP-18 latest-version pattern)', async () => {
+    const coordinate = `34236:${'b'.repeat(64)}:my-video`;
+    setAuthored([event(16, '', '9', [['k', '34236'], ['a', coordinate]])]);
+    renderCard();
+
+    fireEvent.click(await screen.findByRole('button', { name: /toggle details/i }));
+
+    expect(await screen.findByText(`reposted ${coordinate}`)).toBeInTheDocument();
+  });
+
+  it('preserves out-of-spec repost content as moderation evidence instead of discarding it', async () => {
+    setAuthored([event(6, 'plain text spam pushed as a repost', '9')]);
+    renderCard();
+
+    fireEvent.click(await screen.findByRole('button', { name: /toggle details/i }));
+
+    expect(await screen.findByText(/plain text spam pushed as a repost/)).toBeInTheDocument();
+  });
+});

--- a/src/components/BannedUserCard.tsx
+++ b/src/components/BannedUserCard.tsx
@@ -15,8 +15,10 @@ import {
 } from "@/components/ui/collapsible";
 import { ExternalLink, FileText, ChevronDown, Copy, Check, Trash2 } from "lucide-react";
 import { useState } from "react";
-import type { NostrMetadata } from "@nostrify/nostrify";
-import { getProfileUrl } from "@/lib/constants";
+import { getProfileUrl, RECENT_CONTENT_KINDS } from "@/lib/constants";
+import { parseRepostForDisplay } from "@/lib/nip18";
+import { KindBadge } from "@/components/KindBadge";
+import { useAuthor } from "@/hooks/useAuthor";
 
 interface BannedUserCardProps {
   pubkey: string;
@@ -48,38 +50,31 @@ export function BannedUserCard({ pubkey: rawPubkey, reason, onUnban, actionButto
   }
   const shortNpub = npub.slice(0, 12) + '...' + npub.slice(-8);
 
-  // Fetch user profile
-  const { data: profile, isLoading: profileLoading } = useQuery({
-    queryKey: ['profile', pubkey],
-    queryFn: async ({ signal }) => {
-      const events = await nostr.query(
-        [{ kinds: [0], authors: [pubkey], limit: 1 }],
-        { signal: AbortSignal.any([signal, AbortSignal.timeout(3000)]) }
-      );
-      if (events.length > 0) {
-        try {
-          return JSON.parse(events[0].content) as NostrMetadata;
-        } catch {
-          return null;
-        }
-      }
-      return null;
-    },
-  });
+  // Profile via the shared useAuthor hook (Funnelcake REST fast path,
+  // validated metadata, its own staleTime) instead of a hand-rolled query
+  const { data: author, isLoading: profileLoading } = useAuthor(pubkey);
+  const profile = author?.metadata;
 
-  // Fetch recent posts count
+  // Fetch recent authored content — kind 1 alone missed comment-spam accounts
+  // whose only activity is comments/reposts (#159); RECENT_CONTENT_KINDS is
+  // shared with useUserStats so this card and the report page stay aligned.
   const { data: postStats } = useQuery({
     queryKey: ['user-posts-stats', pubkey],
     queryFn: async ({ signal }) => {
       const events = await nostr.query(
-        [{ kinds: [1], authors: [pubkey], limit: 50 }],
+        [{ kinds: [...RECENT_CONTENT_KINDS], authors: [pubkey], limit: 50 }],
         { signal: AbortSignal.any([signal, AbortSignal.timeout(3000)]) }
       );
       return {
         count: events.length,
-        recentPosts: events.slice(0, 3),
+        // Relay result order isn't guaranteed — sort (a copy) newest-first
+        recentPosts: [...events].sort((a, b) => b.created_at - a.created_at).slice(0, 3),
       };
     },
+    // UserManagement renders one card per banned/suspended user and Radix
+    // Tabs remount on tab switch — without staleTime every switch refires
+    // N x 2 relay queries (aligned with useUserStats' 2min)
+    staleTime: 2 * 60_000,
   });
 
   const displayName = profile?.name || profile?.display_name || shortNpub;
@@ -138,6 +133,7 @@ export function BannedUserCard({ pubkey: rawPubkey, reason, onUnban, actionButto
                   size="sm"
                   className="h-5 w-5 p-0"
                   onClick={copyNpub}
+                  aria-label="Copy npub"
                 >
                   {copied ? (
                     <Check className="h-3 w-3 text-green-500" />
@@ -151,7 +147,7 @@ export function BannedUserCard({ pubkey: rawPubkey, reason, onUnban, actionButto
               <div className="flex items-center gap-3 mt-2 text-sm">
                 <span className="flex items-center gap-1 text-muted-foreground">
                   <FileText className="h-3 w-3" />
-                  {postStats?.count || 0} posts on relay
+                  {postStats?.count || 0} events on relay
                 </span>
                 <a
                   href={njumpUrl}
@@ -178,7 +174,7 @@ export function BannedUserCard({ pubkey: rawPubkey, reason, onUnban, actionButto
             {/* Actions */}
             <div className="flex items-center gap-2">
               <CollapsibleTrigger asChild>
-                <Button variant="ghost" size="sm">
+                <Button variant="ghost" size="sm" aria-label={`Toggle details for ${displayName}`}>
                   <ChevronDown
                     className={`h-4 w-4 transition-transform ${
                       isOpen ? 'rotate-180' : ''
@@ -207,28 +203,54 @@ export function BannedUserCard({ pubkey: rawPubkey, reason, onUnban, actionButto
               </div>
             )}
 
-            {/* Recent posts */}
+            {/* Recent authored content */}
             <div>
               <h4 className="text-xs font-medium text-muted-foreground uppercase mb-2">
-                Recent Posts on This Relay
+                Recent Content on This Relay
               </h4>
               {postStats?.recentPosts && postStats.recentPosts.length > 0 ? (
                 <div className="space-y-2">
-                  {postStats.recentPosts.map((post) => (
-                    <div
-                      key={post.id}
-                      className="text-sm p-2 bg-background rounded border"
-                    >
-                      <p className="line-clamp-2">{post.content}</p>
-                      <p className="text-xs text-muted-foreground mt-1">
-                        {new Date(post.created_at * 1000).toLocaleString()}
-                      </p>
-                    </div>
-                  ))}
+                  {postStats.recentPosts.map((post) => {
+                    // Shared NIP-18 display derivation — inner content for
+                    // reposts (never raw JSON), file-data kinds suppressed,
+                    // out-of-spec repost content preserved as evidence.
+                    const { isRepost, inner, displayContent, targetDescription } = parseRepostForDisplay(post);
+                    return (
+                      <div
+                        key={post.id}
+                        className="text-sm p-2 bg-background rounded border space-y-1"
+                      >
+                        {displayContent && (
+                          <p className="line-clamp-2 break-all">
+                            {isRepost && (
+                              <span
+                                className="text-muted-foreground italic"
+                                title={inner?.pubkey ? `Reposted from pubkey ${inner.pubkey}` : undefined}
+                              >
+                                reposted:{' '}
+                              </span>
+                            )}
+                            {displayContent}
+                          </p>
+                        )}
+                        {/* Reposts with nothing displayable — identify the target
+                            (e-tag event id or a-tag coordinate per NIP-18) */}
+                        {isRepost && !displayContent && targetDescription && (
+                          <p className="text-xs text-muted-foreground italic break-all line-clamp-2">
+                            reposted {targetDescription}
+                          </p>
+                        )}
+                        <div className="flex items-center justify-between text-xs text-muted-foreground">
+                          <span>{new Date(post.created_at * 1000).toLocaleString()}</span>
+                          <KindBadge kind={post.kind} />
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
               ) : (
                 <p className="text-sm text-muted-foreground">
-                  No posts found on this relay
+                  No recent content found on this relay
                 </p>
               )}
             </div>

--- a/src/components/KindBadge.tsx
+++ b/src/components/KindBadge.tsx
@@ -1,0 +1,45 @@
+// ABOUTME: Shared kind badge for recent-content rows — single source of truth
+// ABOUTME: for how event kinds are labeled across moderation surfaces
+
+import { Badge } from '@/components/ui/badge';
+import { Globe, MessageSquare, Repeat, Video } from 'lucide-react';
+import { getKindName, isVideoKind } from '@/lib/kindNames';
+import { isRepostKind } from '@/lib/nip18';
+
+// Extracted verbatim from UserProfileCard's recent-content rows (#157) so
+// BannedUserCard and any future surface label kinds identically (#159).
+export function KindBadge({ kind }: { kind: number }) {
+  if (isVideoKind(kind)) {
+    return (
+      <Badge variant="default" className="text-xs gap-1 bg-green-600" title="Video (NIP-71) — visible in Divine apps">
+        <Video className="h-3 w-3" />Video
+      </Badge>
+    );
+  }
+  if (kind === 1111) {
+    return (
+      <Badge variant="outline" className="text-xs gap-1 text-green-600 border-green-300 bg-green-50" title="Comment (kind 1111) — visible in Divine apps when attached to a video">
+        <MessageSquare className="h-3 w-3" />Comment
+      </Badge>
+    );
+  }
+  if (isRepostKind(kind)) {
+    return (
+      <Badge variant="outline" className="text-xs gap-1 text-blue-600 border-blue-300 bg-blue-50" title="Repost — boosts another user's content into feeds">
+        <Repeat className="h-3 w-3" />Repost
+      </Badge>
+    );
+  }
+  if (kind === 1) {
+    return (
+      <Badge variant="outline" className="text-xs gap-1 text-amber-600 border-amber-300 bg-amber-50" title="Text note (kind 1) — not visible in Divine apps. Only visible via external Nostr clients.">
+        <Globe className="h-3 w-3" />Note
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="outline" className="text-xs gap-1 text-amber-600 border-amber-300 bg-amber-50" title={`${getKindName(kind)} — not shown as content in Divine apps`}>
+      <Globe className="h-3 w-3" />{getKindName(kind)}
+    </Badge>
+  );
+}

--- a/src/components/UserProfileCard.test.tsx
+++ b/src/components/UserProfileCard.test.tsx
@@ -83,17 +83,18 @@ describe('UserProfileCard', () => {
     expect(screen.getByText(`reposted event ${'c'.repeat(64)}`)).toBeInTheDocument();
   });
 
-  it('does not render base64 smuggled through a repost of a kind-1064 event', () => {
-    const repostOf1064 = post(
+  it("shows a repost's readable inner text even when a kind claim tries to disguise it", () => {
+    // A reposter could tag readable spam ['k','1064'] to try to hide it; the
+    // card must still surface the text (evidence), never blank it.
+    const disguised = post(
       16,
-      JSON.stringify({ content: 'QmFzZTY0RGF0YQ=='.repeat(10), kind: 1064 }),
+      JSON.stringify({ content: 'FREE GIVEAWAY click my profile', kind: 1064, pubkey: 'b'.repeat(64) }),
       '7',
       [['e', 'c'.repeat(64)], ['k', '1064']]
     );
-    render(<UserProfileCard pubkey={PUBKEY} stats={stats([repostOf1064])} />);
+    render(<UserProfileCard pubkey={PUBKEY} stats={stats([disguised])} />);
 
-    expect(screen.queryByText(/QmFzZTY0/)).not.toBeInTheDocument();
-    expect(screen.getByText(`reposted event ${'c'.repeat(64)}`)).toBeInTheDocument();
+    expect(screen.getByText(/FREE GIVEAWAY click my profile/)).toBeInTheDocument();
   });
 
   it('shows View Activity only when onViewActivity is provided, and fires it', () => {

--- a/src/components/UserProfileCard.test.tsx
+++ b/src/components/UserProfileCard.test.tsx
@@ -83,6 +83,19 @@ describe('UserProfileCard', () => {
     expect(screen.getByText(`reposted event ${'c'.repeat(64)}`)).toBeInTheDocument();
   });
 
+  it('does not render base64 smuggled through a repost of a kind-1064 event', () => {
+    const repostOf1064 = post(
+      16,
+      JSON.stringify({ content: 'QmFzZTY0RGF0YQ=='.repeat(10), kind: 1064 }),
+      '7',
+      [['e', 'c'.repeat(64)], ['k', '1064']]
+    );
+    render(<UserProfileCard pubkey={PUBKEY} stats={stats([repostOf1064])} />);
+
+    expect(screen.queryByText(/QmFzZTY0/)).not.toBeInTheDocument();
+    expect(screen.getByText(`reposted event ${'c'.repeat(64)}`)).toBeInTheDocument();
+  });
+
   it('shows View Activity only when onViewActivity is provided, and fires it', () => {
     const onViewActivity = vi.fn();
 

--- a/src/components/UserProfileCard.tsx
+++ b/src/components/UserProfileCard.tsx
@@ -9,13 +9,13 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useApiUrl } from "@/hooks/useAdminApi";
-import { User, FileText, Flag, Tag, CheckCircle, ChevronDown, ChevronUp, Copy, Check, ArrowUpRight, Trash2, Globe, ExternalLink, Video, MessageSquare, Activity, Repeat } from "lucide-react";
+import { User, FileText, Flag, Tag, CheckCircle, ChevronDown, ChevronUp, Copy, Check, ArrowUpRight, Trash2, Globe, ExternalLink, Activity } from "lucide-react";
 import { InlineMediaPreview } from "@/components/MediaPreview";
 import type { NostrEvent, NostrMetadata } from "@nostrify/nostrify";
 import type { UserStats } from "@/hooks/useUserStats";
 import { getProfileUrl, getPublicEventUrl } from "@/lib/constants";
-import { getKindName } from "@/lib/kindNames";
-import { getRepostTargetId, isRepostKind, parseRepostedEvent } from "@/lib/nip18";
+import { parseRepostForDisplay } from "@/lib/nip18";
+import { KindBadge } from "@/components/KindBadge";
 
 // Label category colors
 const LABEL_COLORS: Record<string, string> = {
@@ -279,9 +279,10 @@ function RecentPostsSection({
           {visiblePosts.map(post => {
             // Kind 6/16 content is the stringified JSON of the reposted event
             // (NIP-18) — surface the inner content, labeled, instead of raw JSON.
-            const isRepost = isRepostKind(post.kind);
-            const inner = isRepost ? parseRepostedEvent(post.content) : null;
-            const displayContent = isRepost ? (inner?.content ?? '') : post.content;
+            // Shared NIP-18 display derivation — inner content for reposts
+            // (never raw JSON), file-data kinds suppressed (direct or
+            // smuggled through a repost), out-of-spec content preserved.
+            const { isRepost, inner, displayContent, targetDescription } = parseRepostForDisplay(post);
             return (
               <div key={post.id} className="p-3 bg-muted rounded-lg space-y-2 overflow-hidden">
                 {/* Post content */}
@@ -298,15 +299,13 @@ function RecentPostsSection({
                     {displayContent}
                   </p>
                 )}
-                {/* NIP-18 allows empty repost content — at least identify the target event */}
-                {isRepost && !displayContent && (() => {
-                  const targetId = getRepostTargetId(post.tags);
-                  return targetId ? (
-                    <p className="text-xs text-muted-foreground italic break-all">
-                      reposted event {targetId}
-                    </p>
-                  ) : null;
-                })()}
+                {/* Reposts with nothing displayable — identify the target
+                    (e-tag event id or a-tag coordinate per NIP-18) */}
+                {isRepost && !displayContent && targetDescription && (
+                  <p className="text-xs text-muted-foreground italic break-all line-clamp-2">
+                    reposted {targetDescription}
+                  </p>
+                )}
 
                 {/* Media preview - uses InlineMediaPreview for admin proxy fallback.
                     Reposts pass the inner event's content+tags so its media resolves. */}
@@ -332,17 +331,7 @@ function RecentPostsSection({
                         );
                       } catch { return null; }
                     })()}
-                    {(post.kind === 21 || post.kind === 22 || post.kind === 34235 || post.kind === 34236) ? (
-                      <Badge variant="default" className="text-xs gap-1 bg-green-600" title="Video (NIP-71) — visible in Divine apps"><Video className="h-3 w-3" />Video</Badge>
-                    ) : post.kind === 1111 ? (
-                      <Badge variant="outline" className="text-xs gap-1 text-green-600 border-green-300 bg-green-50" title="Comment (kind 1111) — visible in Divine apps when attached to a video"><MessageSquare className="h-3 w-3" />Comment</Badge>
-                    ) : isRepost ? (
-                      <Badge variant="outline" className="text-xs gap-1 text-blue-600 border-blue-300 bg-blue-50" title="Repost — boosts another user's content into feeds"><Repeat className="h-3 w-3" />Repost</Badge>
-                    ) : post.kind === 1 ? (
-                      <Badge variant="outline" className="text-xs gap-1 text-amber-600 border-amber-300 bg-amber-50" title="Text note (kind 1) — not visible in Divine apps. Only visible via external Nostr clients."><Globe className="h-3 w-3" />Note</Badge>
-                    ) : (
-                      <Badge variant="outline" className="text-xs gap-1 text-amber-600 border-amber-300 bg-amber-50" title={`${getKindName(post.kind)} — not shown as content in Divine apps`}><Globe className="h-3 w-3" />{getKindName(post.kind)}</Badge>
-                    )}
+                    <KindBadge kind={post.kind} />
                     {onDeleteEvent && (
                       <Button
                         variant="ghost"

--- a/src/hooks/useUserStats.ts
+++ b/src/hooks/useUserStats.ts
@@ -3,6 +3,7 @@
 
 import { useNostr } from "@nostrify/react";
 import { useQuery } from "@tanstack/react-query";
+import { RECENT_CONTENT_KINDS } from "@/lib/constants";
 import type { NostrEvent } from "@nostrify/nostrify";
 
 export interface UserStats {
@@ -36,12 +37,10 @@ export function useUserStats(pubkey: string | undefined) {
 
       // Fetch in parallel
       const [recentPosts, existingLabels, previousReports] = await Promise.all([
-        // User's recent posts (text notes, video events, and other content)
-        // Video kinds per NIP-71: 21 (Video), 22 (Short Video), 34235 (Addressable Video), 34236 (Addressable Short Video)
-        // 1111 (NIP-22 comments) and 6/16 (reposts) matter for moderation:
-        // comment-spam accounts often have no other content (#156)
+        // User's recent authored content — RECENT_CONTENT_KINDS is shared with
+        // BannedUserCard so the two review surfaces stay aligned (#159).
         nostr.query(
-          [{ kinds: [1, 6, 16, 21, 22, 1063, 1064, 20, 1111, 30023, 34235, 34236], authors: [pubkey], limit: 20 }],
+          [{ kinds: [...RECENT_CONTENT_KINDS], authors: [pubkey], limit: 20 }],
           { signal: combinedSignal }
         ),
         // Labels against this user

--- a/src/hooks/useUserSummary.ts
+++ b/src/hooks/useUserSummary.ts
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import type { NostrEvent } from "@nostrify/nostrify";
 import { getApiHeaders } from "@/lib/adminApi";
 import { useApiUrl } from "@/hooks/useAdminApi";
-import { getRepostTargetId, isRepostKind, parseRepostedEvent } from "@/lib/nip18";
+import { parseRepostForDisplay } from "@/lib/nip18";
 
 interface SummaryResponse {
   summary: string;
@@ -31,19 +31,24 @@ export function useUserSummary(
         headers: getApiHeaders(),
         body: JSON.stringify({
           pubkey,
-          recentPosts: recentPosts.slice(0, 10).map(e => ({
-            // Reposts send the inner (reposted) text, not the raw NIP-18 JSON —
-            // the worker slices to 200 chars, which would otherwise all be hex
-            // noise. Empty/unparseable reposts fall back to the target event id.
-            content: isRepostKind(e.kind)
-              ? (parseRepostedEvent(e.content)?.content
-                || `[reposted event ${getRepostTargetId(e.tags) ?? 'unknown'}]`)
-              : e.content,
-            created_at: e.created_at,
-            // Kind lets the summarizer distinguish authored posts from
-            // comments (1111) and reposts of others' content (6/16) — see #156
-            kind: e.kind,
-          })),
+          recentPosts: recentPosts.slice(0, 10).map(e => {
+            // Shared display derivation (parseRepostForDisplay): reposts send
+            // the inner text, never raw NIP-18 JSON; kind-1064 base64 (direct
+            // or smuggled through a repost) is replaced with a marker so the
+            // AI prompt isn't fed file bytes as authored posts.
+            const display = parseRepostForDisplay(e);
+            const content = display.isRepost
+              ? (display.displayContent
+                || `[reposted ${display.targetDescription ?? 'unknown target'}]`)
+              : display.contentSuppressed ? '[file data]' : display.displayContent;
+            return {
+              content,
+              created_at: e.created_at,
+              // Kind lets the summarizer distinguish authored posts from
+              // comments (1111) and reposts of others' content (6/16) — see #156
+              kind: e.kind,
+            };
+          }),
           existingLabels: existingLabels?.map(e => ({
             tags: e.tags,
             created_at: e.created_at,

--- a/src/hooks/useUserSummary.ts
+++ b/src/hooks/useUserSummary.ts
@@ -33,14 +33,13 @@ export function useUserSummary(
           pubkey,
           recentPosts: recentPosts.slice(0, 10).map(e => {
             // Shared display derivation (parseRepostForDisplay): reposts send
-            // the inner text, never raw NIP-18 JSON; kind-1064 base64 (direct
-            // or smuggled through a repost) is replaced with a marker so the
-            // AI prompt isn't fed file bytes as authored posts.
+            // the inner text, never raw NIP-18 JSON. An empty-content repost
+            // falls back to its target label.
             const display = parseRepostForDisplay(e);
             const content = display.isRepost
               ? (display.displayContent
                 || `[reposted ${display.targetDescription ?? 'unknown target'}]`)
-              : display.contentSuppressed ? '[file data]' : display.displayContent;
+              : display.displayContent;
             return {
               content,
               created_at: e.created_at,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -77,7 +77,10 @@ export const UNDERAGE_REPORT_CATEGORY = 'NS-underageUser';
 // list so consuming surfaces can't drift. TODO(#162): UserProfilePreview
 // (Labels page) still carries its own inline list — aligning it also needs
 // the shared rendering pieces, tracked there.
-export const RECENT_CONTENT_KINDS = [1, 6, 16, ...VIDEO_KINDS, 20, 1063, 1064, 1111, 30023] as const;
+// Deliberately excludes kind 1064 (defunct NIP-95 draft, inline base64 file
+// bytes): not a current protocol kind, zero events on the Divine relay, and
+// Divine puts media on Blossom as URLs — querying it only pulled base64 noise.
+export const RECENT_CONTENT_KINDS = [1, 6, 16, ...VIDEO_KINDS, 20, 1063, 1111, 30023] as const;
 
 // Helper to get label with fallback
 export function getCategoryLabel(category: string): string {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,5 @@
 import { getEnvironmentByApiUrl } from "@/lib/environments";
+import { VIDEO_KINDS } from "@/lib/kindNames";
 export { AUTO_HIDE_ACTION, AUTO_HIDE_ACTIONS, type AutoHideAction } from "../../shared/autohide";
 
 // ABOUTME: Shared constants for moderation categories and labels
@@ -68,6 +69,15 @@ export const HIGH_PRIORITY_CATEGORIES = [
 // on this same literal). Distinct from HIGH_PRIORITY_CATEGORIES: CSAM /
 // child-safety are a separate, non-reversible path, not age review.
 export const UNDERAGE_REPORT_CATEGORY = 'NS-underageUser';
+
+// Authored-content kinds surfaced on moderation review cards (report detail's
+// useUserStats and BannedUserCard). Video kinds per NIP-71: 21/22/34235/34236.
+// 1111 (NIP-22 comments) and 6/16 (reposts) matter for moderation because
+// comment-spam accounts often have no other content (#156, #159). One shared
+// list so consuming surfaces can't drift. TODO(#162): UserProfilePreview
+// (Labels page) still carries its own inline list — aligning it also needs
+// the shared rendering pieces, tracked there.
+export const RECENT_CONTENT_KINDS = [1, 6, 16, ...VIDEO_KINDS, 20, 1063, 1064, 1111, 30023] as const;
 
 // Helper to get label with fallback
 export function getCategoryLabel(category: string): string {

--- a/src/lib/kindNames.ts
+++ b/src/lib/kindNames.ts
@@ -35,6 +35,7 @@ export const KIND_NAMES: Record<number, { name: string; description: string; nip
   1040: { name: 'OpenTimestamps', description: 'OpenTimestamps attestation', nip: 'NIP-03' },
   1059: { name: 'Gift Wrap', description: 'Gift wrapped encrypted event', nip: 'NIP-59' },
   1063: { name: 'File Metadata', description: 'File/media metadata', nip: 'NIP-94' },
+  1064: { name: 'File Data', description: 'Inline base64 file contents (draft NIP-95, never merged)', nip: '' },
   1111: { name: 'Comment', description: 'Comment on any event', nip: 'NIP-22' },
 
   // Reports and Moderation
@@ -148,6 +149,19 @@ export const KIND_NAMES: Record<number, { name: string; description: string; nip
   // What's Hot (custom)
   11998: { name: "What's Hot", description: 'Trending/hot content aggregation', nip: '' },
 };
+
+// NIP-71 video kinds: 21 (Video), 22 (Short Video), 34235/34236 (addressable)
+export const VIDEO_KINDS = [21, 22, 34235, 34236] as const;
+
+export function isVideoKind(kind: number): boolean {
+  return (VIDEO_KINDS as readonly number[]).includes(kind);
+}
+
+// Kind 1064 (draft NIP-95) carries raw base64 file bytes in content —
+// never render it as text.
+export function hasDisplayableContent(kind: number): boolean {
+  return kind !== 1064;
+}
 
 // Get kind name with fallback
 export function getKindName(kind: number): string {

--- a/src/lib/kindNames.ts
+++ b/src/lib/kindNames.ts
@@ -35,7 +35,6 @@ export const KIND_NAMES: Record<number, { name: string; description: string; nip
   1040: { name: 'OpenTimestamps', description: 'OpenTimestamps attestation', nip: 'NIP-03' },
   1059: { name: 'Gift Wrap', description: 'Gift wrapped encrypted event', nip: 'NIP-59' },
   1063: { name: 'File Metadata', description: 'File/media metadata', nip: 'NIP-94' },
-  1064: { name: 'File Data', description: 'Inline base64 file contents (draft NIP-95, never merged)', nip: '' },
   1111: { name: 'Comment', description: 'Comment on any event', nip: 'NIP-22' },
 
   // Reports and Moderation
@@ -155,12 +154,6 @@ export const VIDEO_KINDS = [21, 22, 34235, 34236] as const;
 
 export function isVideoKind(kind: number): boolean {
   return (VIDEO_KINDS as readonly number[]).includes(kind);
-}
-
-// Kind 1064 (draft NIP-95) carries raw base64 file bytes in content —
-// never render it as text.
-export function hasDisplayableContent(kind: number): boolean {
-  return kind !== 1064;
 }
 
 // Get kind name with fallback

--- a/src/lib/nip18.test.ts
+++ b/src/lib/nip18.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Tests NIP-18 repost parsing edge cases (empty/malformed/non-event JSON)
 
 import { describe, it, expect } from 'vitest';
-import { getRepostTargetId, isRepostKind, parseRepostedEvent } from './nip18';
+import { getRepostTargetId, isRepostKind, parseRepostedEvent, describeRepostTarget, getRepostKind, getRepostTargetCoordinate, parseRepostForDisplay } from './nip18';
 
 describe('isRepostKind', () => {
   it('matches kinds 6 and 16 only', () => {
@@ -27,6 +27,7 @@ describe('parseRepostedEvent', () => {
       content: 'hello',
       tags: [['e', 'abc']],
       pubkey: 'f'.repeat(64),
+      kind: 34236,
     });
   });
 
@@ -61,5 +62,121 @@ describe('parseRepostedEvent', () => {
     expect(
       parseRepostedEvent(JSON.stringify({ content: 'x', tags: [['imeta', 42], ['e', 'abc'], [null]] }))
     ).toEqual({ content: 'x', tags: [['e', 'abc']], pubkey: '' });
+  });
+});
+
+describe('parseRepostedEvent inner kind', () => {
+  it('exposes a numeric inner kind and drops non-numeric ones', () => {
+    expect(parseRepostedEvent(JSON.stringify({ content: 'x', kind: 1064 }))?.kind).toBe(1064);
+    expect(parseRepostedEvent(JSON.stringify({ content: 'x', kind: '22' }))?.kind).toBeUndefined();
+  });
+});
+
+describe('getRepostKind', () => {
+  it('parses the NIP-18 k tag', () => {
+    expect(getRepostKind([['k', '34236']])).toBe(34236);
+  });
+
+  it('rejects missing or malformed k tags', () => {
+    expect(getRepostKind([])).toBeUndefined();
+    expect(getRepostKind([['k']])).toBeUndefined();
+    expect(getRepostKind([['k', 'abc']])).toBeUndefined();
+    expect(getRepostKind([['k', '12abc']])).toBeUndefined();
+  });
+});
+
+describe('getRepostTargetCoordinate', () => {
+  const PK = 'b'.repeat(64);
+
+  it('returns a well-formed a-tag coordinate (addressable repost, NIP-18)', () => {
+    expect(getRepostTargetCoordinate([['a', `34236:${PK}:my-video`]])).toBe(`34236:${PK}:my-video`);
+    expect(getRepostTargetCoordinate([['a', `34235:${PK}:`]])).toBe(`34235:${PK}:`);
+  });
+
+  it('rejects malformed coordinates (reporter/reposter-authored tags)', () => {
+    expect(getRepostTargetCoordinate([])).toBeUndefined();
+    expect(getRepostTargetCoordinate([['a', 'garbage']])).toBeUndefined();
+    expect(getRepostTargetCoordinate([['a', `notakind:${PK}:d`]])).toBeUndefined();
+    expect(getRepostTargetCoordinate([['a', '34236:shortpubkey:d']])).toBeUndefined();
+  });
+});
+
+describe('describeRepostTarget', () => {
+  const ID = 'c'.repeat(64);
+  const PK = 'b'.repeat(64);
+
+  it('prefers the e-tag event id, falls back to the a-tag coordinate', () => {
+    expect(describeRepostTarget([['e', ID], ['a', `34236:${PK}:d`]])).toBe(`event ${ID}`);
+    expect(describeRepostTarget([['a', `34236:${PK}:d`]])).toBe(`34236:${PK}:d`);
+    expect(describeRepostTarget([])).toBeUndefined();
+  });
+});
+
+describe('parseRepostForDisplay', () => {
+  const PK = 'b'.repeat(64);
+
+  it('passes through displayable non-repost content and suppresses kind 1064', () => {
+    expect(parseRepostForDisplay({ kind: 1, content: 'hello', tags: [] }).displayContent).toBe('hello');
+    expect(parseRepostForDisplay({ kind: 1064, content: 'QmFzZTY0', tags: [] }).displayContent).toBe('');
+  });
+
+  it('suppresses inner content when the reposted event is kind 1064 (JSON or k tag)', () => {
+    const viaJson = parseRepostForDisplay({
+      kind: 16,
+      content: JSON.stringify({ content: 'QmFzZTY0RGF0YQ==', kind: 1064 }),
+      tags: [['e', 'c'.repeat(64)]],
+    });
+    expect(viaJson.displayContent).toBe('');
+    expect(viaJson.targetDescription).toBe(`event ${'c'.repeat(64)}`);
+
+    const viaKTag = parseRepostForDisplay({
+      kind: 16,
+      content: 'not json at all',
+      tags: [['k', '1064'], ['e', 'c'.repeat(64)]],
+    });
+    expect(viaKTag.displayContent).toBe('');
+  });
+
+  it('shows raw content for out-of-spec reposts instead of discarding evidence', () => {
+    const outOfSpec = parseRepostForDisplay({ kind: 6, content: 'plain text spam', tags: [] });
+    expect(outOfSpec.displayContent).toBe('plain text spam');
+  });
+
+  it('describes the a-tag coordinate for empty-content addressable reposts', () => {
+    const addressable = parseRepostForDisplay({
+      kind: 16,
+      content: '',
+      tags: [['k', '34236'], ['a', `34236:${PK}:my-video`]],
+    });
+    expect(addressable.displayContent).toBe('');
+    expect(addressable.targetDescription).toBe(`34236:${PK}:my-video`);
+  });
+});
+
+describe('describeRepostTarget hostile-tag hardening', () => {
+  it('ignores e-tag values that are not 64-hex event ids (NIP-18 MUST)', () => {
+    const junk = 'x'.repeat(20000);
+    expect(describeRepostTarget([['e', junk]])).toBeUndefined();
+    expect(describeRepostTarget([['e', junk], ['a', `34236:${'b'.repeat(64)}:d`]]))
+      .toBe(`34236:${'b'.repeat(64)}:d`);
+  });
+});
+
+describe('getRepostTargetCoordinate segment count', () => {
+  it('rejects 2-segment kind:pubkey values (documented shape is kind:pubkey:d-tag)', () => {
+    expect(getRepostTargetCoordinate([['a', `34236:${'b'.repeat(64)}`]])).toBeUndefined();
+  });
+});
+
+describe('parseRepostForDisplay contentSuppressed', () => {
+  it('distinguishes suppressed file-data content from genuinely empty content', () => {
+    expect(parseRepostForDisplay({ kind: 1064, content: 'QmFzZTY0', tags: [] }).contentSuppressed).toBe(true);
+    expect(parseRepostForDisplay({ kind: 20, content: '', tags: [] }).contentSuppressed).toBe(false);
+    expect(parseRepostForDisplay({
+      kind: 16,
+      content: JSON.stringify({ content: 'QmFzZTY0', kind: 1064 }),
+      tags: [],
+    }).contentSuppressed).toBe(true);
+    expect(parseRepostForDisplay({ kind: 16, content: '', tags: [] }).contentSuppressed).toBe(false);
   });
 });

--- a/src/lib/nip18.test.ts
+++ b/src/lib/nip18.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Tests NIP-18 repost parsing edge cases (empty/malformed/non-event JSON)
 
 import { describe, it, expect } from 'vitest';
-import { getRepostTargetId, isRepostKind, parseRepostedEvent, describeRepostTarget, getRepostKind, getRepostTargetCoordinate, parseRepostForDisplay } from './nip18';
+import { getRepostTargetId, isRepostKind, parseRepostedEvent, describeRepostTarget, getRepostTargetCoordinate, parseRepostForDisplay } from './nip18';
 
 describe('isRepostKind', () => {
   it('matches kinds 6 and 16 only', () => {
@@ -27,7 +27,6 @@ describe('parseRepostedEvent', () => {
       content: 'hello',
       tags: [['e', 'abc']],
       pubkey: 'f'.repeat(64),
-      kind: 34236,
     });
   });
 
@@ -65,26 +64,6 @@ describe('parseRepostedEvent', () => {
   });
 });
 
-describe('parseRepostedEvent inner kind', () => {
-  it('exposes a numeric inner kind and drops non-numeric ones', () => {
-    expect(parseRepostedEvent(JSON.stringify({ content: 'x', kind: 1064 }))?.kind).toBe(1064);
-    expect(parseRepostedEvent(JSON.stringify({ content: 'x', kind: '22' }))?.kind).toBeUndefined();
-  });
-});
-
-describe('getRepostKind', () => {
-  it('parses the NIP-18 k tag', () => {
-    expect(getRepostKind([['k', '34236']])).toBe(34236);
-  });
-
-  it('rejects missing or malformed k tags', () => {
-    expect(getRepostKind([])).toBeUndefined();
-    expect(getRepostKind([['k']])).toBeUndefined();
-    expect(getRepostKind([['k', 'abc']])).toBeUndefined();
-    expect(getRepostKind([['k', '12abc']])).toBeUndefined();
-  });
-});
-
 describe('getRepostTargetCoordinate', () => {
   const PK = 'b'.repeat(64);
 
@@ -115,31 +94,55 @@ describe('describeRepostTarget', () => {
 describe('parseRepostForDisplay', () => {
   const PK = 'b'.repeat(64);
 
-  it('passes through displayable non-repost content and suppresses kind 1064', () => {
+  it('passes non-repost content through unchanged (no kind-based suppression)', () => {
     expect(parseRepostForDisplay({ kind: 1, content: 'hello', tags: [] }).displayContent).toBe('hello');
-    expect(parseRepostForDisplay({ kind: 1064, content: 'QmFzZTY0', tags: [] }).displayContent).toBe('');
   });
 
-  it('suppresses inner content when the reposted event is kind 1064 (JSON or k tag)', () => {
-    const viaJson = parseRepostForDisplay({
+  it('shows the inner text of a parsed repost', () => {
+    const r = parseRepostForDisplay({
       kind: 16,
-      content: JSON.stringify({ content: 'QmFzZTY0RGF0YQ==', kind: 1064 }),
+      content: JSON.stringify({ content: 'inner note', pubkey: PK }),
       tags: [['e', 'c'.repeat(64)]],
     });
-    expect(viaJson.displayContent).toBe('');
-    expect(viaJson.targetDescription).toBe(`event ${'c'.repeat(64)}`);
-
-    const viaKTag = parseRepostForDisplay({
-      kind: 16,
-      content: 'not json at all',
-      tags: [['k', '1064'], ['e', 'c'.repeat(64)]],
-    });
-    expect(viaKTag.displayContent).toBe('');
+    expect(r.displayContent).toBe('inner note');
   });
 
-  it('shows raw content for out-of-spec reposts instead of discarding evidence', () => {
-    const outOfSpec = parseRepostForDisplay({ kind: 6, content: 'plain text spam', tags: [] });
-    expect(outOfSpec.displayContent).toBe('plain text spam');
+  it('never hides readable text a reposter tries to disguise with a kind claim', () => {
+    // Every kind signal on a repost (k tag, inner JSON kind) is authored by
+    // the account under review. None may blank its own readable text.
+    const viaKTag = parseRepostForDisplay({
+      kind: 16,
+      content: 'FREE GIVEAWAY click my profile',
+      tags: [['k', '1064'], ['e', 'c'.repeat(64)]],
+    });
+    expect(viaKTag.displayContent).toBe('FREE GIVEAWAY click my profile');
+
+    const viaInnerKind = parseRepostForDisplay({
+      kind: 16,
+      content: JSON.stringify({ content: 'FREE GIVEAWAY', kind: 1064 }),
+      tags: [['e', 'c'.repeat(64)]],
+    });
+    expect(viaInnerKind.displayContent).toBe('FREE GIVEAWAY');
+  });
+
+  it('shows plain-text and JSON-array out-of-spec content, but not a raw object envelope', () => {
+    // Plain text renders as evidence.
+    expect(parseRepostForDisplay({ kind: 6, content: 'plain text spam', tags: [] }).displayContent)
+      .toBe('plain text spam');
+
+    // A JSON array carrying readable text is not an event envelope — show it.
+    const arr = parseRepostForDisplay({ kind: 16, content: JSON.stringify(['visit scam.link']), tags: [] });
+    expect(arr.displayContent).toBe(JSON.stringify(['visit scam.link']));
+
+    // A serialized-event *object* (not a valid inner event) must not render as
+    // a raw JSON blob or reach the AI — show the target label instead.
+    const objEnvelope = parseRepostForDisplay({
+      kind: 16,
+      content: JSON.stringify({ content: 42, pubkey: 'x' }),
+      tags: [['e', 'c'.repeat(64)]],
+    });
+    expect(objEnvelope.displayContent).toBe('');
+    expect(objEnvelope.targetDescription).toBe(`event ${'c'.repeat(64)}`);
   });
 
   it('describes the a-tag coordinate for empty-content addressable reposts', () => {
@@ -165,18 +168,5 @@ describe('describeRepostTarget hostile-tag hardening', () => {
 describe('getRepostTargetCoordinate segment count', () => {
   it('rejects 2-segment kind:pubkey values (documented shape is kind:pubkey:d-tag)', () => {
     expect(getRepostTargetCoordinate([['a', `34236:${'b'.repeat(64)}`]])).toBeUndefined();
-  });
-});
-
-describe('parseRepostForDisplay contentSuppressed', () => {
-  it('distinguishes suppressed file-data content from genuinely empty content', () => {
-    expect(parseRepostForDisplay({ kind: 1064, content: 'QmFzZTY0', tags: [] }).contentSuppressed).toBe(true);
-    expect(parseRepostForDisplay({ kind: 20, content: '', tags: [] }).contentSuppressed).toBe(false);
-    expect(parseRepostForDisplay({
-      kind: 16,
-      content: JSON.stringify({ content: 'QmFzZTY0', kind: 1064 }),
-      tags: [],
-    }).contentSuppressed).toBe(true);
-    expect(parseRepostForDisplay({ kind: 16, content: '', tags: [] }).contentSuppressed).toBe(false);
   });
 });

--- a/src/lib/nip18.ts
+++ b/src/lib/nip18.ts
@@ -1,8 +1,6 @@
 // ABOUTME: NIP-18 repost helpers — kind 6/16 events carry the reposted event
 // ABOUTME: as stringified JSON in their content field (or empty content)
 
-import { hasDisplayableContent } from '@/lib/kindNames';
-
 // Local, not exported: PR #161 adds a shared isHex64 to lib/constants and
 // #160 tracks consolidating hex-id validation — this stays private until
 // that lands to avoid two exported definitions colliding at merge time.
@@ -16,19 +14,11 @@ export interface RepostedEvent {
   content: string;
   tags: string[][];
   pubkey: string;
-  /** Present when the inner JSON carried a numeric kind. */
-  kind?: number;
 }
 
 /** The reposted event's id from a repost's `e` tag (NIP-18 MUST for kind 6). */
 export function getRepostTargetId(tags: string[][]): string | undefined {
   return tags.find(t => t[0] === 'e')?.[1];
-}
-
-/** The reposted event's kind from a kind-16 repost's `k` tag (NIP-18 SHOULD). */
-export function getRepostKind(tags: string[][]): number | undefined {
-  const value = tags.find(t => t[0] === 'k')?.[1];
-  return value !== undefined && /^\d+$/.test(value) ? Number(value) : undefined;
 }
 
 /**
@@ -78,7 +68,6 @@ export function parseRepostedEvent(content: string): RepostedEvent | null {
         ? o.tags.filter((t): t is string[] => Array.isArray(t) && t.every(x => typeof x === 'string'))
         : [],
       pubkey: typeof o.pubkey === 'string' ? o.pubkey : '',
-      ...(typeof o.kind === 'number' ? { kind: o.kind } : {}),
     };
   } catch {
     return null;
@@ -89,47 +78,52 @@ export interface RepostDisplay {
   isRepost: boolean;
   /** Parsed inner event for spec-conformant reposts (media/attribution). */
   inner: RepostedEvent | null;
-  /** Text safe to render or summarize; '' when nothing is displayable. */
+  /** Text safe to render or summarize; '' when there's nothing to show. */
   displayContent: string;
-  /** True when displayContent is '' because the (inner) kind's content is
-   * non-displayable (file data), as opposed to genuinely empty content. */
-  contentSuppressed: boolean;
   /** Set for reposts with no displayable content: what was reposted. */
   targetDescription?: string;
 }
 
+/** True when the string parses to a JSON *object* — a serialized-event
+ * envelope. Arrays, primitives, and plain text are not envelopes: they may
+ * carry human-readable text a moderator needs, so they are shown, not blanked. */
+function isJsonObjectEnvelope(content: string): boolean {
+  try {
+    const value: unknown = JSON.parse(content);
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+  } catch {
+    return false;
+  }
+}
+
 /**
- * One place for "what text does a recent-content row show for this event":
- * - non-reposts show their content unless the kind's content isn't text
- *   (kind 1064 carries raw base64 — see hasDisplayableContent)
- * - parsed reposts show the inner event's content, with the same
- *   non-displayable-kind guard applied to the INNER kind (from the parsed
- *   JSON, falling back to the NIP-18 `k` tag)
- * - out-of-spec reposts (unparseable content) show their raw content rather
- *   than discarding moderation evidence — bounded by the caller's clamping
- * - reposts with nothing displayable get a target description instead
+ * One place for "what text does a recent-content row show for this event".
+ * We never suppress based on a claimed content kind: for reposts every kind
+ * signal (the `k` tag, the inner JSON's `kind`) is authored by the account
+ * under review, so trusting one to blank content lets it hide its own
+ * evidence from the card and the AI summary. Bias is to SHOW; consumers clamp
+ * length, so any noise is bounded, never a wall.
+ * - non-reposts: show their content
+ * - parsed reposts: show the inner event's content
+ * - out-of-spec reposts (content is not a valid inner event): show the plain
+ *   text as moderation evidence, but a raw serialized-event *object* envelope
+ *   renders as the target label instead of the raw JSON blob (never-raw-JSON)
+ * - reposts with nothing displayable: a target description
  */
 export function parseRepostForDisplay(
   event: { kind: number; content: string; tags: string[][] }
 ): RepostDisplay {
   if (!isRepostKind(event.kind)) {
-    const suppressed = !hasDisplayableContent(event.kind);
-    return {
-      isRepost: false,
-      inner: null,
-      displayContent: suppressed ? '' : event.content,
-      contentSuppressed: suppressed,
-    };
+    return { isRepost: false, inner: null, displayContent: event.content };
   }
   const inner = parseRepostedEvent(event.content);
-  const innerKind = inner?.kind ?? getRepostKind(event.tags);
-  const suppressed = innerKind !== undefined && !hasDisplayableContent(innerKind);
-  const displayContent = suppressed ? '' : (inner ? inner.content : event.content);
+  const displayContent = inner
+    ? inner.content
+    : isJsonObjectEnvelope(event.content) ? '' : event.content;
   return {
     isRepost: true,
     inner,
     displayContent,
-    contentSuppressed: suppressed,
     ...(displayContent ? {} : { targetDescription: describeRepostTarget(event.tags) }),
   };
 }

--- a/src/lib/nip18.ts
+++ b/src/lib/nip18.ts
@@ -1,6 +1,13 @@
 // ABOUTME: NIP-18 repost helpers — kind 6/16 events carry the reposted event
 // ABOUTME: as stringified JSON in their content field (or empty content)
 
+import { hasDisplayableContent } from '@/lib/kindNames';
+
+// Local, not exported: PR #161 adds a shared isHex64 to lib/constants and
+// #160 tracks consolidating hex-id validation — this stays private until
+// that lands to avoid two exported definitions colliding at merge time.
+const HEX_64 = /^[0-9a-f]{64}$/i;
+
 export function isRepostKind(kind: number): boolean {
   return kind === 6 || kind === 16;
 }
@@ -9,11 +16,46 @@ export interface RepostedEvent {
   content: string;
   tags: string[][];
   pubkey: string;
+  /** Present when the inner JSON carried a numeric kind. */
+  kind?: number;
 }
 
-/** The reposted event's id from a repost's `e` tag (NIP-18 says it MUST exist). */
+/** The reposted event's id from a repost's `e` tag (NIP-18 MUST for kind 6). */
 export function getRepostTargetId(tags: string[][]): string | undefined {
   return tags.find(t => t[0] === 'e')?.[1];
+}
+
+/** The reposted event's kind from a kind-16 repost's `k` tag (NIP-18 SHOULD). */
+export function getRepostKind(tags: string[][]): number | undefined {
+  const value = tags.find(t => t[0] === 'k')?.[1];
+  return value !== undefined && /^\d+$/.test(value) ? Number(value) : undefined;
+}
+
+/**
+ * The reposted event's coordinate from a kind-16 repost's `a` tag — per
+ * NIP-18, addressable-event reposts SHOULD carry one, and empty content plus
+ * an `a` tag means "the latest version". Tags are reposter-authored, so only
+ * a well-formed `kind:pubkey:d-tag` shape is returned.
+ */
+export function getRepostTargetCoordinate(tags: string[][]): string | undefined {
+  const value = tags.find(t => t[0] === 'a')?.[1];
+  if (typeof value !== 'string') return undefined;
+  const parts = value.split(':');
+  return parts.length >= 3 && /^\d+$/.test(parts[0]) && HEX_64.test(parts[1])
+    ? value
+    : undefined;
+}
+
+/**
+ * Human-readable "what was reposted": `event <id>`, else the coordinate.
+ * Values are reposter-authored — the e tag is only used when it is a
+ * well-formed 64-hex event id (NIP-18 MUST), so hostile tags can't inject
+ * arbitrary text into moderation UI.
+ */
+export function describeRepostTarget(tags: string[][]): string | undefined {
+  const id = getRepostTargetId(tags);
+  if (id !== undefined && HEX_64.test(id)) return `event ${id}`;
+  return getRepostTargetCoordinate(tags);
 }
 
 /**
@@ -36,8 +78,58 @@ export function parseRepostedEvent(content: string): RepostedEvent | null {
         ? o.tags.filter((t): t is string[] => Array.isArray(t) && t.every(x => typeof x === 'string'))
         : [],
       pubkey: typeof o.pubkey === 'string' ? o.pubkey : '',
+      ...(typeof o.kind === 'number' ? { kind: o.kind } : {}),
     };
   } catch {
     return null;
   }
+}
+
+export interface RepostDisplay {
+  isRepost: boolean;
+  /** Parsed inner event for spec-conformant reposts (media/attribution). */
+  inner: RepostedEvent | null;
+  /** Text safe to render or summarize; '' when nothing is displayable. */
+  displayContent: string;
+  /** True when displayContent is '' because the (inner) kind's content is
+   * non-displayable (file data), as opposed to genuinely empty content. */
+  contentSuppressed: boolean;
+  /** Set for reposts with no displayable content: what was reposted. */
+  targetDescription?: string;
+}
+
+/**
+ * One place for "what text does a recent-content row show for this event":
+ * - non-reposts show their content unless the kind's content isn't text
+ *   (kind 1064 carries raw base64 — see hasDisplayableContent)
+ * - parsed reposts show the inner event's content, with the same
+ *   non-displayable-kind guard applied to the INNER kind (from the parsed
+ *   JSON, falling back to the NIP-18 `k` tag)
+ * - out-of-spec reposts (unparseable content) show their raw content rather
+ *   than discarding moderation evidence — bounded by the caller's clamping
+ * - reposts with nothing displayable get a target description instead
+ */
+export function parseRepostForDisplay(
+  event: { kind: number; content: string; tags: string[][] }
+): RepostDisplay {
+  if (!isRepostKind(event.kind)) {
+    const suppressed = !hasDisplayableContent(event.kind);
+    return {
+      isRepost: false,
+      inner: null,
+      displayContent: suppressed ? '' : event.content,
+      contentSuppressed: suppressed,
+    };
+  }
+  const inner = parseRepostedEvent(event.content);
+  const innerKind = inner?.kind ?? getRepostKind(event.tags);
+  const suppressed = innerKind !== undefined && !hasDisplayableContent(innerKind);
+  const displayContent = suppressed ? '' : (inner ? inner.content : event.content);
+  return {
+    isRepost: true,
+    inner,
+    displayContent,
+    contentSuppressed: suppressed,
+    ...(displayContent ? {} : { targetDescription: describeRepostTarget(event.tags) }),
+  };
 }


### PR DESCRIPTION
Closes #159

## What

sibling of #156, surfaced during #157's review: `BannedUserCard`'s recent-activity query asked the relay for `kinds: [1]` only, so a banned account whose activity was comments (1111), reposts (6/16), or videos showed "No posts found on this relay" — the same blind spot #157 fixed on the report page, here on the surface where a moderator reviews an account that's *already been actioned*.

- **shared kinds list** — new `RECENT_CONTENT_KINDS` in `src/lib/constants.ts` (video kinds derived from a new `VIDEO_KINDS` in `lib/kindNames`), consumed by `useUserStats` and `BannedUserCard` so the surfaces can't drift. TODO(#162) tracks the third, still-drifted list in `UserProfilePreview` — aligning it needs the shared rendering pieces too, so it's deliberately its own change.
- **shared `KindBadge`** — #157's badge chain extracted verbatim from `UserProfileCard` into its own component, consumed by both surfaces; #157's existing badge-mapping tests guard the extraction.
- **NIP-18 display semantics centralized** — new `parseRepostForDisplay()` in `lib/nip18.ts`, consumed by `BannedUserCard`, `UserProfileCard`, and `useUserSummary` (the AI-summary payload). one place now decides what text a recent-content row shows:
  - reposts render the inner event's content labeled "reposted:", never raw NIP-18 JSON
  - the inner kind is resolved from the parsed JSON or the NIP-18 `k` tag, so kind-1064 base64 (draft NIP-95 file data) can't be smuggled through a repost — and direct 1064 events are suppressed the same way on both cards (the report page had this latent too)
  - addressable-video reposts (a-tag coordinate, empty content — the NIP-18 latest-version pattern, and Divine's primary content kinds) identify their target coordinate; previously they rendered nothing
  - out-of-spec reposts (plain text in content) render that text instead of silently discarding moderation evidence
  - reposter-authored e-tag values only render when they are well-formed 64-hex event ids, and the target line is clamped — hostile tags can't balloon the card
- **query correctness** — rows sort newest-first on a copy before taking 3 (relay order is unguaranteed; mutation-verified test); `staleTime` on the content query since UserManagement remounts one card per banned/suspended user on every tab switch; profile now comes from the shared `useAuthor` hook (Funnelcake REST fast path, validated metadata) instead of a hand-rolled query.
- count reads "N events on relay", header "Recent Content on This Relay", per-user aria-labels on the icon buttons.

## Known tradeoffs

- `useAuthor` has no request timeout on its REST fast path (pre-existing hook behavior shared by every consumer; the old hand-rolled query had a 3s abort). adopting the shared hook keeps this card consistent with the rest of the app; a timeout belongs in the hook itself if we want one.
- the repost-row JSX is similar-but-not-identical between the two cards (different clamp/sizing); extracting a shared row component is part of #162's shared-rendering work, where a third consumer forces the shape.

## Verification

- tsc/eslint clean, 198 frontend tests pass (24 new: 13 nip18 helper/derivation tests incl. the smuggling, a-tag, out-of-spec, and hostile-e-tag cases; 10 BannedUserCard tests; repost-of-1064 parity test on UserProfileCard). the newest-3 ordering test is mutation-verified — an inverted sort comparator fails the suite.
- verified against the live production relay in a browser (banned list stubbed browser-locally; no real ban involved): an account whose only activity is kind-1111 comments, which showed "No posts found" before this change, renders its comments newest-first with Comment badges and a correct event count. no screenshot attached — the capture shows a real user's identity under a "Banned Users" heading and this repo is public.
