### PR TITLE
fix(age-review): show a resolving state during the report hand-off lookup

### DIFF
--- a/src/components/AgeReview.handoff-mutation.test.tsx
+++ b/src/components/AgeReview.handoff-mutation.test.tsx
@@ -1,0 +1,124 @@
+// ABOUTME: Integration test for the hand-off seeded cache across mutations —
+// ABOUTME: a terminal action must never leave stale active controls (#179 review)
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { AgeReviewCase } from '../../shared/age-review';
+import { AgeReview } from './AgeReview';
+
+const getAgeReviewCases = vi.fn();
+const getActiveAgeReviewCase = vi.fn();
+const getAgeReviewCase = vi.fn();
+const updateAgeReviewCase = vi.fn();
+const getAgeReviewConfig = vi.fn();
+const getAccountStatus = vi.fn();
+
+vi.mock('@/hooks/useAdminApi', () => ({
+  useApiUrl: () => 'https://api.test.divine.video',
+  useAdminApi: () => ({
+    getAgeReviewCases,
+    getActiveAgeReviewCase,
+    getAgeReviewCase,
+    updateAgeReviewCase,
+    getAgeReviewConfig,
+    getAccountStatus,
+  }),
+}));
+
+vi.mock('@/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ user: { pubkey: 'f'.repeat(64) } }),
+}));
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({ data: undefined, isLoading: false }),
+}));
+
+// Heavy siblings not under test — the REAL AgeReviewDetail renders here
+vi.mock('@/components/AgeReviewFunnel', () => ({ AgeReviewFunnel: () => null }));
+vi.mock('@/components/CreateMinorAccountDialog', () => ({ CreateMinorAccountDialog: () => null }));
+vi.mock('@/components/UserIdentifier', () => ({
+  UserIdentifier: ({ pubkey }: { pubkey: string }) => <span>{pubkey.slice(0, 8)}</span>,
+}));
+vi.mock('@/components/UserActions', () => ({ UserActions: () => null }));
+vi.mock('@/components/DeleteConfirmDialog', () => ({ DeleteConfirmDialog: () => null }));
+
+const PUBKEY = 'a'.repeat(64);
+
+function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
+  return {
+    id: 'case-1',
+    pubkey: PUBKEY,
+    reporter_pubkey: 'b'.repeat(64),
+    report_id: 'report-1',
+    suspected_age_band: 'age_13_15',
+    state: 'under_moderator_review',
+    allowed_resolution: 'parent_video_or_email',
+    parent_contact_email: null,
+    deadline_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    clock_paused: 0,
+    clock_paused_at: null,
+    remaining_days_when_paused: null,
+    moderator_pubkey: null,
+    resolution_note: null,
+    last_alerted_at: null,
+    zendesk_ticket_id: null,
+    created_via: 'report',
+    claim_link_url: null,
+    claim_link_expires_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    version: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAgeReviewCases.mockResolvedValue({ success: true, cases: [] });
+  getAgeReviewConfig.mockResolvedValue({ auto_delete_on_deny: false });
+  getAccountStatus.mockResolvedValue({ success: true, verified_minor: false });
+});
+
+describe('hand-off seeded cache across terminal mutations (#179 review)', () => {
+  it('a terminal action within the seed staleTime shows the terminal state, not stale active controls', async () => {
+    const activeCase = makeCase();
+    const terminalCase = makeCase({ state: 'cleared', version: 1 });
+
+    // Hand-off resolves via the direct lookup (fresh case, not in any list)
+    getActiveAgeReviewCase.mockResolvedValue({ success: true, case: activeCase });
+    // If anything falls back to a by-id fetch, it serves the STALE active row
+    // (worst case) — the fix must not depend on this fetch happening
+    getAgeReviewCase.mockResolvedValue({ success: true, case: activeCase });
+    updateAgeReviewCase.mockResolvedValue({
+      success: true,
+      case: terminalCase,
+      enforcementComplete: true,
+      enforcement: { relay: 'ok', bulk: 'ok', keycast: 'ok', keycastMinorClear: 'not_attempted' },
+    });
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={[`/age-review?pubkey=${PUBKEY}`]}>
+          <AgeReview />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // Hand-off opened the real detail with active controls
+    const clearButton = await screen.findByRole('button', { name: 'Clear' });
+    fireEvent.click(clearButton);
+
+    await waitFor(() => expect(updateAgeReviewCase).toHaveBeenCalledTimes(1));
+
+    // The mutation returned the terminal row: the detail must show it — no
+    // stale active controls, no second action possible
+    expect(await screen.findByText('Cleared')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/AgeReview.list-shadow.test.tsx
+++ b/src/components/AgeReview.list-shadow.test.tsx
@@ -1,0 +1,171 @@
+// ABOUTME: Regression tests for the list-cache shadow (#179 review round 2):
+// ABOUTME: a retained active-list row must never out-vote the mutation result
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { AgeReviewCase } from '../../shared/age-review';
+import { AgeReview } from './AgeReview';
+
+const getAgeReviewCases = vi.fn();
+const getActiveAgeReviewCase = vi.fn();
+const getAgeReviewCase = vi.fn();
+const updateAgeReviewCase = vi.fn();
+const getAgeReviewConfig = vi.fn();
+const getAccountStatus = vi.fn();
+
+vi.mock('@/hooks/useAdminApi', () => ({
+  useApiUrl: () => 'https://api.test.divine.video',
+  useAdminApi: () => ({
+    getAgeReviewCases,
+    getActiveAgeReviewCase,
+    getAgeReviewCase,
+    updateAgeReviewCase,
+    getAgeReviewConfig,
+    getAccountStatus,
+  }),
+}));
+
+vi.mock('@/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ user: { pubkey: 'f'.repeat(64) } }),
+}));
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({ data: undefined, isLoading: false }),
+}));
+vi.mock('@/components/AgeReviewFunnel', () => ({ AgeReviewFunnel: () => null }));
+vi.mock('@/components/CreateMinorAccountDialog', () => ({ CreateMinorAccountDialog: () => null }));
+vi.mock('@/components/UserIdentifier', () => ({
+  UserIdentifier: ({ pubkey }: { pubkey: string }) => <span>{pubkey.slice(0, 8)}</span>,
+}));
+vi.mock('@/components/UserActions', () => ({ UserActions: () => null }));
+vi.mock('@/components/DeleteConfirmDialog', () => ({ DeleteConfirmDialog: () => null }));
+
+const PUBKEY = 'a'.repeat(64);
+
+function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
+  return {
+    id: 'case-1',
+    pubkey: PUBKEY,
+    reporter_pubkey: 'b'.repeat(64),
+    report_id: 'report-1',
+    suspected_age_band: 'age_13_15',
+    state: 'under_moderator_review',
+    allowed_resolution: 'parent_video_or_email',
+    parent_contact_email: null,
+    deadline_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    clock_paused: 0,
+    clock_paused_at: null,
+    remaining_days_when_paused: null,
+    moderator_pubkey: null,
+    resolution_note: null,
+    last_alerted_at: null,
+    zendesk_ticket_id: null,
+    created_via: 'report',
+    claim_link_url: null,
+    claim_link_expires_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    version: 0,
+    ...overrides,
+  };
+}
+
+const activeCase = () => makeCase();
+const terminalCase = () => makeCase({ state: 'cleared', version: 1 });
+
+function renderPage(client: QueryClient, entry = `/age-review?pubkey=${PUBKEY}`) {
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[entry]}>
+        <AgeReview />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAgeReviewConfig.mockResolvedValue({ auto_delete_on_deny: false });
+  getAccountStatus.mockResolvedValue({ success: true, verified_minor: false });
+  getAgeReviewCase.mockResolvedValue({ success: true, case: activeCase() });
+  getActiveAgeReviewCase.mockResolvedValue({ success: true, case: activeCase() });
+  updateAgeReviewCase.mockResolvedValue({
+    success: true,
+    case: terminalCase(),
+    enforcementComplete: true,
+    enforcement: { relay: 'ok', bulk: 'ok', keycast: 'ok', keycastMinorClear: 'not_attempted' },
+  });
+});
+
+describe('active-list rows must not shadow the mutation result (#179 review round 2)', () => {
+  it('terminal action with a NONEMPTY active list and a refetch that never lands', async () => {
+    // The single deduped initial fetch serves the active case IN the list;
+    // every later fetch (the post-mutation refetch) hangs — the reconciled
+    // cache must carry the truth
+    let fetches = 0;
+    getAgeReviewCases.mockImplementation(() => {
+      fetches += 1;
+      if (fetches <= 1) return Promise.resolve({ success: true, cases: [activeCase()] });
+      return new Promise(() => {}); // delayed refetch: never resolves
+    });
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    renderPage(client);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Clear' }));
+    await waitFor(() => expect(updateAgeReviewCase).toHaveBeenCalledTimes(1));
+
+    expect(await screen.findByText('Cleared')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('terminal action with a NONEMPTY active list and a refetch that fails', async () => {
+    let fetches = 0;
+    getAgeReviewCases.mockImplementation(() => {
+      fetches += 1;
+      if (fetches <= 1) return Promise.resolve({ success: true, cases: [activeCase()] });
+      return Promise.reject(new Error('refetch failed'));
+    });
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    renderPage(client);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Clear' }));
+    await waitFor(() => expect(updateAgeReviewCase).toHaveBeenCalledTimes(1));
+
+    expect(await screen.findByText('Cleared')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('remounting the same ?pubkey= hand-off after the terminal action shows no active controls', async () => {
+    let fetches = 0;
+    getAgeReviewCases.mockImplementation(() => {
+      fetches += 1;
+      if (fetches <= 1) return Promise.resolve({ success: true, cases: [activeCase()] });
+      return new Promise(() => {}); // keep the stale list cached, refetch pending
+    });
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const first = renderPage(client);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Clear' }));
+    await waitFor(() => expect(updateAgeReviewCase).toHaveBeenCalledTimes(1));
+    await screen.findByText('Cleared');
+    first.unmount();
+
+    // Same QueryClient (same tab), fresh mount of the hand-off route
+    renderPage(client);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText('Under Moderator Review')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/AgeReview.midflight-switch.test.tsx
+++ b/src/components/AgeReview.midflight-switch.test.tsx
@@ -1,0 +1,136 @@
+// ABOUTME: Adversarial probe — moderator switches selected case while a mutation
+// ABOUTME: is in flight: do the onSuccess cache writes land under the WRONG case's keys?
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { AgeReviewCase } from '../../shared/age-review';
+import { AgeReview } from './AgeReview';
+
+const getAgeReviewCases = vi.fn();
+const getActiveAgeReviewCase = vi.fn();
+const getAgeReviewCase = vi.fn();
+const updateAgeReviewCase = vi.fn();
+const getAgeReviewConfig = vi.fn();
+const getAccountStatus = vi.fn();
+
+vi.mock('@/hooks/useAdminApi', () => ({
+  useApiUrl: () => 'https://api.test.divine.video',
+  useAdminApi: () => ({
+    getAgeReviewCases,
+    getActiveAgeReviewCase,
+    getAgeReviewCase,
+    updateAgeReviewCase,
+    getAgeReviewConfig,
+    getAccountStatus,
+  }),
+}));
+
+vi.mock('@/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ user: { pubkey: 'f'.repeat(64) } }),
+}));
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({ data: undefined, isLoading: false }),
+}));
+vi.mock('@/components/AgeReviewFunnel', () => ({ AgeReviewFunnel: () => null }));
+vi.mock('@/components/CreateMinorAccountDialog', () => ({ CreateMinorAccountDialog: () => null }));
+vi.mock('@/components/UserIdentifier', () => ({
+  UserIdentifier: ({ pubkey }: { pubkey: string }) => <span>{`user-${pubkey.slice(0, 2)}`}</span>,
+}));
+vi.mock('@/components/UserActions', () => ({ UserActions: () => null }));
+vi.mock('@/components/DeleteConfirmDialog', () => ({ DeleteConfirmDialog: () => null }));
+
+const PUBKEY_A = 'a'.repeat(64);
+const PUBKEY_B = 'b'.repeat(64);
+
+function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
+  return {
+    id: 'case-a',
+    pubkey: PUBKEY_A,
+    reporter_pubkey: 'c'.repeat(64),
+    report_id: 'report-1',
+    suspected_age_band: 'age_13_15',
+    state: 'under_moderator_review',
+    allowed_resolution: 'parent_video_or_email',
+    parent_contact_email: null,
+    deadline_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    clock_paused: 0,
+    clock_paused_at: null,
+    remaining_days_when_paused: null,
+    moderator_pubkey: null,
+    resolution_note: null,
+    last_alerted_at: null,
+    zendesk_ticket_id: null,
+    created_via: 'report',
+    claim_link_url: null,
+    claim_link_expires_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    version: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAgeReviewConfig.mockResolvedValue({ auto_delete_on_deny: false });
+  getAccountStatus.mockResolvedValue({ success: true, verified_minor: false });
+  getActiveAgeReviewCase.mockResolvedValue({ success: true, case: null });
+});
+
+describe('mid-flight case switch (adversarial)', () => {
+  it('onSuccess cache writes land under the mutated case, not the newly selected one', async () => {
+    const caseA = makeCase();
+    const caseB = makeCase({ id: 'case-b', pubkey: PUBKEY_B });
+    const terminalA = makeCase({ state: 'cleared', version: 1 });
+
+    getAgeReviewCases.mockResolvedValue({ success: true, cases: [caseA, caseB] });
+    getAgeReviewCase.mockImplementation((id: string) =>
+      Promise.resolve({ success: true, case: id === 'case-a' ? caseA : caseB }));
+
+    // Slow PATCH: resolves 300ms after the moderator has already switched to case B
+    let resolvePatch: (v: unknown) => void;
+    updateAgeReviewCase.mockImplementation(() => new Promise(r => { resolvePatch = r; }));
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/age-review?case=case-a']}>
+          <AgeReview />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // Case A's detail is open with active controls
+    const clearButton = await screen.findByRole('button', { name: 'Clear' });
+    fireEvent.click(clearButton);
+    await waitFor(() => expect(updateAgeReviewCase).toHaveBeenCalledTimes(1));
+    expect(updateAgeReviewCase.mock.calls[0][0]).toBe('case-a');
+
+    // Mid-flight: moderator clicks case B in the list
+    fireEvent.click(screen.getByText('user-bb'));
+    await screen.findAllByText('user-bb'); // B selected/rendered
+
+    // PATCH for A resolves now
+    resolvePatch!({
+      success: true,
+      case: terminalA,
+      enforcementComplete: true,
+      enforcement: { relay: 'ok', bulk: 'ok', keycast: 'ok', keycastMinorClear: 'not_attempted' },
+    });
+
+    await waitFor(() => {
+      // The write-through must land under the MUTATED case's keys...
+      expect(client.getQueryData(['age-review-case', 'case-a'])).toEqual({ success: true, case: terminalA });
+    });
+    expect(client.getQueryData(['age-review-active-case', PUBKEY_A])).toEqual({ success: true, case: null });
+    // ...and must NOT poison the newly selected case's keys
+    const caseBEntry = client.getQueryData<{ case: AgeReviewCase }>(['age-review-case', 'case-b']);
+    expect(caseBEntry === undefined || caseBEntry?.case?.id === 'case-b').toBe(true);
+    const lookupB = client.getQueryData<{ case: AgeReviewCase | null }>(['age-review-active-case', PUBKEY_B]);
+    expect(lookupB === undefined || lookupB?.case?.id === 'case-b').toBe(true);
+  });
+});

--- a/src/components/AgeReview.reentry.test.tsx
+++ b/src/components/AgeReview.reentry.test.tsx
@@ -1,0 +1,139 @@
+// ABOUTME: Adversarial repro — re-entering the ?pubkey= hand-off after a
+// ABOUTME: terminal action, while ['age-review-active-case', pubkey] is still cached.
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { AgeReviewCase } from '../../shared/age-review';
+import { AgeReview } from './AgeReview';
+
+const getAgeReviewCases = vi.fn();
+const getActiveAgeReviewCase = vi.fn();
+const getAgeReviewCase = vi.fn();
+const updateAgeReviewCase = vi.fn();
+const getAgeReviewConfig = vi.fn();
+const getAccountStatus = vi.fn();
+
+vi.mock('@/hooks/useAdminApi', () => ({
+  useApiUrl: () => 'https://api.test.divine.video',
+  useAdminApi: () => ({
+    getAgeReviewCases,
+    getActiveAgeReviewCase,
+    getAgeReviewCase,
+    updateAgeReviewCase,
+    getAgeReviewConfig,
+    getAccountStatus,
+  }),
+}));
+
+vi.mock('@/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ user: { pubkey: 'f'.repeat(64) } }),
+}));
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({ data: undefined, isLoading: false }),
+}));
+vi.mock('@/components/AgeReviewFunnel', () => ({ AgeReviewFunnel: () => null }));
+vi.mock('@/components/CreateMinorAccountDialog', () => ({ CreateMinorAccountDialog: () => null }));
+vi.mock('@/components/UserIdentifier', () => ({
+  UserIdentifier: ({ pubkey }: { pubkey: string }) => <span>{pubkey.slice(0, 8)}</span>,
+}));
+vi.mock('@/components/UserActions', () => ({ UserActions: () => null }));
+vi.mock('@/components/DeleteConfirmDialog', () => ({ DeleteConfirmDialog: () => null }));
+
+const PUBKEY = 'a'.repeat(64);
+
+function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
+  return {
+    id: 'case-1',
+    pubkey: PUBKEY,
+    reporter_pubkey: 'b'.repeat(64),
+    report_id: 'report-1',
+    suspected_age_band: 'age_13_15',
+    state: 'under_moderator_review',
+    allowed_resolution: 'parent_video_or_email',
+    parent_contact_email: null,
+    deadline_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    clock_paused: 0,
+    clock_paused_at: null,
+    remaining_days_when_paused: null,
+    moderator_pubkey: null,
+    resolution_note: null,
+    last_alerted_at: null,
+    zendesk_ticket_id: null,
+    created_via: 'report',
+    claim_link_url: null,
+    claim_link_expires_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    version: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAgeReviewCases.mockResolvedValue({ success: true, cases: [] });
+  getAgeReviewConfig.mockResolvedValue({ auto_delete_on_deny: false });
+  getAccountStatus.mockResolvedValue({ success: true, verified_minor: false });
+});
+
+describe('re-entering the hand-off after a terminal action (adversarial)', () => {
+  it('does not resurrect stale ACTIVE controls from the cached active-case lookup', async () => {
+    const activeCase = makeCase();
+    const terminalCase = makeCase({ state: 'cleared', version: 1 });
+
+    // First hand-off entry resolves via the direct lookup (fresh case, empty lists)
+    getActiveAgeReviewCase.mockResolvedValue({ success: true, case: activeCase });
+    getAgeReviewCase.mockResolvedValue({ success: true, case: activeCase });
+    updateAgeReviewCase.mockResolvedValue({
+      success: true,
+      case: terminalCase,
+      enforcementComplete: true,
+      enforcement: { relay: 'ok', bulk: 'ok', keycast: 'ok', keycastMinorClear: 'not_attempted' },
+    });
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    // --- Visit 1: hand-off -> Clear (terminal) ---
+    const first = render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={[`/age-review?pubkey=${PUBKEY}`]}>
+          <AgeReview />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    const clearButton = await first.findByRole('button', { name: 'Clear' });
+    fireEvent.click(clearButton);
+    await waitFor(() => expect(updateAgeReviewCase).toHaveBeenCalledTimes(1));
+    expect(await first.findByText('Cleared')).toBeInTheDocument();
+
+    // Moderator navigates away (back to the report) — page unmounts, cache lives on
+    first.unmount();
+
+    // From here on, the SERVER knows the truth: no active case, per-case row terminal
+    getActiveAgeReviewCase.mockResolvedValue({ success: true, case: null });
+    getAgeReviewCase.mockResolvedValue({ success: true, case: terminalCase });
+
+    // --- Visit 2: same hand-off link clicked again within the 30s staleTime ---
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={[`/age-review?pubkey=${PUBKEY}`]}>
+          <AgeReview />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // The truth is terminal: the moderator must see Cleared (or the honest
+    // no-active-case empty state) — never actionable ACTIVE controls.
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument();
+    }, { timeout: 3000 });
+    expect(
+      screen.queryByText('Cleared') ??
+      screen.queryByText(/No active age-review case/)
+    ).toBeTruthy();
+  });
+});

--- a/src/components/AgeReview.test.tsx
+++ b/src/components/AgeReview.test.tsx
@@ -1,0 +1,138 @@
+// ABOUTME: Tests the AgeReview page's report hand-off states (#152/#179):
+// ABOUTME: ?pubkey= resolution must never show the generic prompt mid-hand-off
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { AgeReviewCase } from '../../shared/age-review';
+import { AgeReview } from './AgeReview';
+
+const getAgeReviewCases = vi.fn();
+const getActiveAgeReviewCase = vi.fn();
+const getAgeReviewCase = vi.fn();
+
+vi.mock('@/hooks/useAdminApi', () => ({
+  useApiUrl: () => 'https://api.test.divine.video',
+  useAdminApi: () => ({
+    getAgeReviewCases,
+    getActiveAgeReviewCase,
+    getAgeReviewCase,
+  }),
+}));
+
+vi.mock('@/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+
+// Heavy children irrelevant to hand-off sequencing
+vi.mock('@/components/AgeReviewDetail', () => ({
+  AgeReviewDetail: ({ caseData }: { caseData: AgeReviewCase }) => (
+    <div data-testid="case-detail">case:{caseData.id}</div>
+  ),
+}));
+vi.mock('@/components/AgeReviewFunnel', () => ({ AgeReviewFunnel: () => null }));
+vi.mock('@/components/CreateMinorAccountDialog', () => ({ CreateMinorAccountDialog: () => null }));
+vi.mock('@/components/UserIdentifier', () => ({
+  UserIdentifier: ({ pubkey }: { pubkey: string }) => <span>{pubkey.slice(0, 8)}</span>,
+}));
+
+const PUBKEY = 'a'.repeat(64);
+
+function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
+  return {
+    id: 'case-1',
+    pubkey: PUBKEY,
+    reporter_pubkey: 'b'.repeat(64),
+    report_id: 'report-1',
+    suspected_age_band: 'age_13_15',
+    state: 'open_reported',
+    allowed_resolution: 'parent_video_or_email',
+    parent_contact_email: null,
+    deadline_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    clock_paused: 0,
+    clock_paused_at: null,
+    remaining_days_when_paused: null,
+    moderator_pubkey: null,
+    resolution_note: null,
+    last_alerted_at: null,
+    zendesk_ticket_id: null,
+    created_via: 'report',
+    claim_link_url: null,
+    claim_link_expires_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    version: 0,
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+function renderPage(initialEntry: string) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <AgeReview />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  getAgeReviewCases.mockReset();
+  getActiveAgeReviewCase.mockReset();
+  getAgeReviewCase.mockReset();
+  // Case lists resolve empty by default (fresh case not yet in the 30s cache)
+  getAgeReviewCases.mockResolvedValue({ success: true, cases: [] });
+  getAgeReviewCase.mockResolvedValue({ success: true, case: null });
+});
+
+describe('AgeReview report hand-off (?pubkey=)', () => {
+  it('shows the resolving state while the lookup is in flight, never the generic prompt', async () => {
+    const lookup = deferred<{ success: boolean; case: AgeReviewCase }>();
+    getActiveAgeReviewCase.mockReturnValue(lookup.promise);
+
+    renderPage(`/age-review?pubkey=${PUBKEY}`);
+
+    expect(await screen.findByText(/Opening this account's age-review case/)).toBeInTheDocument();
+    expect(screen.queryByText('Select a case to view details')).not.toBeInTheDocument();
+
+    lookup.resolve({ success: true, case: makeCase() });
+
+    // The lookup already returned the full case: the detail must render from
+    // it directly, with no second fetch and no generic-prompt interlude
+    expect(await screen.findByTestId('case-detail')).toHaveTextContent('case:case-1');
+    expect(screen.queryByText('Select a case to view details')).not.toBeInTheDocument();
+    expect(getAgeReviewCase).not.toHaveBeenCalled();
+  });
+
+  it('shows the explicit no-active-case message when the lookup settles empty', async () => {
+    getActiveAgeReviewCase.mockResolvedValue({ success: true, case: null });
+
+    renderPage(`/age-review?pubkey=${PUBKEY}`);
+
+    expect(await screen.findByText(/No active age-review case for this account/)).toBeInTheDocument();
+    expect(screen.queryByText('Select a case to view details')).not.toBeInTheDocument();
+  });
+
+  it('shows an honest error state when the lookup fails, not the no-case message', async () => {
+    getActiveAgeReviewCase.mockRejectedValue(new Error('server exploded'));
+
+    renderPage(`/age-review?pubkey=${PUBKEY}`);
+
+    expect(await screen.findByText(/Couldn't look up this account's case/)).toBeInTheDocument();
+    expect(screen.queryByText(/No active age-review case/)).not.toBeInTheDocument();
+  });
+
+  it('shows the generic prompt only when no hand-off is in play', async () => {
+    renderPage('/age-review');
+
+    expect(await screen.findByText('Select a case to view details')).toBeInTheDocument();
+    expect(getActiveAgeReviewCase).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/AgeReview.tsx
+++ b/src/components/AgeReview.tsx
@@ -122,11 +122,12 @@ export function AgeReview() {
     // the ?case= normalization renders immediately instead of paying a second
     // round-trip (during which the pane regressed to the generic prompt and
     // the mobile sheet bounced closed) — the hand-off's second half.
-    if (pubkeyLookup?.case) {
-      queryClient.setQueryData(['age-review-case', pubkeyResolvedId], { success: true, case: pubkeyLookup.case });
+    const resolvedCase = pubkeyMatch ?? pubkeyLookup?.case;
+    if (resolvedCase) {
+      queryClient.setQueryData(['age-review-case', pubkeyResolvedId], { success: true, case: resolvedCase });
     }
     setSelectedCaseId(pubkeyResolvedId);
-  }, [pubkeyParam, pubkeyResolvedId, pubkeyLookup, queryClient, setSelectedCaseId]);
+  }, [pubkeyParam, pubkeyResolvedId, pubkeyMatch, pubkeyLookup, queryClient, setSelectedCaseId]);
 
   // A ?pubkey= that resolves to no active case (already cleared/verified, or
   // still being created) gets an explicit empty state, not a blank panel — but

--- a/src/components/AgeReview.tsx
+++ b/src/components/AgeReview.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useEffect, useCallback } from "react";
 import { useSearchParams } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAdminApi } from "@/hooks/useAdminApi";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -54,6 +54,7 @@ export function AgeReview() {
   const api = useAdminApi();
   const isMobile = useIsMobile();
   const [searchParams, setSearchParams] = useSearchParams();
+  const queryClient = useQueryClient();
   const selectedCaseId = searchParams.get('case');
   const pubkeyParam = searchParams.get('pubkey');
 
@@ -108,7 +109,7 @@ export function AgeReview() {
   const pubkeyMatch = pubkeyParam
     ? activeData?.cases?.find(c => c.pubkey === pubkeyParam) ?? null
     : null;
-  const { data: pubkeyLookup, isFetching: pubkeyFetching } = useQuery({
+  const { data: pubkeyLookup, isFetching: pubkeyFetching, isError: pubkeyLookupFailed } = useQuery({
     queryKey: ['age-review-active-case', pubkeyParam],
     queryFn: () => api.getActiveAgeReviewCase(pubkeyParam!),
     enabled: !!pubkeyParam && !pubkeyMatch,
@@ -116,19 +117,28 @@ export function AgeReview() {
   });
   const pubkeyResolvedId = pubkeyMatch?.id ?? pubkeyLookup?.case?.id ?? null;
   useEffect(() => {
-    if (pubkeyParam && pubkeyResolvedId) setSelectedCaseId(pubkeyResolvedId);
-  }, [pubkeyParam, pubkeyResolvedId, setSelectedCaseId]);
+    if (!pubkeyParam || !pubkeyResolvedId) return;
+    // The lookup already returned the full case: seed the per-case cache so
+    // the ?case= normalization renders immediately instead of paying a second
+    // round-trip (during which the pane regressed to the generic prompt and
+    // the mobile sheet bounced closed) — the hand-off's second half.
+    if (pubkeyLookup?.case) {
+      queryClient.setQueryData(['age-review-case', pubkeyResolvedId], { success: true, case: pubkeyLookup.case });
+    }
+    setSelectedCaseId(pubkeyResolvedId);
+  }, [pubkeyParam, pubkeyResolvedId, pubkeyLookup, queryClient, setSelectedCaseId]);
 
   // A ?pubkey= that resolves to no active case (already cleared/verified, or
   // still being created) gets an explicit empty state, not a blank panel — but
-  // only once the active list has loaded and the fallback lookup has settled.
+  // only once the active list has loaded and the fallback lookup has settled
+  // WITHOUT error (a failed lookup gets its own honest message below).
   const pubkeyUnresolved = !!pubkeyParam && !pubkeyResolvedId
-    && activeData !== undefined && !pubkeyFetching;
-  // While the hand-off lookup is still in flight, say so — the generic
-  // "Select a case" prompt here read as "nothing happened" to moderators
-  // (a fresh case isn't in the 30s-cached list, so the direct lookup's
-  // round-trip is a visible pause on the report -> age-review hand-off).
-  const pubkeyResolving = !!pubkeyParam && !pubkeyResolvedId && !pubkeyUnresolved;
+    && activeData !== undefined && !pubkeyFetching && !pubkeyLookupFailed;
+  // While the hand-off is still becoming renderable, say so — the generic
+  // "Select a case" prompt here read as "nothing happened" to moderators.
+  // Keyed on render-readiness (!selectedCase), not just lookup settlement,
+  // so the frame between resolution and the ?case= URL rewrite stays covered.
+  const pubkeyResolving = !!pubkeyParam && !pubkeyUnresolved && !pubkeyLookupFailed && !selectedCase;
 
   const activeCounts = useMemo(() => {
     if (!activeData?.cases) return { total: 0, urgent: 0 };
@@ -273,6 +283,10 @@ export function AgeReview() {
       <RefreshCw className="h-4 w-4 animate-spin" />
       Opening this account&apos;s age-review case…
     </div>
+  ) : pubkeyParam && pubkeyLookupFailed ? (
+    <div className="flex items-center justify-center h-full p-6 text-center text-sm text-muted-foreground">
+      Couldn&apos;t look up this account&apos;s case — the lookup failed. Retry from the report, or check the case list.
+    </div>
   ) : pubkeyUnresolved ? (
     <div className="flex items-center justify-center h-full p-6 text-center text-sm text-muted-foreground">
       No active age-review case for this account. It may already be resolved (for example a verified minor), or the case is still being created — refresh in a moment.
@@ -287,7 +301,7 @@ export function AgeReview() {
     return (
       <Card className="h-full flex flex-col overflow-hidden">
         {listContent}
-        <Sheet open={!!selectedCase || pubkeyUnresolved || pubkeyResolving} onOpenChange={() => setSelectedCaseId(null)}>
+        <Sheet open={!!selectedCase || pubkeyUnresolved || pubkeyResolving || (!!pubkeyParam && pubkeyLookupFailed)} onOpenChange={() => setSelectedCaseId(null)}>
           <SheetContent side="bottom" className="h-[80vh] p-0">
             {detailContent}
           </SheetContent>

--- a/src/components/AgeReview.tsx
+++ b/src/components/AgeReview.tsx
@@ -124,7 +124,19 @@ export function AgeReview() {
     // the mobile sheet bounced closed) — the hand-off's second half.
     const resolvedCase = pubkeyMatch ?? pubkeyLookup?.case;
     if (resolvedCase) {
-      queryClient.setQueryData(['age-review-case', pubkeyResolvedId], { success: true, case: resolvedCase });
+      // Stamp the seed with the SOURCE's timestamp, not "now": a cron or
+      // another moderator can close the case while our lookup entry ages,
+      // and a now-stamped seed would re-mark that stale row fresh and block
+      // the corrective refetch. Source-stamped, a stale seed still renders
+      // instantly and self-corrects in one round-trip (review).
+      const sourceUpdatedAt = pubkeyMatch
+        ? queryClient.getQueryState(['age-review-cases', { state: 'active' }])?.dataUpdatedAt
+        : queryClient.getQueryState(['age-review-active-case', pubkeyParam])?.dataUpdatedAt;
+      queryClient.setQueryData(
+        ['age-review-case', pubkeyResolvedId],
+        { success: true, case: resolvedCase },
+        sourceUpdatedAt ? { updatedAt: sourceUpdatedAt } : undefined,
+      );
     }
     setSelectedCaseId(pubkeyResolvedId);
   }, [pubkeyParam, pubkeyResolvedId, pubkeyMatch, pubkeyLookup, queryClient, setSelectedCaseId]);

--- a/src/components/AgeReview.tsx
+++ b/src/components/AgeReview.tsx
@@ -124,6 +124,11 @@ export function AgeReview() {
   // only once the active list has loaded and the fallback lookup has settled.
   const pubkeyUnresolved = !!pubkeyParam && !pubkeyResolvedId
     && activeData !== undefined && !pubkeyFetching;
+  // While the hand-off lookup is still in flight, say so — the generic
+  // "Select a case" prompt here read as "nothing happened" to moderators
+  // (a fresh case isn't in the 30s-cached list, so the direct lookup's
+  // round-trip is a visible pause on the report -> age-review hand-off).
+  const pubkeyResolving = !!pubkeyParam && !pubkeyResolvedId && !pubkeyUnresolved;
 
   const activeCounts = useMemo(() => {
     if (!activeData?.cases) return { total: 0, urgent: 0 };
@@ -263,6 +268,11 @@ export function AgeReview() {
 
   const detailContent = selectedCase ? (
     <AgeReviewDetail caseData={selectedCase} />
+  ) : pubkeyResolving ? (
+    <div className="flex items-center justify-center h-full gap-2 text-sm text-muted-foreground">
+      <RefreshCw className="h-4 w-4 animate-spin" />
+      Opening this account&apos;s age-review case…
+    </div>
   ) : pubkeyUnresolved ? (
     <div className="flex items-center justify-center h-full p-6 text-center text-sm text-muted-foreground">
       No active age-review case for this account. It may already be resolved (for example a verified minor), or the case is still being created — refresh in a moment.
@@ -277,7 +287,7 @@ export function AgeReview() {
     return (
       <Card className="h-full flex flex-col overflow-hidden">
         {listContent}
-        <Sheet open={!!selectedCase || pubkeyUnresolved} onOpenChange={() => setSelectedCaseId(null)}>
+        <Sheet open={!!selectedCase || pubkeyUnresolved || pubkeyResolving} onOpenChange={() => setSelectedCaseId(null)}>
           <SheetContent side="bottom" className="h-[80vh] p-0">
             {detailContent}
           </SheetContent>

--- a/src/components/AgeReview.uninvalidate.test.tsx
+++ b/src/components/AgeReview.uninvalidate.test.tsx
@@ -1,0 +1,147 @@
+// ABOUTME: Adversarial repro — the reconciler's setQueryData runs AFTER the list
+// ABOUTME: invalidation, un-invalidating and fresh-stamping UNOBSERVED list caches.
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { AgeReviewCase } from '../../shared/age-review';
+import { AgeReview } from './AgeReview';
+
+const getAgeReviewCases = vi.fn();
+const getActiveAgeReviewCase = vi.fn();
+const getAgeReviewCase = vi.fn();
+const updateAgeReviewCase = vi.fn();
+const getAgeReviewConfig = vi.fn();
+const getAccountStatus = vi.fn();
+
+vi.mock('@/hooks/useAdminApi', () => ({
+  useApiUrl: () => 'https://api.test.divine.video',
+  useAdminApi: () => ({
+    getAgeReviewCases,
+    getActiveAgeReviewCase,
+    getAgeReviewCase,
+    updateAgeReviewCase,
+    getAgeReviewConfig,
+    getAccountStatus,
+  }),
+}));
+
+vi.mock('@/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ user: { pubkey: 'f'.repeat(64) } }),
+}));
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({ data: undefined, isLoading: false }),
+}));
+vi.mock('@/components/AgeReviewFunnel', () => ({ AgeReviewFunnel: () => null }));
+vi.mock('@/components/CreateMinorAccountDialog', () => ({ CreateMinorAccountDialog: () => null }));
+vi.mock('@/components/UserIdentifier', () => ({
+  UserIdentifier: ({ pubkey }: { pubkey: string }) => <span>{`user-${pubkey.slice(0, 2)}`}</span>,
+}));
+vi.mock('@/components/UserActions', () => ({ UserActions: () => null }));
+vi.mock('@/components/DeleteConfirmDialog', () => ({ DeleteConfirmDialog: () => null }));
+
+const PUBKEY_A = 'a'.repeat(64);
+const PUBKEY_B = 'b'.repeat(64);
+
+function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
+  return {
+    id: 'case-a',
+    pubkey: PUBKEY_A,
+    reporter_pubkey: 'c'.repeat(64),
+    report_id: 'report-1',
+    suspected_age_band: 'age_13_15',
+    state: 'under_moderator_review',
+    allowed_resolution: 'parent_video_or_email',
+    parent_contact_email: null,
+    deadline_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    clock_paused: 0,
+    clock_paused_at: null,
+    remaining_days_when_paused: null,
+    moderator_pubkey: null,
+    resolution_note: null,
+    last_alerted_at: null,
+    zendesk_ticket_id: null,
+    created_via: 'report',
+    claim_link_url: null,
+    claim_link_expires_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    version: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAgeReviewConfig.mockResolvedValue({ auto_delete_on_deny: false });
+  getAccountStatus.mockResolvedValue({ success: true, verified_minor: false });
+  getActiveAgeReviewCase.mockResolvedValue({ success: true, case: null });
+});
+
+describe('reconcile-after-invalidate un-invalidates unobserved list caches (adversarial)', () => {
+  it('a mutation must not suppress the refetch of a stale unobserved filter cache', async () => {
+    const caseA = makeCase();
+    const terminalA = makeCase({ state: 'cleared', version: 1 });
+    // Case B: DENIED 2 minutes ago per the cached closed list, since REOPENED
+    // server-side (cross-actor) — the closed list's refetch is what corrects it
+    const staleClosedB = makeCase({ id: 'case-b', pubkey: PUBKEY_B, state: 'denied_closed', version: 3 });
+
+    getAgeReviewCases.mockImplementation((params?: { state?: string }) => {
+      const cleared = updateAgeReviewCase.mock.calls.length > 0; // server truth after the PATCH
+      if (params?.state === 'closed') {
+        // server truth: B is no longer closed; after the PATCH, A (just cleared) is
+        return Promise.resolve({ success: true, cases: cleared ? [terminalA] : [] });
+      }
+      return Promise.resolve({ success: true, cases: cleared ? [] : [caseA] });
+    });
+    getAgeReviewCase.mockResolvedValue({ success: true, case: caseA });
+    updateAgeReviewCase.mockResolvedValue({
+      success: true,
+      case: terminalA,
+      enforcementComplete: true,
+      enforcement: { relay: 'ok', bulk: 'ok', keycast: 'ok', keycastMinorClear: 'not_attempted' },
+    });
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    // The moderator viewed the Closed tab 2 minutes ago; entry is cached,
+    // currently unobserved, and 2 minutes stale
+    client.setQueryData(
+      ['age-review-cases', { state: 'closed' }],
+      { success: true, cases: [staleClosedB] },
+      { updatedAt: Date.now() - 120_000 },
+    );
+
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/age-review?case=case-a']}>
+          <AgeReview />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // Clear case A (any successful mutation runs invalidate + reconcile)
+    fireEvent.click(await screen.findByRole('button', { name: 'Clear' }));
+    await waitFor(() => expect(updateAgeReviewCase).toHaveBeenCalledTimes(1));
+    await screen.findByText('Cleared');
+
+    // Within 30s the moderator switches to the Closed tab. The invalidation
+    // promised a refetch; the closed list must show server truth (B gone,
+    // A present), not the 2-minute-old row.
+    const closedCallsBefore = getAgeReviewCases.mock.calls.filter(c => c[0]?.state === 'closed').length;
+    const closedTab = screen.getByRole('tab', { name: 'Closed' });
+    fireEvent.mouseDown(closedTab);
+    fireEvent.click(closedTab);
+    await waitFor(() => expect(closedTab.getAttribute('aria-selected')).toBe('true'));
+
+    await waitFor(() => {
+      const closedCallsAfter = getAgeReviewCases.mock.calls.filter(c => c[0]?.state === 'closed').length;
+      expect(closedCallsAfter).toBeGreaterThan(closedCallsBefore); // refetch actually fired
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('user-bb')).not.toBeInTheDocument(); // stale reopened case gone
+    });
+  });
+});

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -118,6 +118,17 @@ export function AgeReviewDetail({ caseData: c }: Props) {
     },
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['age-review-cases'] });
+      // Keep the per-case entry in step: the hand-off seeds
+      // ['age-review-case', id] (30s staleTime), and a terminal action drops
+      // the case from the active list, so the detail falls back to that
+      // entry — left stale, it shows actionable controls with the old
+      // expected_version (review). The PATCH returns the updated row; write
+      // it through, or invalidate if a response ever omits it.
+      if (data.case) {
+        queryClient.setQueryData(['age-review-case', c.id], { success: true, case: data.case });
+      } else {
+        queryClient.invalidateQueries({ queryKey: ['age-review-case', c.id] });
+      }
       const requestedState = pendingStateRef.current as AgeReviewState | undefined;
       if (requestedState && ENFORCEMENT_STATES.includes(requestedState) && data.enforcementComplete === false) {
         // Surface only actual failed enforcement legs. `not_attempted` is valid
@@ -141,6 +152,8 @@ export function AgeReviewDetail({ caseData: c }: Props) {
       // blindly replay a possibly-stale transition.
       if (error instanceof ApiError && error.code === 'version_conflict') {
         queryClient.invalidateQueries({ queryKey: ['age-review-cases'] });
+        // The reload must also reach the per-case fallback the hand-off seeds
+        queryClient.invalidateQueries({ queryKey: ['age-review-case', c.id] });
         toast({
           title: 'Case changed since you opened it',
           description: 'Another moderator or an automated deadline action modified this case. Reloaded the latest state; review it and re-apply if still needed.',

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -116,27 +116,33 @@ export function AgeReviewDetail({ caseData: c }: Props) {
       pendingStateRef.current = updates.state as string | undefined;
       return api.updateAgeReviewCase(c.id, { ...updates, expected_version: c.version });
     },
-    onSuccess: (data) => {
+    // Capture the mutated case's identity at mutate time: onSuccess/onError
+    // fire with the LATEST render's closure, so after a mid-flight case
+    // switch a closure-read c would misroute every cache write below
+    // (review: wrong case's keys written, the acted-on case left stale)
+    onMutate: () => ({ caseId: c.id, casePubkey: c.pubkey }),
+    onSuccess: (data, _updates, ctx) => {
       queryClient.invalidateQueries({ queryKey: ['age-review-cases'] });
       // Keep the per-case entry in step: the hand-off seeds
       // ['age-review-case', id] (30s staleTime), and a terminal action drops
       // the case from the active list, so the detail falls back to that
       // entry — left stale, it shows actionable controls with the old
       // expected_version (review). The PATCH returns the updated row; write
-      // it through, or invalidate if a response ever omits it.
+      // it through (keyed from the RESPONSE), or invalidate the mutate-time
+      // keys if a response ever omits it.
       if (data.case) {
-        queryClient.setQueryData(['age-review-case', c.id], { success: true, case: data.case });
+        queryClient.setQueryData(['age-review-case', data.case.id], { success: true, case: data.case });
         // ...and the hand-off's lookup key: left stale, re-entering the
         // ?pubkey= hand-off within its cache lifetime re-seeds the per-case
         // entry with the pre-action ACTIVE row, resurrecting the exact hole
         // above. Terminal states have no active case; write that truth.
         queryClient.setQueryData(
-          ['age-review-active-case', c.pubkey],
+          ['age-review-active-case', data.case.pubkey],
           { success: true, case: TERMINAL_STATES.includes(data.case.state) ? null : data.case },
         );
       } else {
-        queryClient.invalidateQueries({ queryKey: ['age-review-case', c.id] });
-        queryClient.removeQueries({ queryKey: ['age-review-active-case', c.pubkey] });
+        queryClient.invalidateQueries({ queryKey: ['age-review-case', ctx.caseId] });
+        queryClient.removeQueries({ queryKey: ['age-review-active-case', ctx.casePubkey] });
       }
       const requestedState = pendingStateRef.current as AgeReviewState | undefined;
       if (requestedState && ENFORCEMENT_STATES.includes(requestedState) && data.enforcementComplete === false) {
@@ -154,18 +160,19 @@ export function AgeReviewDetail({ caseData: c }: Props) {
         });
       }
     },
-    onError: (error) => {
+    onError: (error, _updates, ctx) => {
       // A concurrent writer (another moderator, or the deadline cron) changed
       // the case between our read and this write. Reload the current state so
       // the moderator can review it before re-applying; we deliberately do not
       // blindly replay a possibly-stale transition.
       if (error instanceof ApiError && error.code === 'version_conflict') {
         queryClient.invalidateQueries({ queryKey: ['age-review-cases'] });
-        // The reload must also reach the per-case fallback the hand-off seeds
-        queryClient.invalidateQueries({ queryKey: ['age-review-case', c.id] });
+        // Mutate-time identity (ctx), not the render closure: a mid-flight
+        // case switch must reload the case that conflicted
+        queryClient.invalidateQueries({ queryKey: ['age-review-case', ctx?.caseId] });
         // Remove (not invalidate) the lookup entry: the hand-off effect seeds
         // synchronously from cached data before any refetch could land
-        queryClient.removeQueries({ queryKey: ['age-review-active-case', c.pubkey] });
+        queryClient.removeQueries({ queryKey: ['age-review-active-case', ctx?.casePubkey] });
         toast({
           title: 'Case changed since you opened it',
           description: 'Another moderator or an automated deadline action modified this case. Reloaded the latest state; review it and re-apply if still needed.',

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -126,8 +126,17 @@ export function AgeReviewDetail({ caseData: c }: Props) {
       // it through, or invalidate if a response ever omits it.
       if (data.case) {
         queryClient.setQueryData(['age-review-case', c.id], { success: true, case: data.case });
+        // ...and the hand-off's lookup key: left stale, re-entering the
+        // ?pubkey= hand-off within its cache lifetime re-seeds the per-case
+        // entry with the pre-action ACTIVE row, resurrecting the exact hole
+        // above. Terminal states have no active case; write that truth.
+        queryClient.setQueryData(
+          ['age-review-active-case', c.pubkey],
+          { success: true, case: TERMINAL_STATES.includes(data.case.state) ? null : data.case },
+        );
       } else {
         queryClient.invalidateQueries({ queryKey: ['age-review-case', c.id] });
+        queryClient.removeQueries({ queryKey: ['age-review-active-case', c.pubkey] });
       }
       const requestedState = pendingStateRef.current as AgeReviewState | undefined;
       if (requestedState && ENFORCEMENT_STATES.includes(requestedState) && data.enforcementComplete === false) {
@@ -154,6 +163,9 @@ export function AgeReviewDetail({ caseData: c }: Props) {
         queryClient.invalidateQueries({ queryKey: ['age-review-cases'] });
         // The reload must also reach the per-case fallback the hand-off seeds
         queryClient.invalidateQueries({ queryKey: ['age-review-case', c.id] });
+        // Remove (not invalidate) the lookup entry: the hand-off effect seeds
+        // synchronously from cached data before any refetch could land
+        queryClient.removeQueries({ queryKey: ['age-review-active-case', c.pubkey] });
         toast({
           title: 'Case changed since you opened it',
           description: 'Another moderator or an automated deadline action modified this case. Reloaded the latest state; review it and re-apply if still needed.',

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -123,7 +123,6 @@ export function AgeReviewDetail({ caseData: c }: Props) {
     // (review: wrong case's keys written, the acted-on case left stale)
     onMutate: () => ({ caseId: c.id, casePubkey: c.pubkey }),
     onSuccess: (data, _updates, ctx) => {
-      queryClient.invalidateQueries({ queryKey: ['age-review-cases'] });
       // Keep the per-case entry in step: the hand-off seeds
       // ['age-review-case', id] (30s staleTime), and a terminal action drops
       // the case from the active list, so the detail falls back to that
@@ -143,7 +142,12 @@ export function AgeReviewDetail({ caseData: c }: Props) {
           .forEach(([key, old]) => {
             if (!old?.cases) return;
             const params = (key[1] ?? {}) as AgeReviewListParams;
-            queryClient.setQueryData(key, { ...old, cases: reconcileCaseIntoList(params, old.cases, updated) });
+            const reconciled = reconcileCaseIntoList(params, old.cases, updated);
+            // Same-reference result = no change; skip the write so untouched
+            // entries keep their invalidation state and timestamps
+            if (reconciled !== old.cases) {
+              queryClient.setQueryData(key, { ...old, cases: reconciled });
+            }
           });
         // ...and the hand-off's lookup key: left stale, re-entering the
         // ?pubkey= hand-off within its cache lifetime re-seeds the per-case
@@ -157,6 +161,12 @@ export function AgeReviewDetail({ caseData: c }: Props) {
         queryClient.invalidateQueries({ queryKey: ['age-review-case', ctx.caseId] });
         queryClient.removeQueries({ queryKey: ['age-review-active-case', ctx.casePubkey] });
       }
+      // Invalidate AFTER the cache writes: setQueryData clears isInvalidated
+      // and fresh-stamps the entry, so writing after invalidating would
+      // suppress refetch-on-mount for every unobserved list cache (review) —
+      // this order keeps reconciled data rendering now AND every list due a
+      // real refetch.
+      queryClient.invalidateQueries({ queryKey: ['age-review-cases'] });
       const requestedState = pendingStateRef.current as AgeReviewState | undefined;
       if (requestedState && ENFORCEMENT_STATES.includes(requestedState) && data.enforcementComplete === false) {
         // Surface only actual failed enforcement legs. `not_attempted` is valid

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAdminApi, useApiUrl } from "@/hooks/useAdminApi";
 import { ApiError } from "@/lib/adminApi";
+import { reconcileCaseIntoList, type AgeReviewListParams } from "@/lib/ageReviewCache";
 import { useToast } from "@/hooks/useToast";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { UserActions } from "@/components/UserActions";
@@ -131,14 +132,26 @@ export function AgeReviewDetail({ caseData: c }: Props) {
       // it through (keyed from the RESPONSE), or invalidate the mutate-time
       // keys if a response ever omits it.
       if (data.case) {
-        queryClient.setQueryData(['age-review-case', data.case.id], { success: true, case: data.case });
+        const updated = data.case;
+        queryClient.setQueryData(['age-review-case', updated.id], { success: true, case: updated });
+        // ...and every cached LIST: selectedCase prefers the list row, so a
+        // retained pre-action row out-votes both repaired entries while the
+        // invalidation refetch is pending — or forever if it fails (review).
+        // Reconcile the response row into each list per its filter params;
+        // the refetch still supersedes with full server truth when it lands.
+        queryClient.getQueriesData<{ success: boolean; cases: AgeReviewCase[] }>({ queryKey: ['age-review-cases'] })
+          .forEach(([key, old]) => {
+            if (!old?.cases) return;
+            const params = (key[1] ?? {}) as AgeReviewListParams;
+            queryClient.setQueryData(key, { ...old, cases: reconcileCaseIntoList(params, old.cases, updated) });
+          });
         // ...and the hand-off's lookup key: left stale, re-entering the
         // ?pubkey= hand-off within its cache lifetime re-seeds the per-case
         // entry with the pre-action ACTIVE row, resurrecting the exact hole
         // above. Terminal states have no active case; write that truth.
         queryClient.setQueryData(
-          ['age-review-active-case', data.case.pubkey],
-          { success: true, case: TERMINAL_STATES.includes(data.case.state) ? null : data.case },
+          ['age-review-active-case', updated.pubkey],
+          { success: true, case: TERMINAL_STATES.includes(updated.state) ? null : updated },
         );
       } else {
         queryClient.invalidateQueries({ queryKey: ['age-review-case', ctx.caseId] });

--- a/src/lib/ageReviewCache.test.ts
+++ b/src/lib/ageReviewCache.test.ts
@@ -1,0 +1,84 @@
+// ABOUTME: Tests list-cache reconciliation for mutated age-review cases —
+// ABOUTME: the client-side mirror of the worker's list filters (#179 review)
+
+import { describe, expect, it } from 'vitest';
+import type { AgeReviewCase } from '../../shared/age-review';
+import { caseBelongsInList, reconcileCaseIntoList } from './ageReviewCache';
+
+function makeCase(overrides: Partial<AgeReviewCase> = {}): AgeReviewCase {
+  return {
+    id: 'case-1',
+    pubkey: 'a'.repeat(64),
+    reporter_pubkey: 'b'.repeat(64),
+    report_id: 'report-1',
+    suspected_age_band: 'age_13_15',
+    state: 'under_moderator_review',
+    allowed_resolution: 'parent_video_or_email',
+    parent_contact_email: null,
+    deadline_at: null,
+    clock_paused: 0,
+    clock_paused_at: null,
+    remaining_days_when_paused: null,
+    moderator_pubkey: null,
+    resolution_note: null,
+    last_alerted_at: null,
+    zendesk_ticket_id: null,
+    created_via: 'report',
+    claim_link_url: null,
+    claim_link_expires_at: null,
+    created_at: '2026-07-14T00:00:00Z',
+    updated_at: '2026-07-14T00:00:00Z',
+    version: 0,
+    ...overrides,
+  };
+}
+
+describe('caseBelongsInList', () => {
+  it('active list excludes terminal states and includes the rest', () => {
+    expect(caseBelongsInList({ state: 'active' }, makeCase({ state: 'cleared' }))).toBe(false);
+    expect(caseBelongsInList({ state: 'active' }, makeCase({ state: 'denied_closed' }))).toBe(false);
+    expect(caseBelongsInList({ state: 'active' }, makeCase({ state: 'open_reported' }))).toBe(true);
+  });
+
+  it('closed list includes only terminal states', () => {
+    expect(caseBelongsInList({ state: 'closed' }, makeCase({ state: 'cleared' }))).toBe(true);
+    expect(caseBelongsInList({ state: 'closed' }, makeCase({ state: 'open_reported' }))).toBe(false);
+  });
+
+  it('a specific state filter matches exactly', () => {
+    expect(caseBelongsInList({ state: 'under_moderator_review' }, makeCase())).toBe(true);
+    expect(caseBelongsInList({ state: 'under_moderator_review' }, makeCase({ state: 'cleared' }))).toBe(false);
+  });
+
+  it('no state filter means all states; band filters exactly', () => {
+    expect(caseBelongsInList({}, makeCase({ state: 'cleared' }))).toBe(true);
+    expect(caseBelongsInList({ age_band: 'under_13' }, makeCase())).toBe(false);
+    expect(caseBelongsInList({ age_band: 'age_13_15' }, makeCase())).toBe(true);
+  });
+});
+
+describe('reconcileCaseIntoList', () => {
+  const other = makeCase({ id: 'case-2', pubkey: 'c'.repeat(64) });
+
+  it('drops a newly terminal case from an active list (the shadowing row)', () => {
+    const active = makeCase();
+    const next = reconcileCaseIntoList({ state: 'active' }, [active, other], makeCase({ state: 'cleared', version: 1 }));
+    expect(next.map(c => c.id)).toEqual(['case-2']);
+  });
+
+  it('replaces the row in-place when the case still belongs (fresh version reaches the list)', () => {
+    const next = reconcileCaseIntoList({ state: 'active' }, [makeCase(), other], makeCase({ version: 3, clock_paused: 1 }));
+    expect(next.find(c => c.id === 'case-1')).toMatchObject({ version: 3, clock_paused: 1 });
+    expect(next).toHaveLength(2);
+  });
+
+  it('leaves a belonging-but-absent case for the refetch (never fabricates order)', () => {
+    const next = reconcileCaseIntoList({ state: 'closed' }, [makeCase({ id: 'case-9', state: 'cleared' })], makeCase({ state: 'cleared', version: 1 }));
+    expect(next.map(c => c.id)).toEqual(['case-9']);
+  });
+
+  it('does not disturb other rows when dropping', () => {
+    const next = reconcileCaseIntoList({ state: 'active' }, [other, makeCase()], makeCase({ state: 'denied_closed', version: 1 }));
+    expect(next).toEqual([other]);
+  });
+});

--- a/src/lib/ageReviewCache.ts
+++ b/src/lib/ageReviewCache.ts
@@ -1,0 +1,41 @@
+// ABOUTME: Pure reconciliation of a mutated age-review case into cached list
+// ABOUTME: data — every list cache must tell the truth about a case we just wrote
+
+import { TERMINAL_STATES, type AgeReviewCase } from "../../shared/age-review";
+
+/** The list-query param shapes used by the AgeReview page (mirrors the
+ * worker's handleGetAgeReviewCases filters). */
+export interface AgeReviewListParams {
+  state?: string;
+  age_band?: string;
+}
+
+/** Whether `c` belongs in a list fetched with `params` (client-side mirror
+ * of the worker's WHERE clause: active = not terminal, closed = terminal,
+ * a specific state matches exactly, absent = all; band matches exactly). */
+export function caseBelongsInList(params: AgeReviewListParams, c: AgeReviewCase): boolean {
+  if (params.state === 'active' && TERMINAL_STATES.includes(c.state)) return false;
+  if (params.state === 'closed' && !TERMINAL_STATES.includes(c.state)) return false;
+  if (params.state && params.state !== 'active' && params.state !== 'closed' && c.state !== params.state) return false;
+  if (params.age_band && c.suspected_age_band !== params.age_band) return false;
+  return true;
+}
+
+/**
+ * Reconcile a freshly mutated case into one cached list: replace the row when
+ * it still belongs, drop it when it no longer does (e.g. a terminal action on
+ * an active list). A belonging-but-absent case is left for the refetch to add
+ * — absence can't render stale controls, which is the failure this prevents:
+ * a retained pre-action row shadows the repaired per-case cache while the
+ * list refetch is pending or failed (review).
+ */
+export function reconcileCaseIntoList(
+  params: AgeReviewListParams,
+  cases: AgeReviewCase[],
+  updated: AgeReviewCase,
+): AgeReviewCase[] {
+  if (!caseBelongsInList(params, updated)) {
+    return cases.filter(c => c.id !== updated.id);
+  }
+  return cases.map(c => (c.id === updated.id ? updated : c));
+}

--- a/src/lib/ageReviewCache.ts
+++ b/src/lib/ageReviewCache.ts
@@ -12,7 +12,9 @@ export interface AgeReviewListParams {
 
 /** Whether `c` belongs in a list fetched with `params` (client-side mirror
  * of the worker's WHERE clause: active = not terminal, closed = terminal,
- * a specific state matches exactly, absent = all; band matches exactly). */
+ * a specific state matches exactly, absent = all; band matches exactly).
+ * Divergence for INVALID filter values only (worker ignores them and returns
+ * all; this excludes) — unreachable from the UI's FilterMode/AGE_BANDS. */
 export function caseBelongsInList(params: AgeReviewListParams, c: AgeReviewCase): boolean {
   if (params.state === 'active' && TERMINAL_STATES.includes(c.state)) return false;
   if (params.state === 'closed' && !TERMINAL_STATES.includes(c.state)) return false;
@@ -34,8 +36,11 @@ export function reconcileCaseIntoList(
   cases: AgeReviewCase[],
   updated: AgeReviewCase,
 ): AgeReviewCase[] {
+  const present = cases.some(c => c.id === updated.id);
   if (!caseBelongsInList(params, updated)) {
-    return cases.filter(c => c.id !== updated.id);
+    // Return the SAME array when nothing changes so callers can skip the
+    // cache write entirely (a no-op setQueryData still churns subscribers)
+    return present ? cases.filter(c => c.id !== updated.id) : cases;
   }
-  return cases.map(c => (c.id === updated.id ? updated : c));
+  return present ? cases.map(c => (c.id === updated.id ? updated : c)) : cases;
 }


### PR DESCRIPTION
Relates to #152 (the report -> age-review hand-off).

## what

the "Handle in Age Review" hand-off resolves `?pubkey=` to the account's active case and opens it. this PR makes every intermediate state of that hand-off honest:

- while the lookup is in flight, the detail pane says "Opening this account's age-review case…" instead of the generic "Select a case to view details" (which moderators read as "nothing happened"; surfaced by the T&S team 2026-07-14; the lookup measures ~0.4s on prod from a fast connection).
- the hand-off's second window is gone entirely: the lookup already returns the full case, so the ?case= normalization seeds the per-case cache instead of paying a second uncached round-trip (during which the pane used to regress to the generic prompt and the mobile sheet bounced closed and open again). caught by adversarial review of the first cut.
- a failed lookup gets its own message ("Couldn't look up this account's case — retry from the report") instead of landing in the no-active-case text, which was a wrong diagnosis for a server error.

## review round: cache coherence across mutations

review caught that the seed created a staleness hole: a terminal action drops the case from the active list, and the detail's fallback served the still-fresh seeded row — actionable controls with the old expected_version. fixed, then an adversarial pass proved the same class survived one key over (the hand-off's lookup cache), where re-entry within its cache lifetime re-seeded the stale active row and clobbered the first fix:

- mutation success writes the PATCH's returned row through to ['age-review-case', id] AND writes the truth to ['age-review-active-case', pubkey] (terminal = no active case); the version-conflict reload invalidates the per-case entry and REMOVES the lookup entry (the seed fires synchronously from cached data, so invalidation alone provably cannot close it).
- two new integration tests drive the real detail component: one-click Clear within the seed staleTime (terminal state renders, no second action), and hand-off re-entry after a terminal action (no resurrected active controls). both verified to fail against the pre-fix code.

## review round 2: the list caches

review round 2 caught the third reader in the same class: selectedCase prefers the list row, and every cached list retained the pre-action row until its refetch landed (or forever on failure), shadowing both previously repaired keys. earlier tests missed it because their mock lists were empty. fixes:

- mutation success reconciles the response row into every cached ['age-review-cases', ...] entry via a pure helper that mirrors the worker's list filters (drop where it no longer belongs, replace in place, leave absent rows for the refetch — absence can't render stale controls). the refetch still supersedes with full server truth.
- the adversarial pass then caught the reconciler's own footgun: writing after invalidating un-invalidates unobserved list caches (setQueryData clears isInvalidated and fresh-stamps), suppressing refetch-on-mount for up to gcTime. the invalidation now runs AFTER the writes, and no-op reconciliations skip the write entirely so untouched entries keep their invalidation state.
- coverage: 8 unit tests on the filter mirror; integration tests with a NONEMPTY active list against a hanging refetch, a failing refetch, and a remount of the same ?pubkey= hand-off; plus the un-invalidation repro (closed-tab within staleTime). every one verified red against the pre-fix code.

## verification

- new AgeReview hand-off render tests (first test harness for this page) pin the sequencing with deferred promises: spinner shows during resolution with no generic-prompt interlude and **zero** second fetches (`getAgeReviewCase` asserted never called); settled-empty shows the explicit no-case message; lookup failure shows the error state; no hand-off shows the generic prompt with no lookup fired.
- `tsc -p tsconfig.app.json` clean, eslint clean, full frontend suite 309 pass, vite build clean.
- visual change: three transient/terminal pane states (spinner, error, unchanged no-case). all use the standard muted empty-state styling matching the siblings; screenshots impractical for sub-second states, and the tests pin the sequencing directly.


