### PR TITLE
chore: gitignore *.tsbuildinfo incremental build cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ dist-ssr
 .env
 .dev.vars
 
+# TypeScript incremental build cache (emitted by tsc -p tsconfig.*.json)
+*.tsbuildinfo
+
 # Editor directories and files
 .idea
 .DS_Store


### PR DESCRIPTION
## What

ignore `*.tsbuildinfo` — TypeScript's incremental build cache, emitted by `tsc -p tsconfig.*.json` (e.g. `tsconfig.app.tsbuildinfo`, `tsconfig.node.tsbuildinfo`). these are per-machine build artifacts that were showing up as untracked files after running the project type-check.

## Motivation

surfaced while running the real type-check (`tsc -p tsconfig.app.json --noEmit`) during PR #165. no code impact; pure hygiene so the artifacts don't get accidentally committed.

## Validation

`git status` no longer lists the `.tsbuildinfo` files after a type-check run. no build or test surface touched.