### PR TITLE
ci(minor-safety): synthetic check for the minor-review endpoints

### DIFF
--- a/.github/workflows/minor-review-endpoint-health.yml
+++ b/.github/workflows/minor-review-endpoint-health.yml
@@ -17,6 +17,9 @@
 # worker AND the auth layer is alive. Anything else means trouble:
 #   404 -- routing broke (the #108 failure mode)
 #   302 -- CF Access got applied to /v1 paths (devices would be locked out)
+#   200 -- auth layer removed/bypassed (worst case: unauthenticated reads)
+#   403 -- the NIP-98 handler's status contract changed (mobile clients
+#          share this contract; investigate the worker auth path)
 #   5xx/transport -- worker or edge outage
 #
 # Runbook on failure:
@@ -35,10 +38,26 @@
 # https://api.divine.video as a second BASE_URL probe target so coverage
 # for pre-fix app installs is monitored too.
 #
-# Alerting: a failed run notifies via GitHub (scheduled-workflow failure
-# email + the red run). If the SLACK_WEBHOOK_ALERTS secret is configured
-# (shared with the ReportWatcher health check design), it also posts to
-# the alerts channel; absent secret just skips that step.
+# Alerting -- know the limits:
+#   - A failed run turns red, and GitHub emails ONLY the user who last
+#     modified the cron line below (subject to their personal notification
+#     settings). Until Slack is wired, that one person is the whole
+#     alerting story.
+#   - If the SLACK_WEBHOOK_ALERTS secret is configured, failures also post
+#     to the alerts channel; absent secret, that step skips with a warning.
+#   - This repo is public: GitHub auto-disables scheduled workflows after
+#     60 days without repository activity -- the monitor can die silently
+#     during a quiet period. Re-enable from the Actions tab; consider a
+#     keepalive if the repo goes dormant.
+#   - Schedules only run from the default branch: this check goes live at
+#     merge, not on the PR.
+#
+# Setup:
+#   1. (Recommended) Repo secret SLACK_WEBHOOK_ALERTS -- incoming webhook
+#      for the alerts channel (same value as vmalertmanager-slack-webhook-prod
+#      in GCP Secret Manager; shared with the ReportWatcher health design).
+#   2. To test manually: Actions tab > "Minor-Review Endpoint Health" >
+#      Run workflow.
 
 name: Minor-Review Endpoint Health
 
@@ -47,9 +66,13 @@ on:
     - cron: '7,22,37,52 * * * *' # every 15 min, offset to avoid top-of-hour runner contention
   workflow_dispatch:
 
+# The job runs shell + outbound curl only: no checkout, no token use
+permissions: {}
+
 jobs:
   probe:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Probe minor-review endpoints (expect 401)
@@ -58,17 +81,27 @@ jobs:
           BASE_URL="https://api-relay-prod.divine.video"
           FAILURES=""
 
+          # Human-readable transport diagnosis for the common curl exits
+          diagnose() {
+            case "$1" in
+              6) echo "DNS resolution failed" ;;
+              7) echo "connection refused" ;;
+              28) echo "timeout after 15s" ;;
+              *) echo "curl exit $1" ;;
+            esac
+          }
+
           probe() {
             local method="$1" path="$2" attempt code
             for attempt in 1 2; do
               if [ "$method" = "GET" ]; then
                 code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
-                  "$BASE_URL$path" 2>/dev/null) || code="transport_error($?)"
+                  "$BASE_URL$path" 2>/dev/null) || code="transport_error: $(diagnose $?)"
               else
                 code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
                   -X POST -H 'Content-Type: application/json' \
                   -d '{"email":"synthetic@check.invalid"}' \
-                  "$BASE_URL$path" 2>/dev/null) || code="transport_error($?)"
+                  "$BASE_URL$path" 2>/dev/null) || code="transport_error: $(diagnose $?)"
               fi
               if [ "$code" = "401" ]; then
                 echo "OK: $method $path -> 401 (routed, auth layer alive)"
@@ -78,7 +111,7 @@ jobs:
               # One retry damps transient edge blips without hiding real outages
               [ "$attempt" = "1" ] && sleep 30
             done
-            FAILURES="$FAILURES\n$method $path -> $code"
+            FAILURES="$FAILURES$method $path -> $code"$'\n'
             return 0
           }
 
@@ -86,8 +119,10 @@ jobs:
           probe POST "/v1/minor-review-cases/synthetic-check/parent-contact"
 
           if [ -n "$FAILURES" ]; then
-            printf 'failures<<EOF\n%b\nEOF\n' "$FAILURES" >> "$GITHUB_OUTPUT"
-            printf '::error::Minor-review endpoints unhealthy -- clients are silently failing open:%b\n' "$FAILURES"
+            printf 'failures<<EOF\n%s\nEOF\n' "${FAILURES%$'\n'}" >> "$GITHUB_OUTPUT"
+            # Workflow-command annotations are single-line: encode newlines
+            printf '::error::Minor-review endpoints unhealthy -- clients are silently failing open: %s\n' \
+              "$(printf '%s' "${FAILURES%$'\n'}" | tr '\n' '|')"
             echo "unhealthy=true" >> "$GITHUB_OUTPUT"
           else
             echo "unhealthy=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/minor-review-endpoint-health.yml
+++ b/.github/workflows/minor-review-endpoint-health.yml
@@ -12,11 +12,20 @@
 #   GET  /v1/account/moderation-status                      -> expect 401
 #   POST /v1/minor-review-cases/<id>/parent-contact         -> expect 401
 #
-# Why 401 is the healthy signal: the endpoints require NIP-98 user auth,
-# so an unauthenticated probe answering 401 proves the path is routed and
-# an auth layer answers -- the strongest signal an unauthenticated probe
-# can give. Anything else means trouble:
-#   404 -- routing broke (the #108 failure mode)
+# Why "401 + NIP-98 marker" is the healthy signal: the endpoints require
+# NIP-98 user auth and reject an unauthenticated probe with the worker's
+# distinctive body ("... expected: Nostr <base64>", single-sourced in
+# verifyNip98Auth, worker/src/index.ts). The status code alone is NOT
+# enough: any unmatched path on these hosts also answers 401 via the
+# generic admin fallback (verified live), so a status-only probe would
+# stay green through a route regression -- the exact #108 failure class.
+# If the worker's error copy ever changes, this probe goes red (fail-safe);
+# update the marker and the copy together. What each outcome means:
+#   401 + marker -- healthy: endpoint routed, NIP-98 auth answering
+#   401 without marker -- generic admin fallback: the route did NOT match
+#          (removed/renamed/method drift). The #108-class failure.
+#   404 -- cannot happen unauth on these hosts today (everything falls to
+#          the 401 fallback); will matter for the api.divine.video target (#173)
 #   302 -- CF Access got applied to /v1 paths (devices would be locked out)
 #   200 -- auth layer removed/bypassed (worst case: unauthenticated reads)
 #   403 -- the NIP-98 handler's status contract changed (mobile clients
@@ -25,7 +34,9 @@
 #
 # Runbook on failure:
 #   1. Check the run log for which probe failed and the code it saw.
-#   2. curl the URL yourself; if 404, check worker routes/deploy state
+#   2. curl the URL yourself and read the body. A 401 with the admin
+#      fallback text means the route no longer matches: check the /v1
+#      route conditions in worker/src/index.ts and the deployed version
 #      (wrangler deployments list --config wrangler.<env>.toml).
 #   3. If 302, someone extended the CF Access app on that env over /v1.
 #   4. Remember: clients are silently failing open the whole time this
@@ -82,6 +93,7 @@ jobs:
         id: probe
         run: |
           FAILURES=""
+          BODY_FILE=$(mktemp)
 
           # Human-readable transport diagnosis for the common curl exits
           diagnose() {
@@ -93,23 +105,34 @@ jobs:
             esac
           }
 
+          # The endpoint-specific NIP-98 rejection marker (single-sourced in
+          # verifyNip98Auth, worker/src/index.ts). A 401 WITHOUT it is the
+          # generic admin fallback: the route did not match.
+          MARKER='expected: Nostr'
+
           probe() {
-            local method="$1" path="$2" attempt code
+            local method="$1" path="$2" attempt code snippet
             for attempt in 1 2; do
+              : > "$BODY_FILE"
               if [ "$method" = "GET" ]; then
-                code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
+                code=$(curl -s -o "$BODY_FILE" -w '%{http_code}' --max-time 15 \
                   "$BASE_URL$path" 2>/dev/null) || code="transport_error: $(diagnose $?)"
               else
-                code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
+                code=$(curl -s -o "$BODY_FILE" -w '%{http_code}' --max-time 15 \
                   -X POST -H 'Content-Type: application/json' \
                   -d '{"email":"synthetic@check.invalid"}' \
                   "$BASE_URL$path" 2>/dev/null) || code="transport_error: $(diagnose $?)"
               fi
-              if [ "$code" = "401" ]; then
-                echo "OK: $method $BASE_URL$path -> 401 (routed, auth answering)"
+              if [ "$code" = "401" ] && grep -q "$MARKER" "$BODY_FILE"; then
+                echo "OK: $method $BASE_URL$path -> 401 + NIP-98 marker (endpoint routed, auth answering)"
                 return 0
               fi
-              echo "attempt $attempt: $method $BASE_URL$path -> $code (expected 401)"
+              if [ "$code" = "401" ]; then
+                # Sanitize the response-derived snippet: single line, bounded
+                snippet=$(tr -d '\r' < "$BODY_FILE" | tr '\n' ' ' | head -c 100)
+                code="401 without NIP-98 marker (generic fallback; route regression?): $snippet"
+              fi
+              echo "attempt $attempt: $method $BASE_URL$path -> $code (expected 401 + NIP-98 marker)"
               # One retry damps transient edge blips without hiding real outages
               [ "$attempt" = "1" ] && sleep 30
             done

--- a/.github/workflows/minor-review-endpoint-health.yml
+++ b/.github/workflows/minor-review-endpoint-health.yml
@@ -16,16 +16,18 @@
 # NIP-98 user auth and reject an unauthenticated probe with the worker's
 # distinctive body ("... expected: Nostr <base64>", single-sourced in
 # verifyNip98Auth, worker/src/index.ts). The status code alone is NOT
-# enough: any unmatched path on these hosts also answers 401 via the
-# generic admin fallback (verified live), so a status-only probe would
-# stay green through a route regression -- the exact #108 failure class.
+# enough: any unmatched path under /v1 on these hosts also answers 401
+# via the worker's generic admin fallback (verified live; non-/v1 paths
+# hit CF Access at the edge instead), so a status-only probe would stay
+# green through a route regression -- the exact #108 failure class.
 # If the worker's error copy ever changes, this probe goes red (fail-safe);
 # update the marker and the copy together. What each outcome means:
 #   401 + marker -- healthy: endpoint routed, NIP-98 auth answering
 #   401 without marker -- generic admin fallback: the route did NOT match
 #          (removed/renamed/method drift). The #108-class failure.
-#   404 -- cannot happen unauth on these hosts today (everything falls to
-#          the 401 fallback); will matter for the api.divine.video target (#173)
+#   404 -- cannot happen unauth under /v1 on these hosts today (unmatched
+#          /v1 paths fall to the 401 fallback); will matter for the
+#          api.divine.video target (#173)
 #   302 -- CF Access got applied to /v1 paths (devices would be locked out)
 #   200 -- auth layer removed/bypassed (worst case: unauthenticated reads)
 #   403 -- the NIP-98 handler's status contract changed (mobile clients
@@ -128,8 +130,11 @@ jobs:
                 return 0
               fi
               if [ "$code" = "401" ]; then
-                # Sanitize the response-derived snippet: single line, bounded
-                snippet=$(tr -d '\r' < "$BODY_FILE" | tr '\n' ' ' | head -c 100)
+                # Sanitize the response-derived snippet: bound the read FIRST
+                # (head before the pipe: a multi-MB body must not SIGPIPE the
+                # pipeline if pipefail is ever enabled), then single-line and
+                # strip control chars (ANSI etc.) for logs/annotation/Slack
+                snippet=$(head -c 100 "$BODY_FILE" | tr -d '\r' | tr '\n' ' ' | tr -cd '[:print:]')
                 code="401 without NIP-98 marker (generic fallback; route regression?): $snippet"
               fi
               echo "attempt $attempt: $method $BASE_URL$path -> $code (expected 401 + NIP-98 marker)"

--- a/.github/workflows/minor-review-endpoint-health.yml
+++ b/.github/workflows/minor-review-endpoint-health.yml
@@ -7,14 +7,15 @@
 # found only by manually root-causing a mobile report). This check makes
 # that failure mode alert instead of hide.
 #
-# What it probes (production relay-manager worker, where these endpoints
-# live -- NOT api.divine.video, see #108):
+# What it probes (the relay-manager workers, where these endpoints live --
+# NOT api.divine.video, see #108), on both production and staging:
 #   GET  /v1/account/moderation-status                      -> expect 401
 #   POST /v1/minor-review-cases/<id>/parent-contact         -> expect 401
 #
 # Why 401 is the healthy signal: the endpoints require NIP-98 user auth,
-# so an unauthenticated probe answering 401 proves the path routes to the
-# worker AND the auth layer is alive. Anything else means trouble:
+# so an unauthenticated probe answering 401 proves the path is routed and
+# an auth layer answers -- the strongest signal an unauthenticated probe
+# can give. Anything else means trouble:
 #   404 -- routing broke (the #108 failure mode)
 #   302 -- CF Access got applied to /v1 paths (devices would be locked out)
 #   200 -- auth layer removed/bypassed (worst case: unauthenticated reads)
@@ -25,14 +26,16 @@
 # Runbook on failure:
 #   1. Check the run log for which probe failed and the code it saw.
 #   2. curl the URL yourself; if 404, check worker routes/deploy state
-#      (wrangler deployments list --config wrangler.prod.toml).
-#   3. If 302, someone changed the CF Access app covering api-relay-prod.
+#      (wrangler deployments list --config wrangler.<env>.toml).
+#   3. If 302, someone extended the CF Access app on that env over /v1.
 #   4. Remember: clients are silently failing open the whole time this
 #      is red -- treat as a minor-safety enforcement outage, not routine CI.
 #
-# Staging is deliberately not probed: api-relay-staging sits behind CF
-# Access for all callers, so an unauthenticated probe sees the edge 302,
-# not worker health -- there is no signal in it.
+# Staging note: the staging worker's /v1 paths bypass CF Access (verified
+# 2026-07-13: /v1 answers the worker's own 401 while /api/* 302s to Access)
+# -- mobile devices must reach /v1, so this is by design. If the staging
+# probe starts seeing 302, someone extended the Access app over /v1 and
+# staging devices are locked out.
 #
 # TODO(#173): when the api.divine.video ingress route lands, add
 # https://api.divine.video as a second BASE_URL probe target so coverage
@@ -44,7 +47,7 @@
 #     settings). Until Slack is wired, that one person is the whole
 #     alerting story.
 #   - If the SLACK_WEBHOOK_ALERTS secret is configured, failures also post
-#     to the alerts channel; absent secret, that step skips with a warning.
+#     to the alerts channel; absent secret, that step no-ops with a warning.
 #   - This repo is public: GitHub auto-disables scheduled workflows after
 #     60 days without repository activity -- the monitor can die silently
 #     during a quiet period. Re-enable from the Actions tab; consider a
@@ -78,7 +81,6 @@ jobs:
       - name: Probe minor-review endpoints (expect 401)
         id: probe
         run: |
-          BASE_URL="https://api-relay-prod.divine.video"
           FAILURES=""
 
           # Human-readable transport diagnosis for the common curl exits
@@ -104,19 +106,23 @@ jobs:
                   "$BASE_URL$path" 2>/dev/null) || code="transport_error: $(diagnose $?)"
               fi
               if [ "$code" = "401" ]; then
-                echo "OK: $method $path -> 401 (routed, auth layer alive)"
+                echo "OK: $method $BASE_URL$path -> 401 (routed, auth answering)"
                 return 0
               fi
-              echo "attempt $attempt: $method $path -> $code (expected 401)"
+              echo "attempt $attempt: $method $BASE_URL$path -> $code (expected 401)"
               # One retry damps transient edge blips without hiding real outages
               [ "$attempt" = "1" ] && sleep 30
             done
-            FAILURES="$FAILURES$method $path -> $code"$'\n'
+            FAILURES="$FAILURES$method $BASE_URL$path -> $code"$'\n'
             return 0
           }
 
-          probe GET  "/v1/account/moderation-status"
-          probe POST "/v1/minor-review-cases/synthetic-check/parent-contact"
+          for BASE_URL in \
+            "https://api-relay-prod.divine.video" \
+            "https://api-relay-staging.divine.video"; do
+            probe GET  "/v1/account/moderation-status"
+            probe POST "/v1/minor-review-cases/synthetic-check/parent-contact"
+          done
 
           if [ -n "$FAILURES" ]; then
             printf 'failures<<EOF\n%s\nEOF\n' "${FAILURES%$'\n'}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/minor-review-endpoint-health.yml
+++ b/.github/workflows/minor-review-endpoint-health.yml
@@ -54,8 +54,8 @@
 #
 # Setup:
 #   1. (Recommended) Repo secret SLACK_WEBHOOK_ALERTS -- incoming webhook
-#      for the alerts channel (same value as vmalertmanager-slack-webhook-prod
-#      in GCP Secret Manager; shared with the ReportWatcher health design).
+#      for the alerts channel (same webhook the prod alertmanager uses;
+#      see the iac repo / GCP Secret Manager for the value).
 #   2. To test manually: Actions tab > "Minor-Review Endpoint Health" >
 #      Run workflow.
 

--- a/.github/workflows/minor-review-endpoint-health.yml
+++ b/.github/workflows/minor-review-endpoint-health.yml
@@ -38,7 +38,7 @@
 # staging devices are locked out.
 #
 # TODO(#173): when the api.divine.video ingress route lands, add
-# https://api.divine.video as a second BASE_URL probe target so coverage
+# https://api.divine.video as a third BASE_URL probe target so coverage
 # for pre-fix app installs is monitored too.
 #
 # Alerting -- know the limits:

--- a/.github/workflows/minor-review-endpoint-health.yml
+++ b/.github/workflows/minor-review-endpoint-health.yml
@@ -1,0 +1,123 @@
+# Minor-Review Endpoint Health (#174)
+#
+# The mobile minor-account-review gate fails open by design: if
+# /v1/account/moderation-status is unreachable, every client treats the
+# account as active and the parental-consent gate silently never fires.
+# That is exactly what happened in #108 (wrong host, 404, dead for months,
+# found only by manually root-causing a mobile report). This check makes
+# that failure mode alert instead of hide.
+#
+# What it probes (production relay-manager worker, where these endpoints
+# live -- NOT api.divine.video, see #108):
+#   GET  /v1/account/moderation-status                      -> expect 401
+#   POST /v1/minor-review-cases/<id>/parent-contact         -> expect 401
+#
+# Why 401 is the healthy signal: the endpoints require NIP-98 user auth,
+# so an unauthenticated probe answering 401 proves the path routes to the
+# worker AND the auth layer is alive. Anything else means trouble:
+#   404 -- routing broke (the #108 failure mode)
+#   302 -- CF Access got applied to /v1 paths (devices would be locked out)
+#   5xx/transport -- worker or edge outage
+#
+# Runbook on failure:
+#   1. Check the run log for which probe failed and the code it saw.
+#   2. curl the URL yourself; if 404, check worker routes/deploy state
+#      (wrangler deployments list --config wrangler.prod.toml).
+#   3. If 302, someone changed the CF Access app covering api-relay-prod.
+#   4. Remember: clients are silently failing open the whole time this
+#      is red -- treat as a minor-safety enforcement outage, not routine CI.
+#
+# Staging is deliberately not probed: api-relay-staging sits behind CF
+# Access for all callers, so an unauthenticated probe sees the edge 302,
+# not worker health -- there is no signal in it.
+#
+# TODO(#173): when the api.divine.video ingress route lands, add
+# https://api.divine.video as a second BASE_URL probe target so coverage
+# for pre-fix app installs is monitored too.
+#
+# Alerting: a failed run notifies via GitHub (scheduled-workflow failure
+# email + the red run). If the SLACK_WEBHOOK_ALERTS secret is configured
+# (shared with the ReportWatcher health check design), it also posts to
+# the alerts channel; absent secret just skips that step.
+
+name: Minor-Review Endpoint Health
+
+on:
+  schedule:
+    - cron: '7,22,37,52 * * * *' # every 15 min, offset to avoid top-of-hour runner contention
+  workflow_dispatch:
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Probe minor-review endpoints (expect 401)
+        id: probe
+        run: |
+          BASE_URL="https://api-relay-prod.divine.video"
+          FAILURES=""
+
+          probe() {
+            local method="$1" path="$2" attempt code
+            for attempt in 1 2; do
+              if [ "$method" = "GET" ]; then
+                code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
+                  "$BASE_URL$path" 2>/dev/null) || code="transport_error($?)"
+              else
+                code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
+                  -X POST -H 'Content-Type: application/json' \
+                  -d '{"email":"synthetic@check.invalid"}' \
+                  "$BASE_URL$path" 2>/dev/null) || code="transport_error($?)"
+              fi
+              if [ "$code" = "401" ]; then
+                echo "OK: $method $path -> 401 (routed, auth layer alive)"
+                return 0
+              fi
+              echo "attempt $attempt: $method $path -> $code (expected 401)"
+              # One retry damps transient edge blips without hiding real outages
+              [ "$attempt" = "1" ] && sleep 30
+            done
+            FAILURES="$FAILURES\n$method $path -> $code"
+            return 0
+          }
+
+          probe GET  "/v1/account/moderation-status"
+          probe POST "/v1/minor-review-cases/synthetic-check/parent-contact"
+
+          if [ -n "$FAILURES" ]; then
+            printf 'failures<<EOF\n%b\nEOF\n' "$FAILURES" >> "$GITHUB_OUTPUT"
+            printf '::error::Minor-review endpoints unhealthy -- clients are silently failing open:%b\n' "$FAILURES"
+            echo "unhealthy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "unhealthy=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Alert to Slack (if configured)
+        if: steps.probe.outputs.unhealthy == 'true'
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ALERTS }}
+          FAILURES: ${{ steps.probe.outputs.failures }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK" ]; then
+            echo "::warning::SLACK_WEBHOOK_ALERTS not configured; relying on the red run for notification"
+            exit 0
+          fi
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          PAYLOAD=$(jq -n \
+            --arg failures "$FAILURES" \
+            --arg run_url "$RUN_URL" \
+            '{
+              text: ":rotating_light: Minor-review endpoints unhealthy -- the mobile gate is silently failing open",
+              blocks: [
+                {type: "section", text: {type: "mrkdwn", text: ":rotating_light: *Minor-review endpoint health failing* (#174)\nClients fail open while this is red -- minor-safety enforcement outage.\n```\($failures)```"}},
+                {type: "context", elements: [{type: "mrkdwn", text: "<\($run_url)|View workflow run>"}]}
+              ]
+            }')
+          curl -sf --max-time 10 -X POST "$SLACK_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD"
+
+      - name: Fail the run so GitHub notifies
+        if: steps.probe.outputs.unhealthy == 'true'
+        run: exit 1

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1867,6 +1867,8 @@ async function verifyNip98Auth(
 ): Promise<Nip98Result> {
   const authHeader = request.headers.get('Authorization');
   if (!authHeader || !authHeader.startsWith('Nostr ')) {
+    // 'expected: Nostr' is probed by .github/workflows/minor-review-endpoint-health.yml
+    // as the endpoint-liveness marker -- rewording this string reds the monitor; update together
     return { valid: false, error: 'Missing or invalid Authorization header (expected: Nostr <base64>)' };
   }
 


### PR DESCRIPTION
Closes #174

## what

a scheduled workflow (every 15 minutes) probing the two minor-review endpoints on both relay-manager workers (production and staging), unauthenticated, expecting 401:

- GET /v1/account/moderation-status
- POST /v1/minor-review-cases/<id>/parent-contact

the healthy signal is 401 **plus the worker's NIP-98 rejection marker** in the body ("expected: Nostr", single-sourced in verifyNip98Auth). review caught that status alone is not enough: every unmatched path on these hosts also answers 401 via the generic admin fallback (verified live), so a status-only probe would stay green through a route regression, the exact #108 failure class. a marker-less 401 now fails with a sanitized body snippet naming the fallback. other alarms: 302 means CF Access got applied to /v1 (devices locked out), 200 means the auth layer is gone (worst case), 5xx/transport is an outage. one in-run retry damps transient blips. the marker coupling is fail-safe: if the worker's error copy changes, the probe goes red and the two get updated together.

## why

the minor-review client fails open by design, so when these endpoints broke (#108) nothing alerted and the gate was silently dead in production for months. this makes that failure mode page instead of hide.

## alerting posture (limits documented in the file)

- a failed run goes red and GitHub emails the user who last touched the cron line (me), per personal notification settings. that is the whole story until the SLACK_WEBHOOK_ALERTS repo secret is configured, at which point failures also post to the alerts channel (the step skips with a warning while unconfigured).
- public repo: GitHub auto-disables cron workflows after 60 days of no repo activity; the header documents the re-enable path.
- schedules run from the default branch only, so this goes live at merge, not on the PR.

## scope notes

- the PR now also touches worker/src/index.ts with a one-line comment coupling the NIP-98 error string to the monitor (rewording it reds the check; the comment says to update both together).
- staging is probed too: its /v1 paths bypass CF Access (verified live: /v1 answers the worker's own 401 while /api/* 302s to Access — devices must reach /v1, so this is by design). a staging 302 means someone extended the Access app over /v1 and locked devices out. my first cut excluded staging on a wrong premise; the adversarial review round caught it.
- TODO(#173): api.divine.video joins as a second probe target once the ingress route lands.

## validation

- all four probes (both endpoints, both workers) verified 401 + marker live; an unmatched /v1 route on both workers verified to flag as unhealthy (the false-green case from review).
- the probe script body was executed locally under bash -e across three legs: healthy (401/401), wrong-host 404 (simulating exactly the #108 breakage), and DNS transport failure. correct diagnostics, GITHUB_OUTPUT, and single-line error annotation in all three. shellcheck clean; YAML validated.
- after merge: run once manually via workflow_dispatch to see the green path in CI proper.
- no visual change; CI-only.



