### PR TITLE
fix(reports): resolve deep-link targets to found/gone/unavailable instead of a blank pane

### DIFF
--- a/src/components/DeepLinkFallback.tsx
+++ b/src/components/DeepLinkFallback.tsx
@@ -1,0 +1,68 @@
+// ABOUTME: Right-pane fallback shown when a Reports deep-link target is no
+// ABOUTME: longer retrievable from the relay (gone) or the relay was unreachable.
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import type { ModerationDecision } from '@/lib/adminApi';
+
+const GONE_COPY =
+  "This report's event is no longer on the relay. The reported content was deleted, or the account was removed. The report was recorded when it arrived.";
+const UNAVAILABLE_COPY = "Couldn't reach the relay to look up this report. Try again.";
+
+interface DeepLinkFallbackProps {
+  status: 'gone' | 'unavailable';
+  target: { type: 'event' | 'pubkey'; value: string };
+  decisions: ModerationDecision[];
+  onRetry: () => void;
+}
+
+export function DeepLinkFallback({ status, target, decisions, onRetry }: DeepLinkFallbackProps) {
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle>{status === 'gone' ? 'Report no longer on relay' : 'Relay unavailable'}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          {status === 'gone' ? GONE_COPY : UNAVAILABLE_COPY}
+        </p>
+
+        <div className="text-xs text-muted-foreground">
+          <span className="font-medium">
+            {target.type === 'event' ? 'Reported event' : 'Reported pubkey'}:
+          </span>{' '}
+          <code className="break-all">{target.value}</code>
+        </div>
+
+        {status === 'unavailable' && (
+          <Button variant="outline" size="sm" onClick={onRetry}>
+            Try again
+          </Button>
+        )}
+
+        {status === 'gone' && decisions.length > 0 && (
+          <div className="space-y-1">
+            <p className="text-xs font-medium">Prior moderation actions on this target:</p>
+            <ul className="text-xs text-muted-foreground space-y-2">
+              {decisions.map((d) => (
+                <li key={d.id}>
+                  <code>{d.action}</code>
+                  {d.created_at ? ` — ${d.created_at}` : ''}
+                  {d.moderator_pubkey ? (
+                    <>
+                      {' '}by <code className="break-all">{d.moderator_pubkey}</code>
+                    </>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {status === 'gone' && decisions.length === 0 && (
+          <p className="text-xs text-muted-foreground">
+            No prior moderation actions recorded for this target.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/DeepLinkFallback.tsx
+++ b/src/components/DeepLinkFallback.tsx
@@ -46,7 +46,7 @@ export function DeepLinkFallback({ status, target, decisions, onRetry }: DeepLin
               {decisions.map((d) => (
                 <li key={d.id}>
                   <code>{d.action}</code>
-                  {d.created_at ? ` — ${d.created_at}` : ''}
+                  {d.created_at ? ` · ${d.created_at}` : ''}
                   {d.moderator_pubkey ? (
                     <>
                       {' '}by <code className="break-all">{d.moderator_pubkey}</code>

--- a/src/components/Reports.deeplink.test.tsx
+++ b/src/components/Reports.deeplink.test.tsx
@@ -26,6 +26,19 @@ function ev(id: string, tags: string[][]) {
 const OTHER_REPORT = ev('5'.repeat(64), [['e', OTHER_EVENT]]); // in the bulk list, unrelated target
 const MATCHING_REPORT = ev(MATCHING_ID, [['e', EFOUND]]); // resolves to event:EFOUND
 
+const PWITHNOTE = '7'.repeat(64); // pubkey deep-link whose only reports are note-reports
+const NOTE_REPORT_ID = '8'.repeat(64);
+// A note-report: p-tags the reported author (PWITHNOTE) but also e-tags the note, so
+// getReportTarget resolves it to the *event* target — reportsMatchingTarget would drop it
+// for a ?pubkey= lookup. The relay's #p filter still returns it, so it must resolve 'found'.
+const NOTE_REPORT = ev(NOTE_REPORT_ID, [['e', OTHER_EVENT], ['p', PWITHNOTE]]);
+
+const MULTI_ETAG_ID = '9'.repeat(64);
+// A report whose FIRST e-tag is a different note, so getReportTarget resolves it to
+// event:OTHER_EVENT — reportsMatchingTarget drops it under ?event=EFOUND even though the
+// relay's #e filter matched EFOUND (the second e-tag). Must still resolve 'found'.
+const MULTI_ETAG_REPORT = ev(MULTI_ETAG_ID, [['e', OTHER_EVENT], ['e', EFOUND]]);
+
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
 }
@@ -84,6 +97,34 @@ describe('Reports deep-link resolution', () => {
     // The fix: navigate to /reports/:id, and the redundant setSearchParams({}) that used to
     // clobber it back to /reports is gone — so the resolved URL is bookmarkable.
     await waitFor(() => expect(window.location.pathname).toBe(`/reports/${MATCHING_ID}`));
+    expect(window.location.search).toBe('');
+  });
+
+  it('resolves a ?pubkey= deep-link to found when its only reports are note-reports that p-tag it (relay filter is authoritative, not a false "gone")', async () => {
+    window.history.pushState({}, '', `/reports?pubkey=${PWITHNOTE}`);
+    stubFetch(() => jsonResponse({ success: true, events: [NOTE_REPORT] }));
+
+    render(
+      <TestApp>
+        <Reports relayUrl="wss://relay.example" />
+      </TestApp>
+    );
+
+    await waitFor(() => expect(window.location.pathname).toBe(`/reports/${NOTE_REPORT_ID}`));
+    expect(window.location.search).toBe('');
+  });
+
+  it('resolves a ?event= deep-link to found when the matching report\'s first e-tag is a different note (relay #e filter is authoritative)', async () => {
+    window.history.pushState({}, '', `/reports?event=${EFOUND}`);
+    stubFetch(() => jsonResponse({ success: true, events: [MULTI_ETAG_REPORT] }));
+
+    render(
+      <TestApp>
+        <Reports relayUrl="wss://relay.example" />
+      </TestApp>
+    );
+
+    await waitFor(() => expect(window.location.pathname).toBe(`/reports/${MULTI_ETAG_ID}`));
     expect(window.location.search).toBe('');
   });
 

--- a/src/components/Reports.deeplink.test.tsx
+++ b/src/components/Reports.deeplink.test.tsx
@@ -36,6 +36,10 @@ function ev(id: string, tags: string[][]) {
 const OTHER_REPORT = ev('5'.repeat(64), [['e', OTHER_EVENT]]); // in the bulk list, unrelated target
 const MATCHING_REPORT = ev(MATCHING_ID, [['e', EFOUND]]); // resolves to event:EFOUND
 
+const PBULK = 'd'.repeat(64);
+const BULK_PUBKEY_REPORT_ID = 'e'.repeat(64);
+const BULK_PUBKEY_REPORT = ev(BULK_PUBKEY_REPORT_ID, [['p', PBULK]]);
+
 const PWITHNOTE = '7'.repeat(64); // pubkey deep-link whose only reports are note-reports
 const NOTE_REPORT_ID = '8'.repeat(64);
 // A note-report: p-tags the reported author (PWITHNOTE) but also e-tags the note, so
@@ -113,9 +117,67 @@ describe('Reports deep-link resolution', () => {
     );
 
     // The fix: navigate to /reports/:id, and the redundant setSearchParams({}) that used to
-    // clobber it back to /reports is gone — so the resolved URL is bookmarkable.
+    // clobber it back to /reports is gone, so the query params stay cleared.
     await waitFor(() => expect(window.location.pathname).toBe(`/reports/${MATCHING_ID}`));
     expect(window.location.search).toBe('');
+  });
+
+  it('resolves a bulk-hit target and clears deep-link params without a targeted fetch', async () => {
+    window.history.pushState({}, '', `/reports?event=${OTHER_EVENT}`);
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.includes('/api/reports') && (url.includes('event=') || url.includes('pubkey='))) {
+        throw new Error('bulk hit should not issue targeted lookup');
+      }
+      if (url.includes('/api/reports')) return jsonResponse({ success: true, events: [OTHER_REPORT] });
+      if (url.includes('/api/resolution-labels')) return jsonResponse({ success: true, events: [] });
+      if (url.includes('/api/decisions')) return jsonResponse({ success: true, decisions: [] });
+      if (url.includes('/api/relay-rpc')) return jsonResponse({ success: true, result: [] });
+      return jsonResponse({ success: true });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <TestApp>
+        <Reports relayUrl="wss://relay.example" />
+      </TestApp>
+    );
+
+    await waitFor(() => expect(window.location.pathname).toBe(`/reports/${OTHER_REPORT.id}`));
+    expect(window.location.search).toBe('');
+    expect(fetchMock.mock.calls.some((c) => String(c[0]).includes('event='))).toBe(false);
+  });
+
+  it('keeps a selected bulk-hit deep-link visible when ban data marks it resolved after navigation', async () => {
+    window.history.pushState({}, '', `/reports?pubkey=${PBULK}`);
+    let resolveBannedPubkeys!: (r: Response) => void;
+    const bannedPubkeysPromise = new Promise<Response>((res) => { resolveBannedPubkeys = res; });
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.includes('/api/reports')) return jsonResponse({ success: true, events: [BULK_PUBKEY_REPORT] });
+      if (url.includes('/api/resolution-labels')) return jsonResponse({ success: true, events: [] });
+      if (url.includes('/api/decisions')) return jsonResponse({ success: true, decisions: [] });
+      if (url.includes('/api/relay-rpc')) {
+        const body = typeof init?.body === 'string' ? JSON.parse(init.body) as { method?: string } : {};
+        if (body.method === 'listbannedpubkeys') return bannedPubkeysPromise;
+        return jsonResponse({ success: true, result: [] });
+      }
+      return jsonResponse({ success: true });
+    }));
+
+    render(
+      <TestApp>
+        <Reports relayUrl="wss://relay.example" />
+      </TestApp>
+    );
+
+    await waitFor(() => expect(window.location.pathname).toBe(`/reports/${BULK_PUBKEY_REPORT_ID}`));
+    resolveBannedPubkeys(jsonResponse({ success: true, result: [{ pubkey: PBULK }] }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('switch', { name: /hide resolved/i })).not.toBeChecked()
+    );
+    expect(screen.getByText(/Grouped \(1\)/)).toBeInTheDocument();
   });
 
   it('resolves a ?pubkey= deep-link to found when its only reports are note-reports that p-tag it (relay filter is authoritative, not a false "gone")', async () => {

--- a/src/components/Reports.deeplink.test.tsx
+++ b/src/components/Reports.deeplink.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MockInstance } from 'vitest';
 import TestApp from '@/test/TestApp';
 import { Reports } from './Reports';
+import { useIsMobile } from '@/hooks/useIsMobile';
 
 // Benign detail pane, so a "found" resolution renders instead of crashing (unlike #158's test).
 vi.mock('@/components/ReportDetail', () => ({
@@ -13,6 +14,15 @@ vi.mock('@/components/ReportDetail', () => ({
     <div data-testid="report-detail">{report ? report.id : 'none'}</div>
   ),
 }));
+
+// Default desktop; the mobile-fallback test overrides to true.
+vi.mock('@/hooks/useIsMobile', () => ({ useIsMobile: vi.fn(() => false) }));
+
+// In-test navigation: TestApp uses BrowserRouter, which listens to popstate.
+function navigateTo(url: string) {
+  window.history.pushState({}, '', url);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}
 
 const EFOUND = '1'.repeat(64);
 const MATCHING_ID = '2'.repeat(64);
@@ -39,6 +49,13 @@ const MULTI_ETAG_ID = '9'.repeat(64);
 // relay's #e filter matched EFOUND (the second e-tag). Must still resolve 'found'.
 const MULTI_ETAG_REPORT = ev(MULTI_ETAG_ID, [['e', OTHER_EVENT], ['e', EFOUND]]);
 
+// Same 64-hex value used as BOTH an ?event= and a ?pubkey= target, to prove the
+// resolution guard keys on the full identity (type+value) and doesn't reuse the
+// first attempt for the second.
+const SHARED = 'a'.repeat(64);
+const SHARED_FOUND_ID = 'c'.repeat(64);
+const SHARED_FOUND_REPORT = ev(SHARED_FOUND_ID, [['p', SHARED]]);
+
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
 }
@@ -62,6 +79,7 @@ function stubFetch(targeted: (url: string) => Response) {
 
 beforeEach(() => {
   consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.mocked(useIsMobile).mockReturnValue(false);
 });
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -174,5 +192,61 @@ describe('Reports deep-link resolution', () => {
     await new Promise((r) => setTimeout(r, 0));
 
     expect(window.location.pathname).toBe('/reports'); // unchanged — not /reports/:id
+  });
+
+  it('re-resolves when the same value switches target type (identity guard, not value-only)', async () => {
+    // event=SHARED → gone; pubkey=SHARED → found. The guard must NOT reuse the
+    // event attempt for the pubkey target just because the value matches.
+    stubFetch((url) =>
+      url.includes('pubkey=')
+        ? jsonResponse({ success: true, events: [SHARED_FOUND_REPORT] })
+        : jsonResponse({ success: true, events: [] })
+    );
+
+    window.history.pushState({}, '', `/reports?event=${SHARED}`);
+    render(
+      <TestApp>
+        <Reports relayUrl="wss://relay.example" />
+      </TestApp>
+    );
+    expect(await screen.findByText(/no longer on the relay/i)).toBeInTheDocument();
+
+    navigateTo(`/reports?pubkey=${SHARED}`);
+    // Must re-resolve (not skip on the value-only guard) and land found.
+    await waitFor(() => expect(window.location.pathname).toBe(`/reports/${SHARED_FOUND_ID}`));
+  });
+
+  it('clears a prior selection when a new target resolves gone (fallback, not stale detail)', async () => {
+    stubFetch((url) =>
+      url.includes(`event=${EFOUND}`)
+        ? jsonResponse({ success: true, events: [MATCHING_REPORT] })
+        : jsonResponse({ success: true, events: [] }) // pubkey=PGONE → gone
+    );
+
+    window.history.pushState({}, '', `/reports?event=${EFOUND}`);
+    render(
+      <TestApp>
+        <Reports relayUrl="wss://relay.example" />
+      </TestApp>
+    );
+    await waitFor(() => expect(window.location.pathname).toBe(`/reports/${MATCHING_ID}`));
+
+    navigateTo(`/reports?pubkey=${PGONE}`);
+    // Selection must be cleared so the gone fallback renders, not the stale report.
+    expect(await screen.findByText(/no longer on the relay/i)).toBeInTheDocument();
+  });
+
+  it('shows the gone fallback on mobile (Sheet opens for fallback states, not just selection)', async () => {
+    vi.mocked(useIsMobile).mockReturnValue(true);
+    window.history.pushState({}, '', `/reports?pubkey=${PGONE}`);
+    stubFetch(() => jsonResponse({ success: true, events: [] }));
+
+    render(
+      <TestApp>
+        <Reports relayUrl="wss://relay.example" />
+      </TestApp>
+    );
+    // On mobile the fallback lives inside the Sheet; it must still be visible.
+    expect(await screen.findByText(/no longer on the relay/i)).toBeInTheDocument();
   });
 });

--- a/src/components/Reports.deeplink.test.tsx
+++ b/src/components/Reports.deeplink.test.tsx
@@ -1,0 +1,137 @@
+// ABOUTME: Integration tests for the Reports deep-link resolver — the gone / found (+ the
+// ABOUTME: resulting /reports/:id URL) / unavailable states driven by ?event=/?pubkey= params.
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MockInstance } from 'vitest';
+import TestApp from '@/test/TestApp';
+import { Reports } from './Reports';
+
+// Benign detail pane, so a "found" resolution renders instead of crashing (unlike #158's test).
+vi.mock('@/components/ReportDetail', () => ({
+  ReportDetail: ({ report }: { report: { id: string } | null }) => (
+    <div data-testid="report-detail">{report ? report.id : 'none'}</div>
+  ),
+}));
+
+const EFOUND = '1'.repeat(64);
+const MATCHING_ID = '2'.repeat(64);
+const PGONE = '3'.repeat(64);
+const PUNAVAIL = '4'.repeat(64);
+const OTHER_EVENT = '6'.repeat(64);
+
+function ev(id: string, tags: string[][]) {
+  return { id, pubkey: 'b'.repeat(64), created_at: 1751000000, kind: 1984, tags, content: '', sig: 'e'.repeat(128) };
+}
+const OTHER_REPORT = ev('5'.repeat(64), [['e', OTHER_EVENT]]); // in the bulk list, unrelated target
+const MATCHING_REPORT = ev(MATCHING_ID, [['e', EFOUND]]); // resolves to event:EFOUND
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+let consoleError: MockInstance;
+
+// Bulk /api/reports returns only OTHER_REPORT (so deep-link targets miss the bulk window and
+// fall to the targeted lookup). `targeted` controls the ?event=/?pubkey= response per test.
+function stubFetch(targeted: (url: string) => Response) {
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input instanceof Request ? input.url : input);
+    const isTargeted = url.includes('/api/reports') && (url.includes('event=') || url.includes('pubkey='));
+    if (isTargeted) return targeted(url);
+    if (url.includes('/api/reports')) return jsonResponse({ success: true, events: [OTHER_REPORT] });
+    if (url.includes('/api/resolution-labels')) return jsonResponse({ success: true, events: [] });
+    if (url.includes('/api/decisions')) return jsonResponse({ success: true, decisions: [] });
+    if (url.includes('/api/relay-rpc')) return jsonResponse({ success: true, result: [] });
+    return jsonResponse({ success: true });
+  }));
+}
+
+beforeEach(() => {
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  consoleError.mockRestore();
+  window.history.pushState({}, '', '/');
+});
+
+describe('Reports deep-link resolution', () => {
+  it('shows the "gone" pane when the relay confirms the target has no report', async () => {
+    window.history.pushState({}, '', `/reports?pubkey=${PGONE}`);
+    stubFetch(() => jsonResponse({ success: true, events: [] }));
+
+    render(
+      <TestApp>
+        <Reports relayUrl="wss://relay.example" />
+      </TestApp>
+    );
+
+    expect(await screen.findByText(/no longer on the relay/i)).toBeInTheDocument();
+    expect(screen.getByText(PGONE)).toBeInTheDocument();
+  });
+
+  it('resolves an aged-out target via the targeted fetch and lands on /reports/:id', async () => {
+    window.history.pushState({}, '', `/reports?event=${EFOUND}`);
+    stubFetch(() => jsonResponse({ success: true, events: [MATCHING_REPORT] }));
+
+    render(
+      <TestApp>
+        <Reports relayUrl="wss://relay.example" />
+      </TestApp>
+    );
+
+    // The fix: navigate to /reports/:id, and the redundant setSearchParams({}) that used to
+    // clobber it back to /reports is gone — so the resolved URL is bookmarkable.
+    await waitFor(() => expect(window.location.pathname).toBe(`/reports/${MATCHING_ID}`));
+    expect(window.location.search).toBe('');
+  });
+
+  it('shows the "unavailable" pane (with retry) when the targeted lookup errors', async () => {
+    window.history.pushState({}, '', `/reports?pubkey=${PUNAVAIL}`);
+    stubFetch(() => jsonResponse({ success: false, error: 'boom' }, 502));
+
+    render(
+      <TestApp>
+        <Reports relayUrl="wss://relay.example" />
+      </TestApp>
+    );
+
+    expect(await screen.findByText(/couldn't reach the relay/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it('does not navigate after unmount while a targeted lookup is in flight', async () => {
+    window.history.pushState({}, '', `/reports?event=${EFOUND}`);
+    let resolveTargeted!: (r: Response) => void;
+    const targetedPromise = new Promise<Response>((res) => { resolveTargeted = res; });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.includes('/api/reports') && url.includes('event=')) return targetedPromise;
+      if (url.includes('/api/reports')) return jsonResponse({ success: true, events: [OTHER_REPORT] });
+      if (url.includes('/api/resolution-labels')) return jsonResponse({ success: true, events: [] });
+      if (url.includes('/api/decisions')) return jsonResponse({ success: true, decisions: [] });
+      if (url.includes('/api/relay-rpc')) return jsonResponse({ success: true, result: [] });
+      return jsonResponse({ success: true });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { unmount } = render(
+      <TestApp>
+        <Reports relayUrl="wss://relay.example" />
+      </TestApp>
+    );
+
+    // Wait until the targeted lookup has actually been issued, then unmount before it resolves.
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some((c) => String(c[0]).includes('event='))).toBe(true)
+    );
+    unmount();
+
+    // The lookup resolves after unmount; the fix must drop it (no late navigate()).
+    resolveTargeted(jsonResponse({ success: true, events: [MATCHING_REPORT] }));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(window.location.pathname).toBe('/reports'); // unchanged — not /reports/:id
+  });
+});

--- a/src/components/Reports.deeplink.test.tsx
+++ b/src/components/Reports.deeplink.test.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Integration tests for the Reports deep-link resolver — the gone / found (+ the
 // ABOUTME: resulting /reports/:id URL) / unavailable states driven by ?event=/?pubkey= params.
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MockInstance } from 'vitest';
 import TestApp from '@/test/TestApp';
@@ -310,5 +310,41 @@ describe('Reports deep-link resolution', () => {
     );
     // On mobile the fallback lives inside the Sheet; it must still be visible.
     expect(await screen.findByText(/no longer on the relay/i)).toBeInTheDocument();
+  });
+
+  it('drops a late lookup after the mobile resolving Sheet is closed mid-flight (no reopen)', async () => {
+    vi.mocked(useIsMobile).mockReturnValue(true);
+    window.history.pushState({}, '', `/reports?event=${EFOUND}`);
+    let resolveTargeted!: (r: Response) => void;
+    const targetedPromise = new Promise<Response>((res) => { resolveTargeted = res; });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.includes('/api/reports') && url.includes('event=')) return targetedPromise;
+      if (url.includes('/api/reports')) return jsonResponse({ success: true, events: [OTHER_REPORT] });
+      if (url.includes('/api/resolution-labels')) return jsonResponse({ success: true, events: [] });
+      if (url.includes('/api/decisions')) return jsonResponse({ success: true, decisions: [] });
+      if (url.includes('/api/relay-rpc')) return jsonResponse({ success: true, result: [] });
+      return jsonResponse({ success: true });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <TestApp>
+        <Reports relayUrl="wss://relay.example" />
+      </TestApp>
+    );
+
+    // The mobile resolving Sheet is up while the targeted lookup is pending.
+    expect(await screen.findByText(/looking up this report/i)).toBeInTheDocument();
+
+    // Close the Sheet mid-lookup.
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+
+    // The late response resolves as a would-be 'found' — it must be dropped, not
+    // reopen the report after the moderator returned to the queue.
+    resolveTargeted(jsonResponse({ success: true, events: [MATCHING_REPORT] }));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(window.location.pathname).toBe('/reports'); // no reopen
   });
 });

--- a/src/components/Reports.tsx
+++ b/src/components/Reports.tsx
@@ -859,6 +859,10 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
     detailBoundaryRef.current?.reset();
     setSelectedReport(report);
     setDeepLinkStatus('idle'); // clear any deep-link fallback once the user interacts
+    // Invalidate any in-flight targeted lookup: a user selection/dismissal
+    // supersedes the deep link, so a late response must not pass the resolution
+    // guard and re-navigate (e.g. closing the mobile resolving Sheet mid-lookup).
+    attemptedTargetRef.current = null;
     if (report) {
       navigate(`/reports/${report.id}`, { replace: true });
     } else {

--- a/src/components/Reports.tsx
+++ b/src/components/Reports.tsx
@@ -45,7 +45,7 @@ import { ReportDetail } from "@/components/ReportDetail";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { ReportDetailErrorFallback } from "@/components/ReportDetailErrorFallback";
 import { DeepLinkFallback } from "@/components/DeepLinkFallback";
-import { classifyTargetedFetch, decisionsForTarget, type DeepLinkStatus } from "@/lib/deepLinkResolution";
+import { classifyTargetedFetch, decisionsForTarget, reportsMatchingTarget, type DeepLinkStatus } from "@/lib/deepLinkResolution";
 import { useAdminApi } from "@/hooks/useAdminApi";
 import { AUTO_HIDE_ACTIONS, CATEGORY_LABELS, HIGH_PRIORITY_CATEGORIES, getReportCategory } from "@/lib/constants";
 import { useIsMobile } from "@/hooks/useIsMobile";
@@ -781,17 +781,20 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
         const events = await fetchReportsByTarget(
           target.type === 'event' ? { event: target.value } : { pubkey: target.value }
         );
-        const verdict = classifyTargetedFetch({ ok: true, events });
+        // Match by resolved target (same rule as the bulk list) so a report that only
+        // p-tags the pubkey but resolves to an event target isn't a false 'found'.
+        const matching = reportsMatchingTarget(events, target, getReportTarget);
+        const verdict = classifyTargetedFetch({ ok: true, events: matching });
         if (verdict === 'found') {
           // Merge into the reports cache so the detail pane has full context,
           queryClient.setQueryData<NostrEvent[]>(['reports', relayUrl], (old) => {
             const merged = [...(old ?? [])];
-            for (const e of events) if (!merged.some(m => m.id === e.id)) merged.push(e);
+            for (const e of matching) if (!merged.some(m => m.id === e.id)) merged.push(e);
             return merged;
           });
           // and select the newest fetched report directly — not via a re-run, so a
           // consolidation mismatch can neither loop nor hang the pane on 'resolving'.
-          const latest = events.reduce((a, b) => (b.created_at > a.created_at ? b : a));
+          const latest = matching.reduce((a, b) => (b.created_at > a.created_at ? b : a));
           setSelectedReport(latest);
           setDeepLinkStatus('found');
           navigate(`/reports/${latest.id}`, { replace: true });

--- a/src/components/Reports.tsx
+++ b/src/components/Reports.tsx
@@ -784,9 +784,16 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
     }
 
     // Bulk list is loaded and the target isn't in it. Do one targeted relay fetch
-    // per target to tell "aged out / vanished" apart from "still loading".
-    if (attemptedTargetRef.current === target.value) return;
-    attemptedTargetRef.current = target.value;
+    // per target to tell "aged out / vanished" apart from "still loading". Key the
+    // attempt on the full target identity (relay + type + value) so a same-value
+    // target across type, or a relay/environment switch, re-resolves instead of
+    // reusing the prior attempt or its stale result.
+    const targetKey = `${relayUrl}|${target.type}|${target.value}`;
+    if (attemptedTargetRef.current === targetKey) return;
+    attemptedTargetRef.current = targetKey;
+    // Drop any prior selection so the resolving / gone / unavailable panes (which
+    // gate on !selectedReport) render for this new target rather than stale detail.
+    setSelectedReport(null);
     setDeepLinkStatus('resolving');
 
     (async () => {
@@ -797,8 +804,8 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
         // Drop the result if this run was superseded (target changed) or the component
         // unmounted while the fetch was in flight — otherwise a late navigate() would yank
         // the moderator back to this report. (A benign same-target re-run keeps
-        // attemptedTargetRef === target.value, so this correctly still applies.)
-        if (!mountedRef.current || attemptedTargetRef.current !== target.value) return;
+        // attemptedTargetRef === targetKey, so this correctly still applies.)
+        if (!mountedRef.current || attemptedTargetRef.current !== targetKey) return;
         // The relay's own #e/#p filter is authoritative for existence: every returned
         // report tags the deep-link target. Gate found/gone on the raw result, not on
         // reportsMatchingTarget — re-filtering by resolved target made a note-report that
@@ -827,7 +834,7 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
           setDeepLinkStatus(verdict); // 'gone' — relay-confirmed empty (timeout is a 502 → catch)
         }
       } catch {
-        if (!mountedRef.current || attemptedTargetRef.current !== target.value) return;
+        if (!mountedRef.current || attemptedTargetRef.current !== targetKey) return;
         setDeepLinkStatus('unavailable');
       }
     })();
@@ -1172,7 +1179,10 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
 
       {/* Mobile Sheet - Report Detail */}
       {isMobile && (
-        <Sheet open={!!selectedReport} onOpenChange={(open) => !open && handleSelectReport(null)}>
+        <Sheet
+          open={!!selectedReport || showDeepLinkResolving || showDeepLinkFallback}
+          onOpenChange={(open) => !open && handleSelectReport(null)}
+        >
           <SheetContent side="right" className="!w-full !max-w-[100vw] pt-10 px-0 pb-0 overflow-y-auto">
             {reportDetailPane}
           </SheetContent>

--- a/src/components/Reports.tsx
+++ b/src/components/Reports.tsx
@@ -399,7 +399,7 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
 
   // Query banned pubkeys from relay (NIP-86 RPC)
   // Force fresh fetch (staleTime: 0) when deep linking to ensure accurate ban status
-  const { data: bannedPubkeys, isFetching: isFetchingBanned } = useQuery({
+  const { data: bannedPubkeys } = useQuery({
     queryKey: ['banned-pubkeys'],
     queryFn: async () => {
       try {
@@ -739,8 +739,11 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
       }
     }
 
-    // Still loading the bulk list (or fresh ban data) — resolving, don't conclude yet.
-    if (isLoading || isFetchingBanned) {
+    // Still loading the bulk list — resolving, don't conclude yet. We intentionally
+    // do NOT gate on isFetchingBanned: ban data affects how a report is displayed,
+    // not whether it exists, and gating on it flips a resolved pane back to
+    // 'resolving' (and re-fires the lookup) on every background ban refetch.
+    if (isLoading) {
       setDeepLinkStatus('resolving');
       return;
     }
@@ -806,7 +809,7 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
         setDeepLinkStatus('unavailable');
       }
     })();
-  }, [allConsolidated, searchParams, hideResolved, resolvedTargets, navigate, setSearchParams, isLoading, isFetchingBanned, config.relayUrl, config.apiUrl, updateConfig, queryClient, fetchReportsByTarget, relayUrl, retryNonce]);
+  }, [allConsolidated, searchParams, hideResolved, resolvedTargets, navigate, setSearchParams, isLoading, config.relayUrl, config.apiUrl, updateConfig, queryClient, fetchReportsByTarget, relayUrl, retryNonce]);
 
   // Update URL when report selection changes
   const handleSelectReport = (report: NostrEvent | null) => {

--- a/src/components/Reports.tsx
+++ b/src/components/Reports.tsx
@@ -724,6 +724,17 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
     }
   }, [selectedReportId, reports, selectedReport]);
 
+  // A deep link can select a report before ban/label/decision queries finish.
+  // Re-check the selected target as resolution data arrives so it cannot stay
+  // hidden from the list while its detail pane is open.
+  useEffect(() => {
+    if (!hideResolved || !selectedReport) return;
+    const target = getReportTarget(selectedReport);
+    if (target && resolvedTargets.has(`${target.type}:${target.value}`)) {
+      setHideResolved(false);
+    }
+  }, [hideResolved, selectedReport, resolvedTargets]);
+
   // Handle deep linking via query params (?event=... or ?pubkey=... or &env=...)
   useEffect(() => {
     const eventParam = searchParams.get('event');
@@ -813,7 +824,7 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
         // result here is a relay-confirmed absence; an empty *timeout* never reaches this
         // branch (the worker 502s it → the catch below → 'unavailable').
         const matching = reportsMatchingTarget(events, target, getReportTarget);
-        const verdict = classifyTargetedFetch({ ok: true, events });
+        const verdict = classifyTargetedFetch(events);
         if (verdict === 'found') {
           // Prefer a report whose resolved target IS the deep-link target for display;
           // fall back to any returned report (all of them tag the target).

--- a/src/components/Reports.tsx
+++ b/src/components/Reports.tsx
@@ -357,7 +357,7 @@ function IndividualReportItem({
 
 export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const { listBannedPubkeys, listBannedEvents, getAllDecisions, fetchReports, fetchReportsByTarget, fetchResolutionLabels } = useAdminApi();
   const { config, updateConfig } = useAppContext();
   const queryClient = useQueryClient();
@@ -377,6 +377,14 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
   const [deepLinkStatus, setDeepLinkStatus] = useState<DeepLinkStatus>('idle');
   const attemptedTargetRef = useRef<string | null>(null); // one targeted fetch per target
   const [retryNonce, setRetryNonce] = useState(0); // forces the deep-link effect to re-run on retry
+  // Tracks mount state so an in-flight targeted lookup that resolves after the component
+  // unmounts (e.g. the moderator switched tabs) can't fire a late navigate() and yank them back.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    // Set on mount (not only cleared on unmount) so a StrictMode remount restores it.
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
 
   // Reports and resolution labels fetched via server-side relay query through
   // the worker. Replaces browser-side WebSocket (nostrify NPool) which served
@@ -767,8 +775,10 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
       }
       setSelectedReport(inBulk.latestReport);
       setDeepLinkStatus('found');
+      // Navigating to the path (no query string) already clears the deep-link params;
+      // a separate setSearchParams({}) here would run against the stale pre-navigate path
+      // and clobber this back to /reports.
       navigate(`/reports/${inBulk.latestReport.id}`, { replace: true });
-      setSearchParams({}, { replace: true });
       attemptedTargetRef.current = null;
       return;
     }
@@ -784,6 +794,11 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
         const events = await fetchReportsByTarget(
           target.type === 'event' ? { event: target.value } : { pubkey: target.value }
         );
+        // Drop the result if this run was superseded (target changed) or the component
+        // unmounted while the fetch was in flight — otherwise a late navigate() would yank
+        // the moderator back to this report. (A benign same-target re-run keeps
+        // attemptedTargetRef === target.value, so this correctly still applies.)
+        if (!mountedRef.current || attemptedTargetRef.current !== target.value) return;
         // Match by resolved target (same rule as the bulk list) so a report that only
         // p-tags the pubkey but resolves to an event target isn't a false 'found'.
         const matching = reportsMatchingTarget(events, target, getReportTarget);
@@ -801,15 +816,15 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
           setSelectedReport(latest);
           setDeepLinkStatus('found');
           navigate(`/reports/${latest.id}`, { replace: true });
-          setSearchParams({}, { replace: true });
         } else {
           setDeepLinkStatus(verdict); // 'gone'
         }
       } catch {
+        if (!mountedRef.current || attemptedTargetRef.current !== target.value) return;
         setDeepLinkStatus('unavailable');
       }
     })();
-  }, [allConsolidated, searchParams, hideResolved, resolvedTargets, navigate, setSearchParams, isLoading, config.relayUrl, config.apiUrl, updateConfig, queryClient, fetchReportsByTarget, relayUrl, retryNonce]);
+  }, [allConsolidated, searchParams, hideResolved, resolvedTargets, navigate, isLoading, config.relayUrl, config.apiUrl, updateConfig, queryClient, fetchReportsByTarget, relayUrl, retryNonce]);
 
   // Update URL when report selection changes
   const handleSelectReport = (report: NostrEvent | null) => {

--- a/src/components/Reports.tsx
+++ b/src/components/Reports.tsx
@@ -799,25 +799,32 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
         // the moderator back to this report. (A benign same-target re-run keeps
         // attemptedTargetRef === target.value, so this correctly still applies.)
         if (!mountedRef.current || attemptedTargetRef.current !== target.value) return;
-        // Match by resolved target (same rule as the bulk list) so a report that only
-        // p-tags the pubkey but resolves to an event target isn't a false 'found'.
+        // The relay's own #e/#p filter is authoritative for existence: every returned
+        // report tags the deep-link target. Gate found/gone on the raw result, not on
+        // reportsMatchingTarget — re-filtering by resolved target made a note-report that
+        // p-tags a ?pubkey= target (but resolves to an event) a false 'gone'. An empty
+        // result here is a relay-confirmed absence; an empty *timeout* never reaches this
+        // branch (the worker 502s it → the catch below → 'unavailable').
         const matching = reportsMatchingTarget(events, target, getReportTarget);
-        const verdict = classifyTargetedFetch({ ok: true, events: matching });
+        const verdict = classifyTargetedFetch({ ok: true, events });
         if (verdict === 'found') {
+          // Prefer a report whose resolved target IS the deep-link target for display;
+          // fall back to any returned report (all of them tag the target).
+          const pool = matching.length > 0 ? matching : events;
           // Merge into the reports cache so the detail pane has full context,
           queryClient.setQueryData<NostrEvent[]>(['reports', relayUrl], (old) => {
             const merged = [...(old ?? [])];
-            for (const e of matching) if (!merged.some(m => m.id === e.id)) merged.push(e);
+            for (const e of pool) if (!merged.some(m => m.id === e.id)) merged.push(e);
             return merged;
           });
-          // and select the newest fetched report directly — not via a re-run, so a
+          // and select the newest report directly — not via a re-run, so a
           // consolidation mismatch can neither loop nor hang the pane on 'resolving'.
-          const latest = matching.reduce((a, b) => (b.created_at > a.created_at ? b : a));
+          const latest = pool.reduce((a, b) => (b.created_at > a.created_at ? b : a));
           setSelectedReport(latest);
           setDeepLinkStatus('found');
           navigate(`/reports/${latest.id}`, { replace: true });
         } else {
-          setDeepLinkStatus(verdict); // 'gone'
+          setDeepLinkStatus(verdict); // 'gone' — relay-confirmed empty (timeout is a 502 → catch)
         }
       } catch {
         if (!mountedRef.current || attemptedTargetRef.current !== target.value) return;
@@ -884,7 +891,7 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
     ? { type: 'event' as const, value: searchParams.get('event')! }
     : { type: 'pubkey' as const, value: searchParams.get('pubkey') ?? '' };
   const showDeepLinkFallback =
-    !selectedReport && (deepLinkStatus === 'gone' || deepLinkStatus === 'unavailable');
+    !selectedReport && hasDeepLinkParams && (deepLinkStatus === 'gone' || deepLinkStatus === 'unavailable');
   const showDeepLinkResolving =
     !selectedReport && deepLinkStatus === 'resolving' && hasDeepLinkParams;
 

--- a/src/components/Reports.tsx
+++ b/src/components/Reports.tsx
@@ -887,9 +887,12 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
   // the two views cannot drift. Reports render attacker-authored event data:
   // a crashing report degrades to the inline fallback (with the target's
   // identifiers and retry/dismiss) while the reports list stays usable (#158).
+  // Lowercase to match the worker's reports filter (buildReportsFilter also
+  // lowercases), so decisionsForTarget below keys off the same normalized hex
+  // an uppercase-hex deep link would otherwise miss lowercase-keyed decisions.
   const deepLinkTarget = searchParams.get('event')
-    ? { type: 'event' as const, value: searchParams.get('event')! }
-    : { type: 'pubkey' as const, value: searchParams.get('pubkey') ?? '' };
+    ? { type: 'event' as const, value: searchParams.get('event')!.toLowerCase() }
+    : { type: 'pubkey' as const, value: (searchParams.get('pubkey') ?? '').toLowerCase() };
   const showDeepLinkFallback =
     !selectedReport && hasDeepLinkParams && (deepLinkStatus === 'gone' || deepLinkStatus === 'unavailable');
   const showDeepLinkResolving =

--- a/src/components/Reports.tsx
+++ b/src/components/Reports.tsx
@@ -44,6 +44,8 @@ import { nip19 } from "nostr-tools";
 import { ReportDetail } from "@/components/ReportDetail";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { ReportDetailErrorFallback } from "@/components/ReportDetailErrorFallback";
+import { DeepLinkFallback } from "@/components/DeepLinkFallback";
+import { classifyTargetedFetch, decisionsForTarget, type DeepLinkStatus } from "@/lib/deepLinkResolution";
 import { useAdminApi } from "@/hooks/useAdminApi";
 import { AUTO_HIDE_ACTIONS, CATEGORY_LABELS, HIGH_PRIORITY_CATEGORIES, getReportCategory } from "@/lib/constants";
 import { useIsMobile } from "@/hooks/useIsMobile";
@@ -356,7 +358,7 @@ function IndividualReportItem({
 export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { listBannedPubkeys, listBannedEvents, getAllDecisions, fetchReports, fetchResolutionLabels } = useAdminApi();
+  const { listBannedPubkeys, listBannedEvents, getAllDecisions, fetchReports, fetchReportsByTarget, fetchResolutionLabels } = useAdminApi();
   const { config, updateConfig } = useAppContext();
   const queryClient = useQueryClient();
   const isMobile = useIsMobile();
@@ -370,6 +372,11 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
   const [filterTargetType, setFilterTargetType] = useState<'all' | 'event' | 'pubkey'>('all');
   // Check for deep link params to force fresh data fetch
   const hasDeepLinkParams = !!(searchParams.get('event') || searchParams.get('pubkey'));
+  // Deep-link resolution: 'resolving' while we look a target up, 'gone' when the
+  // relay confirms the report is absent, 'unavailable' when the relay itself failed.
+  const [deepLinkStatus, setDeepLinkStatus] = useState<DeepLinkStatus>('idle');
+  const attemptedTargetRef = useRef<string | null>(null); // one targeted fetch per target
+  const [retryNonce, setRetryNonce] = useState(0); // forces the deep-link effect to re-run on retry
 
   // Reports and resolution labels fetched via server-side relay query through
   // the worker. Replaces browser-side WebSocket (nostrify NPool) which served
@@ -732,39 +739,71 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
       }
     }
 
-    if (!allConsolidated || allConsolidated.length === 0) return;
-
-    // Wait for fresh ban data before processing deep link
-    if (isFetchingBanned) return;
-
-    let targetReport: ConsolidatedReport | undefined;
-
-    if (eventParam) {
-      targetReport = allConsolidated.find(c =>
-        c.target.type === 'event' && c.target.value === eventParam
-      );
-    } else if (pubkeyParam) {
-      targetReport = allConsolidated.find(c =>
-        c.target.type === 'pubkey' && c.target.value === pubkeyParam
-      );
+    // Still loading the bulk list (or fresh ban data) — resolving, don't conclude yet.
+    if (isLoading || isFetchingBanned) {
+      setDeepLinkStatus('resolving');
+      return;
     }
 
-    if (targetReport) {
+    const target: { type: 'event' | 'pubkey'; value: string } | null = eventParam
+      ? { type: 'event', value: eventParam }
+      : pubkeyParam
+      ? { type: 'pubkey', value: pubkeyParam }
+      : null;
+    if (!target) return;
+
+    const inBulk = allConsolidated.find(
+      c => c.target.type === target.type && c.target.value === target.value
+    );
+
+    if (inBulk) {
       // If target is resolved and we're hiding resolved, temporarily show it
-      const targetKey = `${targetReport.target.type}:${targetReport.target.value}`;
+      const targetKey = `${inBulk.target.type}:${inBulk.target.value}`;
       if (hideResolved && resolvedTargets.has(targetKey)) {
         setHideResolved(false);
       }
-
-      // Select the report
-      setSelectedReport(targetReport.latestReport);
-      navigate(`/reports/${targetReport.latestReport.id}`, { replace: true });
-
-      // Clear params from URL now that we've navigated
+      setSelectedReport(inBulk.latestReport);
+      setDeepLinkStatus('found');
+      navigate(`/reports/${inBulk.latestReport.id}`, { replace: true });
       setSearchParams({}, { replace: true });
+      attemptedTargetRef.current = null;
+      return;
     }
-    // If report not found, keep params — effect will re-run when more data loads
-  }, [allConsolidated, searchParams, hideResolved, resolvedTargets, navigate, setSearchParams, isFetchingBanned, config.relayUrl, config.apiUrl, updateConfig, queryClient]);
+
+    // Bulk list is loaded and the target isn't in it. Do one targeted relay fetch
+    // per target to tell "aged out / vanished" apart from "still loading".
+    if (attemptedTargetRef.current === target.value) return;
+    attemptedTargetRef.current = target.value;
+    setDeepLinkStatus('resolving');
+
+    (async () => {
+      try {
+        const events = await fetchReportsByTarget(
+          target.type === 'event' ? { event: target.value } : { pubkey: target.value }
+        );
+        const verdict = classifyTargetedFetch({ ok: true, events });
+        if (verdict === 'found') {
+          // Merge into the reports cache so the detail pane has full context,
+          queryClient.setQueryData<NostrEvent[]>(['reports', relayUrl], (old) => {
+            const merged = [...(old ?? [])];
+            for (const e of events) if (!merged.some(m => m.id === e.id)) merged.push(e);
+            return merged;
+          });
+          // and select the newest fetched report directly — not via a re-run, so a
+          // consolidation mismatch can neither loop nor hang the pane on 'resolving'.
+          const latest = events.reduce((a, b) => (b.created_at > a.created_at ? b : a));
+          setSelectedReport(latest);
+          setDeepLinkStatus('found');
+          navigate(`/reports/${latest.id}`, { replace: true });
+          setSearchParams({}, { replace: true });
+        } else {
+          setDeepLinkStatus(verdict); // 'gone'
+        }
+      } catch {
+        setDeepLinkStatus('unavailable');
+      }
+    })();
+  }, [allConsolidated, searchParams, hideResolved, resolvedTargets, navigate, setSearchParams, isLoading, isFetchingBanned, config.relayUrl, config.apiUrl, updateConfig, queryClient, fetchReportsByTarget, relayUrl, retryNonce]);
 
   // Update URL when report selection changes
   const handleSelectReport = (report: NostrEvent | null) => {
@@ -773,6 +812,7 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
     // boundary explicitly (no-op when the pane is healthy).
     detailBoundaryRef.current?.reset();
     setSelectedReport(report);
+    setDeepLinkStatus('idle'); // clear any deep-link fallback once the user interacts
     if (report) {
       navigate(`/reports/${report.id}`, { replace: true });
     } else {
@@ -819,7 +859,31 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
   // the two views cannot drift. Reports render attacker-authored event data:
   // a crashing report degrades to the inline fallback (with the target's
   // identifiers and retry/dismiss) while the reports list stays usable (#158).
-  const reportDetailPane = (
+  const deepLinkTarget = searchParams.get('event')
+    ? { type: 'event' as const, value: searchParams.get('event')! }
+    : { type: 'pubkey' as const, value: searchParams.get('pubkey') ?? '' };
+  const showDeepLinkFallback =
+    !selectedReport && (deepLinkStatus === 'gone' || deepLinkStatus === 'unavailable');
+  const showDeepLinkResolving =
+    !selectedReport && deepLinkStatus === 'resolving' && hasDeepLinkParams;
+
+  const reportDetailPane = showDeepLinkFallback ? (
+    <DeepLinkFallback
+      status={deepLinkStatus === 'gone' ? 'gone' : 'unavailable'}
+      target={deepLinkTarget}
+      decisions={decisionsForTarget(allDecisions, deepLinkTarget.value)}
+      onRetry={() => {
+        attemptedTargetRef.current = null;
+        setDeepLinkStatus('resolving');
+        setRetryNonce(n => n + 1);
+        refetch();
+      }}
+    />
+  ) : showDeepLinkResolving ? (
+    <Card className="h-full">
+      <CardContent className="p-6 text-sm text-muted-foreground">Looking up this report…</CardContent>
+    </Card>
+  ) : (
     <ErrorBoundary
       ref={detailBoundaryRef}
       resetKeys={[selectedReport?.id]}

--- a/src/hooks/useAdminApi.ts
+++ b/src/hooks/useAdminApi.ts
@@ -65,6 +65,8 @@ export function useAdminApi() {
     // Server-side relay queries (replaces browser WebSocket for freshness)
     fetchReports: () =>
       adminApi.fetchReports(apiUrl),
+    fetchReportsByTarget: (target: { event: string } | { pubkey: string }) =>
+      adminApi.fetchReportsByTarget(apiUrl, target),
     fetchResolutionLabels: () =>
       adminApi.fetchResolutionLabels(apiUrl),
 

--- a/src/lib/adminApi.test.ts
+++ b/src/lib/adminApi.test.ts
@@ -18,6 +18,7 @@ import {
   listBannedPubkeys,
   listBannedEvents,
   fetchReports,
+  fetchReportsByTarget,
   fetchResolutionLabels,
   publishLabel,
   publishLabelAndBan,
@@ -1175,6 +1176,32 @@ describe('adminApi', () => {
       const hashes = extractMediaHashes(content, tags);
 
       expect(hashes).toEqual([]);
+    });
+  });
+
+  describe('fetchReportsByTarget', () => {
+    it('requests /api/reports?event= and returns sanitized events', async () => {
+      const events = [{ id: 'r1', kind: 1984, pubkey: 'pk', created_at: 1, tags: [], content: '', sig: '' }];
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ success: true, events }) });
+
+      const result = await fetchReportsByTarget(API_URL, { event: 'abc' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/reports?event=abc'),
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(result.map((e) => e.id)).toEqual(['r1']);
+    });
+
+    it('requests /api/reports?pubkey= when given a pubkey target', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ success: true, events: [] }) });
+
+      await fetchReportsByTarget(API_URL, { pubkey: 'def' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/reports?pubkey=def'),
+        expect.objectContaining({ method: 'GET' })
+      );
     });
   });
 

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -380,6 +380,24 @@ export async function fetchReports(apiUrl: string): Promise<NostrEvent[]> {
   return sanitizeRelayEvents(data.events).sort((a, b) => b.created_at - a.created_at);
 }
 
+// Fetch reports scoped to a single target (reported event id or pubkey) via the
+// worker's /api/reports filter. Used to resolve a deep-link whose target isn't in
+// the bulk window, so we can tell "aged out / vanished" apart from "still loading".
+export async function fetchReportsByTarget(
+  apiUrl: string,
+  target: { event: string } | { pubkey: string }
+): Promise<NostrEvent[]> {
+  const qs = 'event' in target
+    ? `?event=${encodeURIComponent(target.event)}`
+    : `?pubkey=${encodeURIComponent(target.pubkey)}`;
+  const data = await apiRequest<{ success: boolean; events: NostrEvent[] }>(
+    apiUrl,
+    `/api/reports${qs}`,
+    'GET'
+  );
+  return sanitizeRelayEvents(data.events);
+}
+
 // Fetch resolution labels via server-side relay query (replaces browser WebSocket)
 export async function fetchResolutionLabels(apiUrl: string): Promise<NostrEvent[]> {
   const data = await apiRequest<{ success: boolean; events: NostrEvent[] }>(apiUrl, '/api/resolution-labels', 'GET');

--- a/src/lib/deepLinkResolution.test.ts
+++ b/src/lib/deepLinkResolution.test.ts
@@ -16,14 +16,17 @@ describe('classifyTargetedFetch', () => {
 describe('decisionsForTarget', () => {
   const decisions = [
     { target_id: 'PK', action: 'banned' },
-    { target_id: 'user_PK', action: 'age_review_case_created' },
+    { target_id: 'PK', action: 'age_review_case_created' }, // written with the bare pubkey
     { target_id: 'OTHER', action: 'deleted' },
   ];
-  it('matches both raw and user_-prefixed target ids', () => {
+  it('matches every decision recorded against the bare target id', () => {
     expect(decisionsForTarget(decisions, 'PK').map((d) => d.action)).toEqual([
       'banned',
       'age_review_case_created',
     ]);
+  });
+  it('does not match a different target id', () => {
+    expect(decisionsForTarget(decisions, 'PK').some((d) => d.target_id === 'OTHER')).toBe(false);
   });
   it('returns [] for undefined input', () => {
     expect(decisionsForTarget(undefined, 'PK')).toEqual([]);

--- a/src/lib/deepLinkResolution.test.ts
+++ b/src/lib/deepLinkResolution.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { classifyTargetedFetch, decisionsForTarget } from './deepLinkResolution';
+import { classifyTargetedFetch, decisionsForTarget, reportsMatchingTarget } from './deepLinkResolution';
 
 describe('classifyTargetedFetch', () => {
   it('unavailable when the fetch failed', () => {
@@ -27,5 +27,25 @@ describe('decisionsForTarget', () => {
   });
   it('returns [] for undefined input', () => {
     expect(decisionsForTarget(undefined, 'PK')).toEqual([]);
+  });
+});
+
+describe('reportsMatchingTarget', () => {
+  type E = { id: string; t: { type: string; value: string } | null };
+  const getTarget = (e: E) => e.t;
+  const events: E[] = [
+    { id: 'a', t: { type: 'event', value: 'E1' } },
+    { id: 'b', t: { type: 'pubkey', value: 'P1' } },
+    { id: 'c', t: null },
+    { id: 'd', t: { type: 'pubkey', value: 'P1' } },
+  ];
+  it('keeps only events whose resolved target matches type and value', () => {
+    expect(reportsMatchingTarget(events, { type: 'pubkey', value: 'P1' }, getTarget).map((e) => e.id)).toEqual([
+      'b',
+      'd',
+    ]);
+  });
+  it('drops events whose resolved target is null or differs (event-typed report does not satisfy a pubkey target)', () => {
+    expect(reportsMatchingTarget(events, { type: 'event', value: 'E1' }, getTarget).map((e) => e.id)).toEqual(['a']);
   });
 });

--- a/src/lib/deepLinkResolution.test.ts
+++ b/src/lib/deepLinkResolution.test.ts
@@ -2,14 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { classifyTargetedFetch, decisionsForTarget, reportsMatchingTarget } from './deepLinkResolution';
 
 describe('classifyTargetedFetch', () => {
-  it('unavailable when the fetch failed', () => {
-    expect(classifyTargetedFetch({ ok: false })).toBe('unavailable');
+  it('gone when the successful fetch returned nothing', () => {
+    expect(classifyTargetedFetch([])).toBe('gone');
   });
-  it('gone when the fetch succeeded but returned nothing', () => {
-    expect(classifyTargetedFetch({ ok: true, events: [] })).toBe('gone');
-  });
-  it('found when the fetch returned at least one report', () => {
-    expect(classifyTargetedFetch({ ok: true, events: [{}] })).toBe('found');
+  it('found when the successful fetch returned at least one report', () => {
+    expect(classifyTargetedFetch([{}])).toBe('found');
   });
 });
 

--- a/src/lib/deepLinkResolution.test.ts
+++ b/src/lib/deepLinkResolution.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { classifyTargetedFetch, decisionsForTarget } from './deepLinkResolution';
+
+describe('classifyTargetedFetch', () => {
+  it('unavailable when the fetch failed', () => {
+    expect(classifyTargetedFetch({ ok: false })).toBe('unavailable');
+  });
+  it('gone when the fetch succeeded but returned nothing', () => {
+    expect(classifyTargetedFetch({ ok: true, events: [] })).toBe('gone');
+  });
+  it('found when the fetch returned at least one report', () => {
+    expect(classifyTargetedFetch({ ok: true, events: [{}] })).toBe('found');
+  });
+});
+
+describe('decisionsForTarget', () => {
+  const decisions = [
+    { target_id: 'PK', action: 'banned' },
+    { target_id: 'user_PK', action: 'age_review_case_created' },
+    { target_id: 'OTHER', action: 'deleted' },
+  ];
+  it('matches both raw and user_-prefixed target ids', () => {
+    expect(decisionsForTarget(decisions, 'PK').map((d) => d.action)).toEqual([
+      'banned',
+      'age_review_case_created',
+    ]);
+  });
+  it('returns [] for undefined input', () => {
+    expect(decisionsForTarget(undefined, 'PK')).toEqual([]);
+  });
+});

--- a/src/lib/deepLinkResolution.ts
+++ b/src/lib/deepLinkResolution.ts
@@ -28,15 +28,14 @@ export function reportsMatchingTarget<E>(
   });
 }
 
-// The moderation decisions recorded for a target, matching both the raw id and
-// the mobile "user_<pubkey>" form the report/decision pipeline sometimes uses.
+// The moderation decisions recorded for a target. Every decision writer keys
+// target_id on the bare pubkey/event id (ReportWatcher.logDecision, handleLogDecision,
+// bulk-moderate — including age_review_case_created), so an exact match is complete.
 // Generic so it preserves the caller's element type (e.g. ModerationDecision).
 export function decisionsForTarget<T extends { target_id: string }>(
   allDecisions: T[] | undefined,
   targetValue: string
 ): T[] {
   if (!allDecisions) return [];
-  return allDecisions.filter(
-    (d) => d.target_id === targetValue || d.target_id === `user_${targetValue}`
-  );
+  return allDecisions.filter((d) => d.target_id === targetValue);
 }

--- a/src/lib/deepLinkResolution.ts
+++ b/src/lib/deepLinkResolution.ts
@@ -3,20 +3,16 @@
 
 export type DeepLinkStatus = 'idle' | 'resolving' | 'found' | 'gone' | 'unavailable';
 
-// Classify a targeted relay lookup for a deep-link's report. A failed request
-// (timeout/502) is 'unavailable' — never treated as 'gone' — so a transient
-// relay problem is not reported to a moderator as a deletion.
-export function classifyTargetedFetch(
-  outcome: { ok: boolean; events?: unknown[] }
-): 'found' | 'gone' | 'unavailable' {
-  if (!outcome.ok) return 'unavailable';
-  return (outcome.events?.length ?? 0) > 0 ? 'found' : 'gone';
+// Classify a successful targeted relay lookup for a deep-link's report.
+// Failed requests throw at the API boundary and are surfaced as 'unavailable'
+// by the component's catch path.
+export function classifyTargetedFetch(events: unknown[]): 'found' | 'gone' {
+  return events.length > 0 ? 'found' : 'gone';
 }
 
-// Keep only the reports whose resolved target (via the caller's getReportTarget)
-// matches the deep-link target. This mirrors the bulk list's consolidation rule so
-// a targeted lookup and the bulk search agree: a report that merely p-tags a pubkey
-// but resolves to an event target does NOT satisfy a ?pubkey= deep-link.
+// Prefer reports whose resolved target (via the caller's getReportTarget) matches
+// the deep-link target for display. This is not an existence gate: the relay's
+// own #e/#p filter result is authoritative for found/gone.
 export function reportsMatchingTarget<E>(
   events: E[],
   target: { type: string; value: string },

--- a/src/lib/deepLinkResolution.ts
+++ b/src/lib/deepLinkResolution.ts
@@ -1,0 +1,27 @@
+// ABOUTME: Pure helpers for resolving a Reports deep-link when the target may
+// ABOUTME: no longer be on the relay. No React, no I/O — unit-testable.
+
+export type DeepLinkStatus = 'idle' | 'resolving' | 'found' | 'gone' | 'unavailable';
+
+// Classify a targeted relay lookup for a deep-link's report. A failed request
+// (timeout/502) is 'unavailable' — never treated as 'gone' — so a transient
+// relay problem is not reported to a moderator as a deletion.
+export function classifyTargetedFetch(
+  outcome: { ok: boolean; events?: unknown[] }
+): 'found' | 'gone' | 'unavailable' {
+  if (!outcome.ok) return 'unavailable';
+  return (outcome.events?.length ?? 0) > 0 ? 'found' : 'gone';
+}
+
+// The moderation decisions recorded for a target, matching both the raw id and
+// the mobile "user_<pubkey>" form the report/decision pipeline sometimes uses.
+// Generic so it preserves the caller's element type (e.g. ModerationDecision).
+export function decisionsForTarget<T extends { target_id: string }>(
+  allDecisions: T[] | undefined,
+  targetValue: string
+): T[] {
+  if (!allDecisions) return [];
+  return allDecisions.filter(
+    (d) => d.target_id === targetValue || d.target_id === `user_${targetValue}`
+  );
+}

--- a/src/lib/deepLinkResolution.ts
+++ b/src/lib/deepLinkResolution.ts
@@ -13,6 +13,21 @@ export function classifyTargetedFetch(
   return (outcome.events?.length ?? 0) > 0 ? 'found' : 'gone';
 }
 
+// Keep only the reports whose resolved target (via the caller's getReportTarget)
+// matches the deep-link target. This mirrors the bulk list's consolidation rule so
+// a targeted lookup and the bulk search agree: a report that merely p-tags a pubkey
+// but resolves to an event target does NOT satisfy a ?pubkey= deep-link.
+export function reportsMatchingTarget<E>(
+  events: E[],
+  target: { type: string; value: string },
+  getTarget: (event: E) => { type: string; value: string } | null
+): E[] {
+  return events.filter((e) => {
+    const t = getTarget(e);
+    return t !== null && t.type === target.type && t.value === target.value;
+  });
+}
+
 // The moderation decisions recorded for a target, matching both the raw id and
 // the mobile "user_<pubkey>" form the report/decision pipeline sometimes uses.
 // Generic so it preserves the caller's element type (e.g. ModerationDecision).

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -9,7 +9,7 @@ import {
   type SecretStoreSecret,
 } from './nip86';
 import { ensureSchema } from './db';
-import { buildReportsFilter } from './reports-filter';
+import { buildReportsFilter, isUnconfirmedTargetedMiss } from './reports-filter';
 import { generatePreAuthToken, verifyPreAuthToken, base64UrlEncode } from './zendesk-preauth';
 import { deriveFunnelcakeApiUrl, proxyFunnelcakeRequest } from './funnelcake-proxy';
 import type { KeycastEnv } from './keycast-client';
@@ -525,6 +525,11 @@ export default {
         const result = await queryRelay(filter, env.RELAY_URL);
         if (!result.success) {
           return jsonResponse({ success: false, error: result.error }, 502, corsHeaders);
+        }
+        // A targeted lookup that came back empty but unconfirmed (relay never sent EOSE) is
+        // ambiguous — 502 so the client shows "unavailable" (retry), not a false "deleted".
+        if (isUnconfirmedTargetedMiss(url.searchParams, result)) {
+          return jsonResponse({ success: false, error: 'Relay did not confirm results (timeout)' }, 502, corsHeaders);
         }
         return jsonResponse({ success: true, events: result.events }, 200, corsHeaders);
       }
@@ -1627,7 +1632,7 @@ async function handleModerateMedia(
 async function queryRelay(
   filter: object,
   relayUrl: string
-): Promise<{ success: boolean; events?: object[]; error?: string }> {
+): Promise<{ success: boolean; events?: object[]; error?: string; complete?: boolean }> {
   return new Promise((resolve) => {
     try {
       const ws = new WebSocket(relayUrl);
@@ -1639,7 +1644,8 @@ async function queryRelay(
         if (!resolved) {
           resolved = true;
           ws.close();
-          resolve({ success: true, events });
+          // Timed out without EOSE: results may be truncated, so absence is unconfirmed.
+          resolve({ success: true, events, complete: false });
         }
       }, 5000);
 
@@ -1656,7 +1662,8 @@ async function queryRelay(
             clearTimeout(timeout);
             resolved = true;
             ws.close();
-            resolve({ success: true, events });
+            // EOSE = relay confirmed end of stored events, so an empty result is real.
+            resolve({ success: true, events, complete: true });
           }
         } catch {
           // Ignore parse errors
@@ -1675,7 +1682,8 @@ async function queryRelay(
         if (!resolved) {
           clearTimeout(timeout);
           resolved = true;
-          resolve({ success: true, events });
+          // Closed before EOSE: absence is unconfirmed.
+          resolve({ success: true, events, complete: false });
         }
       });
     } catch (error) {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -9,6 +9,7 @@ import {
   type SecretStoreSecret,
 } from './nip86';
 import { ensureSchema } from './db';
+import { buildReportsFilter } from './reports-filter';
 import { generatePreAuthToken, verifyPreAuthToken, base64UrlEncode } from './zendesk-preauth';
 import { deriveFunnelcakeApiUrl, proxyFunnelcakeRequest } from './funnelcake-proxy';
 import type { KeycastEnv } from './keycast-client';
@@ -520,7 +521,8 @@ export default {
       // nostrify NPool connection caching. The worker opens a fresh WebSocket
       // per request via queryRelay(), so every poll gets current data.
       if (path === '/api/reports' && request.method === 'GET') {
-        const result = await queryRelay({ kinds: [1984], limit: 200 }, env.RELAY_URL);
+        const filter = buildReportsFilter(url.searchParams);
+        const result = await queryRelay(filter, env.RELAY_URL);
         if (!result.success) {
           return jsonResponse({ success: false, error: result.error }, 502, corsHeaders);
         }

--- a/worker/src/reports-filter.test.ts
+++ b/worker/src/reports-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildReportsFilter } from './reports-filter';
+import { buildReportsFilter, isUnconfirmedTargetedMiss } from './reports-filter';
 
 describe('buildReportsFilter', () => {
   it('defaults to the bulk 200 window when no target param', () => {
@@ -13,5 +13,21 @@ describe('buildReportsFilter', () => {
   });
   it('prefers event over pubkey when both are present', () => {
     expect(buildReportsFilter(new URLSearchParams('event=abc&pubkey=def'))).toEqual({ kinds: [1984], '#e': ['abc'] });
+  });
+});
+
+describe('isUnconfirmedTargetedMiss', () => {
+  it('true for a targeted empty result the relay never confirmed (timeout/close)', () => {
+    expect(isUnconfirmedTargetedMiss(new URLSearchParams('event=abc'), { events: [], complete: false })).toBe(true);
+    expect(isUnconfirmedTargetedMiss(new URLSearchParams('pubkey=def'), { events: [], complete: false })).toBe(true);
+  });
+  it('false when the relay confirmed the empty result via EOSE (a real "gone")', () => {
+    expect(isUnconfirmedTargetedMiss(new URLSearchParams('event=abc'), { events: [], complete: true })).toBe(false);
+  });
+  it('false when the targeted lookup returned results', () => {
+    expect(isUnconfirmedTargetedMiss(new URLSearchParams('event=abc'), { events: [{}], complete: false })).toBe(false);
+  });
+  it('false for a bulk request (no target param), even if unconfirmed and empty', () => {
+    expect(isUnconfirmedTargetedMiss(new URLSearchParams(''), { events: [], complete: false })).toBe(false);
   });
 });

--- a/worker/src/reports-filter.test.ts
+++ b/worker/src/reports-filter.test.ts
@@ -6,17 +6,17 @@ describe('buildReportsFilter', () => {
     expect(buildReportsFilter(new URLSearchParams(''))).toEqual({ kinds: [1984], limit: 200 });
   });
   it('scopes to #e when an event param is present', () => {
-    expect(buildReportsFilter(new URLSearchParams('event=abc'))).toEqual({ kinds: [1984], '#e': ['abc'] });
+    expect(buildReportsFilter(new URLSearchParams('event=abc'))).toEqual({ kinds: [1984], '#e': ['abc'], limit: 200 });
   });
   it('scopes to #p when a pubkey param is present', () => {
-    expect(buildReportsFilter(new URLSearchParams('pubkey=def'))).toEqual({ kinds: [1984], '#p': ['def'] });
+    expect(buildReportsFilter(new URLSearchParams('pubkey=def'))).toEqual({ kinds: [1984], '#p': ['def'], limit: 200 });
   });
   it('prefers event over pubkey when both are present', () => {
-    expect(buildReportsFilter(new URLSearchParams('event=abc&pubkey=def'))).toEqual({ kinds: [1984], '#e': ['abc'] });
+    expect(buildReportsFilter(new URLSearchParams('event=abc&pubkey=def'))).toEqual({ kinds: [1984], '#e': ['abc'], limit: 200 });
   });
   it('lowercases uppercase-hex target params so the relay filter still matches', () => {
-    expect(buildReportsFilter(new URLSearchParams('event=ABC123'))).toEqual({ kinds: [1984], '#e': ['abc123'] });
-    expect(buildReportsFilter(new URLSearchParams('pubkey=DEADBEEF'))).toEqual({ kinds: [1984], '#p': ['deadbeef'] });
+    expect(buildReportsFilter(new URLSearchParams('event=ABC123'))).toEqual({ kinds: [1984], '#e': ['abc123'], limit: 200 });
+    expect(buildReportsFilter(new URLSearchParams('pubkey=DEADBEEF'))).toEqual({ kinds: [1984], '#p': ['deadbeef'], limit: 200 });
   });
 });
 

--- a/worker/src/reports-filter.test.ts
+++ b/worker/src/reports-filter.test.ts
@@ -14,6 +14,10 @@ describe('buildReportsFilter', () => {
   it('prefers event over pubkey when both are present', () => {
     expect(buildReportsFilter(new URLSearchParams('event=abc&pubkey=def'))).toEqual({ kinds: [1984], '#e': ['abc'] });
   });
+  it('lowercases uppercase-hex target params so the relay filter still matches', () => {
+    expect(buildReportsFilter(new URLSearchParams('event=ABC123'))).toEqual({ kinds: [1984], '#e': ['abc123'] });
+    expect(buildReportsFilter(new URLSearchParams('pubkey=DEADBEEF'))).toEqual({ kinds: [1984], '#p': ['deadbeef'] });
+  });
 });
 
 describe('isUnconfirmedTargetedMiss', () => {

--- a/worker/src/reports-filter.test.ts
+++ b/worker/src/reports-filter.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { buildReportsFilter } from './reports-filter';
+
+describe('buildReportsFilter', () => {
+  it('defaults to the bulk 200 window when no target param', () => {
+    expect(buildReportsFilter(new URLSearchParams(''))).toEqual({ kinds: [1984], limit: 200 });
+  });
+  it('scopes to #e when an event param is present', () => {
+    expect(buildReportsFilter(new URLSearchParams('event=abc'))).toEqual({ kinds: [1984], '#e': ['abc'] });
+  });
+  it('scopes to #p when a pubkey param is present', () => {
+    expect(buildReportsFilter(new URLSearchParams('pubkey=def'))).toEqual({ kinds: [1984], '#p': ['def'] });
+  });
+  it('prefers event over pubkey when both are present', () => {
+    expect(buildReportsFilter(new URLSearchParams('event=abc&pubkey=def'))).toEqual({ kinds: [1984], '#e': ['abc'] });
+  });
+});

--- a/worker/src/reports-filter.ts
+++ b/worker/src/reports-filter.ts
@@ -20,3 +20,15 @@ export function buildReportsFilter(params: URLSearchParams): {
   }
   return { kinds: [REPORT_KIND], limit: BULK_LIMIT };
 }
+
+// A targeted deep-link lookup (?event=/?pubkey=) that came back empty without the relay
+// confirming end-of-stored-events (no EOSE — a timeout or early close) is ambiguous, not
+// proof of absence. The caller should surface it as "unavailable" (retry), never as a
+// deletion. Bulk requests (no target param) are exempt: they self-correct on the next poll.
+export function isUnconfirmedTargetedMiss(
+  params: URLSearchParams,
+  result: { events?: unknown[]; complete?: boolean }
+): boolean {
+  const isTargeted = params.has('event') || params.has('pubkey');
+  return isTargeted && !result.complete && (result.events?.length ?? 0) === 0;
+}

--- a/worker/src/reports-filter.ts
+++ b/worker/src/reports-filter.ts
@@ -14,11 +14,11 @@ export function buildReportsFilter(params: URLSearchParams): {
   // Normalize so an uppercase-hex deep link still resolves instead of false-'gone'.
   const event = params.get('event');
   if (event) {
-    return { kinds: [REPORT_KIND], '#e': [event.toLowerCase()] };
+    return { kinds: [REPORT_KIND], '#e': [event.toLowerCase()], limit: BULK_LIMIT };
   }
   const pubkey = params.get('pubkey');
   if (pubkey) {
-    return { kinds: [REPORT_KIND], '#p': [pubkey.toLowerCase()] };
+    return { kinds: [REPORT_KIND], '#p': [pubkey.toLowerCase()], limit: BULK_LIMIT };
   }
   return { kinds: [REPORT_KIND], limit: BULK_LIMIT };
 }

--- a/worker/src/reports-filter.ts
+++ b/worker/src/reports-filter.ts
@@ -1,0 +1,22 @@
+// ABOUTME: Builds the relay filter for GET /api/reports, honoring optional
+// ABOUTME: ?event=/?pubkey= deep-link target params for scoped lookups.
+
+const REPORT_KIND = 1984;
+const BULK_LIMIT = 200;
+
+export function buildReportsFilter(params: URLSearchParams): {
+  kinds: number[];
+  limit?: number;
+  '#e'?: string[];
+  '#p'?: string[];
+} {
+  const event = params.get('event');
+  if (event) {
+    return { kinds: [REPORT_KIND], '#e': [event] };
+  }
+  const pubkey = params.get('pubkey');
+  if (pubkey) {
+    return { kinds: [REPORT_KIND], '#p': [pubkey] };
+  }
+  return { kinds: [REPORT_KIND], limit: BULK_LIMIT };
+}

--- a/worker/src/reports-filter.ts
+++ b/worker/src/reports-filter.ts
@@ -10,13 +10,15 @@ export function buildReportsFilter(params: URLSearchParams): {
   '#e'?: string[];
   '#p'?: string[];
 } {
+  // Nostr event ids and pubkeys are lowercase hex; relay filters match exactly.
+  // Normalize so an uppercase-hex deep link still resolves instead of false-'gone'.
   const event = params.get('event');
   if (event) {
-    return { kinds: [REPORT_KIND], '#e': [event] };
+    return { kinds: [REPORT_KIND], '#e': [event.toLowerCase()] };
   }
   const pubkey = params.get('pubkey');
   if (pubkey) {
-    return { kinds: [REPORT_KIND], '#p': [pubkey] };
+    return { kinds: [REPORT_KIND], '#p': [pubkey.toLowerCase()] };
   }
   return { kinds: [REPORT_KIND], limit: BULK_LIMIT };
 }


### PR DESCRIPTION
## Problem

Clicking "View in Relay Admin" from a Zendesk ticket could land on the Reports list with a blank right pane and no explanation, whenever the report's target wasn't in the fetched set -- most starkly when a reported account self-deleted (NIP-62 vanish) and its report event came off the relay before anyone acted.

Closes #193.

## Change

The deep-link now resolves into four explicit states instead of "found, or blank forever":

- **found** -- target present (bulk list or targeted lookup) -> opens the report.
- **resolving** -- a brief "looking up this report" state.
- **gone** -- a targeted relay query confirms the report is no longer on the relay -> clear message + the target id + any prior moderation actions on it.
- **unavailable** -- the relay lookup failed or couldn't confirm -> "couldn't reach the relay, retry", never mislabeled as deleted.

To make "gone" honest (and to resolve reports aged out past the 200-record bulk window), `/api/reports` accepts an optional `?event=`/`?pubkey=` filter and the client does a targeted lookup on a bulk miss. **Existence is gated on the relay's own `#e`/`#p` filter result** -- authoritative, since every returned report tags the queried target -- not on a re-filter by resolved target. An earlier cut re-filtered by resolved target, which false-flagged a report that only p-tags a pubkey (but resolves to an event) as "gone"; resolved-target matching is now only a display preference for *which* report to show.

Defensive about failure modes:
- A slow-but-healthy relay (no EOSE within timeout) surfaces as **unavailable** with retry, never a false "deleted" -- the worker distinguishes an EOSE-confirmed empty result from a timed-out one.
- A lookup resolving after the moderator navigated away is dropped rather than firing a late navigate.
- A "found" target lands on `/reports/:id`, so the deep-link query params are cleared and the in-session selection is stable. A full reload of an aged-out `/reports/:id` is still limited by the current report list window.
- Hex target params are lowercased so an uppercase-hex deep link still matches (client and worker in parity).
- Targeted `?event=`/`?pubkey=` report queries keep the same 200-result limit as the bulk list.
- If ban/label/decision data marks the selected deep-link target resolved after navigation, the UI re-opens the resolved filter so the selected row does not disappear.

## Out of scope

- The 200-record cap on the Reports **list** view (verified currently binding; a list-view fix is separate).
- Full reload/shared-link recovery for aged-out `/reports/:id` route IDs. Zendesk links use `?event=`/`?pubkey=`, which this PR resolves.
- `getReportTarget`'s e-tag-first resolution -- a separate latent item (`TODO(#160)`).

## Testing

- Unit tests: the worker filter + unconfirmed-miss guard, the client call, and the resolution helpers -- including regressions for the two false-"gone" cases (p-tag-only `?pubkey=`, multi-e-tag `?event=`), mutation-verified to fail on the old behavior.
- Integration tests (RTL): gone / found (asserting the `/reports/:id` URL) / unavailable / resolve-after-unmount / bulk-hit URL cleanup / late ban-data unhide.
- `npx tsc -p tsconfig.app.json --noEmit`
- `npm run test`
- `cd worker && npx vitest run`
