### PR TITLE
docs: align README with Divine brand guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,7 @@ This is a **focused, minimal implementation** that prioritizes:
 - ✅ **Responsive design** that works everywhere
 
 The app is built to **just work** for the core use case of moderating events on your Nostr relay.
+
+---
+
+Part of [Divine](https://divine.video) — your playground for human creativity · [Brand guidelines](https://github.com/divinevideo/brand-guidelines)


### PR DESCRIPTION
Aligns the README with the Divine brand guidelines.

Changes:
- Added the standard Divine footer linking to divine.video and the brand guidelines.

No brand-name corrections were needed: the README describes the Nostr relay management tool and contains no product-name usage in prose. Diff is intentionally minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)