### PR TITLE
fix(reports): treat relay query timeout/early-close as errors, not empty results

### DIFF
--- a/docs/api-webhooks.md
+++ b/docs/api-webhooks.md
@@ -309,15 +309,36 @@ Get all decisions for a target.
 
 ### DELETE /api/decisions/:targetId
 
-Delete all decisions for a target (reopen a dismissed report).
+Delete all decisions for a target (reopen a dismissed report), and remove the
+target's relay-side resolution labels (kind 1985, `L=moderation/resolution`).
+
+**Query parameters:**
+
+| Name | Values | Default |
+|------|--------|---------|
+| `targetType` | `event` \| `pubkey` | both label tags are queried |
+
+A resolution label carries an `e` tag for an event target or a `p` tag for a
+pubkey target, never both, so naming the type skips the query that could not
+match. Any other value — absent, empty, wrong case, junk — falls back to
+querying both, which is what an older frontend gets.
 
 **Response:**
 ```json
 {
   "success": true,
-  "deleted": 2
+  "deleted": 2,
+  "labelsDeleted": 1,
+  "labelCleanupFailed": false
 }
 ```
+
+The D1 decision rows are deleted unconditionally; the relay-side label cleanup
+is best-effort. `labelCleanupFailed: true` means at least one resolution label
+may have survived — the label read failed, it filled its page so there may be
+more beyond it, or a label was read but could not be removed. A surviving label
+keeps the report hidden even though its decisions are gone, so callers must
+surface this rather than reporting a clean reopen.
 
 ---
 

--- a/src/components/ReportDetail.reopen.test.tsx
+++ b/src/components/ReportDetail.reopen.test.tsx
@@ -208,6 +208,18 @@ describe('ReportDetail reopen reporting', () => {
     expect(invalidate).toHaveBeenCalledWith({ queryKey: ['resolution-labels'] });
   });
 
+  // Each target's type is known here, so the worker never has to run the label
+  // filter that cannot match it. Passing it is easy to drop silently in a
+  // wrapper, so it is asserted at the call the component actually makes.
+  it('names each target type so neither cleanup runs a dead filter', async () => {
+    renderDetail();
+    clickReopen();
+
+    await waitFor(() => expect(toast).toHaveBeenCalled());
+    expect(api.deleteDecisions).toHaveBeenNthCalledWith(1, TARGET_EVENT, 'event');
+    expect(api.deleteDecisions).toHaveBeenNthCalledWith(2, REPORTED_PUBKEY, 'pubkey');
+  });
+
   // The tooltip makes the same promise the toast does, and is the copy a
   // moderator reads BEFORE deciding to reopen.
   it('does not promise the queue in the reopen tooltip either', async () => {

--- a/src/components/ReportDetail.reopen.test.tsx
+++ b/src/components/ReportDetail.reopen.test.tsx
@@ -1,0 +1,188 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReportDetail } from './ReportDetail';
+import type { NostrEvent } from '@nostrify/nostrify';
+
+// Reopen is the one action that asserts a queue state rather than reporting an
+// outcome: it tells the moderator the report is "back in the pending queue".
+// Whether that is true depends on relay-side resolution labels the worker may
+// have failed to clear, so the degraded branch is the whole point of the flag
+// and needs to be pinned at the hop where the moderator actually reads it.
+
+const TARGET_EVENT = 'c'.repeat(64);
+const REPORTED_PUBKEY = 'd'.repeat(64);
+const MOD_PUBKEY = 'e'.repeat(64);
+
+const api = vi.hoisted(() => ({
+  deleteEvent: vi.fn(),
+  allowEvent: vi.fn(),
+  markAsReviewed: vi.fn(),
+  logDecision: vi.fn(),
+  deleteDecisions: vi.fn(),
+}));
+const toast = vi.hoisted(() => vi.fn());
+
+vi.mock('react-router-dom', async (orig) => ({
+  ...(await orig<typeof import('react-router-dom')>()),
+  useNavigate: () => vi.fn(),
+}));
+vi.mock('@/hooks/useAdminApi', () => ({ useAdminApi: () => api }));
+vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast }) }));
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ user: { pubkey: MOD_PUBKEY }, getModeratorPubkey: async () => MOD_PUBKEY }),
+}));
+vi.mock('@/hooks/useAppContext', () => ({
+  useAppContext: () => ({ config: { relayUrl: 'wss://relay.example' } }),
+}));
+
+// The report has decisions (so Reopen renders) and is neither banned nor gone.
+const decisionLog = vi.hoisted(() => ({
+  hasDecisions: true,
+  isPendingReview: false,
+  isDeleted: false,
+  isAutoHidden: false,
+  isAutoHideRestored: false,
+  decisions: [],
+  latestDecision: null,
+  refetch: vi.fn(),
+}));
+vi.mock('@/hooks/useDecisionLog', () => ({ useDecisionLog: () => decisionLog }));
+vi.mock('@/hooks/useModerationStatus', () => ({
+  useModerationStatus: () => ({ isUserBanned: false, isEventGone: false }),
+}));
+vi.mock('@/hooks/useBannedEvent', () => ({
+  useBannedEvent: () => ({ data: null, isLoading: false }),
+}));
+vi.mock('@/hooks/useUserSummary', () => ({
+  useUserSummary: () => ({ data: null, isLoading: false }),
+}));
+vi.mock('@/hooks/useMediaStatus', () => ({ useMediaStatus: () => ({}) }));
+vi.mock('@/hooks/useReportContext', () => ({
+  useReportContext: () => ({
+    target: { type: 'event', value: TARGET_EVENT },
+    reportedUser: { pubkey: REPORTED_PUBKEY },
+    targetEvent: null,
+    isLoading: false,
+  }),
+}));
+
+// Heavy presentational children are irrelevant to the reopen decision and drag
+// in relay sockets of their own.
+vi.mock('@/components/ThreadContext', () => ({ ThreadContext: () => null }));
+vi.mock('@/components/UserProfileCard', () => ({ UserProfileCard: () => null }));
+vi.mock('@/components/AISummary', () => ({ AISummary: () => null }));
+vi.mock('@/components/HiveAIReport', () => ({ HiveAIReport: () => null }));
+vi.mock('@/components/AIDetectionReport', () => ({ AIDetectionReport: () => null }));
+vi.mock('@/components/MediaPreview', () => ({ MediaPreview: () => null }));
+vi.mock('@/components/ThreadModal', () => ({ ThreadModal: () => null }));
+vi.mock('@/components/EventActions', () => ({ EventActions: () => null }));
+vi.mock('@/components/UserActions', () => ({ UserActions: () => null }));
+vi.mock('@/components/BulkDeleteByKind', () => ({ BulkDeleteByKind: () => null }));
+vi.mock('@/components/ReporterCard', () => ({ ReporterInline: () => null }));
+vi.mock('@/components/UserIdentifier', () => ({ UserIdentifier: () => null }));
+
+const REPORT: NostrEvent = {
+  id: 'f'.repeat(64),
+  pubkey: 'a'.repeat(64),
+  created_at: 1751000000,
+  kind: 1984,
+  tags: [['e', TARGET_EVENT], ['p', REPORTED_PUBKEY]],
+  content: 'spam',
+  sig: 'b'.repeat(128),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.deleteDecisions.mockResolvedValue({ deleted: 2, labelCleanupFailed: false });
+});
+
+function renderDetail() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const invalidate = vi.spyOn(qc, 'invalidateQueries');
+  render(
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <ReportDetail report={REPORT} />
+      </TooltipProvider>
+    </QueryClientProvider>
+  );
+  return { invalidate };
+}
+
+const clickReopen = () => fireEvent.click(screen.getByRole('button', { name: /reopen/i }));
+
+describe('ReportDetail reopen reporting', () => {
+  // Even a fully successful reopen cannot promise the report is back in the
+  // queue: resolvedTargets also hides targets via relay bans and deletions,
+  // which reopen never touches, so a ban-resolved report stays hidden. Report
+  // what was actually done instead of asserting a queue state.
+  it('reports what a clean reopen did, without promising the report is back in the queue', async () => {
+    renderDetail();
+    clickReopen();
+
+    await waitFor(() => expect(toast).toHaveBeenCalled());
+    const arg = toast.mock.calls[0][0];
+    expect(arg.variant).not.toBe('destructive');
+    const text = `${arg.title} ${arg.description}`;
+    expect(text).not.toMatch(/could not|may stay hidden/i);
+    expect(text).not.toMatch(/back in the pending queue/i);
+  });
+
+  // The label survived, so resolvedTargets still hides the target and the
+  // report does NOT come back. Claiming it did is the exact failure this flag
+  // exists to prevent.
+  it('warns that the report may stay hidden when label cleanup failed', async () => {
+    api.deleteDecisions.mockResolvedValue({ deleted: 2, labelCleanupFailed: true });
+    renderDetail();
+    clickReopen();
+
+    await waitFor(() => expect(toast).toHaveBeenCalled());
+    const arg = toast.mock.calls[0][0];
+    expect(arg.variant).toBe('destructive');
+    expect(`${arg.title} ${arg.description}`).toMatch(/may stay hidden/i);
+  });
+
+  // An event report reopens two targets. A failure on the second must not be
+  // masked by a clean first result.
+  it('reports incomplete cleanup when only the pubkey target failed', async () => {
+    api.deleteDecisions
+      .mockResolvedValueOnce({ deleted: 1, labelCleanupFailed: false })
+      .mockResolvedValueOnce({ deleted: 1, labelCleanupFailed: true });
+    renderDetail();
+    clickReopen();
+
+    await waitFor(() => expect(toast).toHaveBeenCalled());
+    expect(toast.mock.calls[0][0].variant).toBe('destructive');
+  });
+
+  // resolvedTargets is built from the resolution-label query, so a reopen that
+  // does not refresh it leaves the target hidden for a poll cycle even when the
+  // cleanup fully succeeded.
+  it('invalidates the resolution-label cache the queue filters on', async () => {
+    const { invalidate } = renderDetail();
+    clickReopen();
+
+    await waitFor(() => expect(toast).toHaveBeenCalled());
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['resolution-labels'] });
+  });
+
+  // The two deleteDecisions calls are sequential and the first commits
+  // server-side before the second runs. When the second throws, the panel is
+  // showing decisions the server no longer has, so an error toast alone leaves
+  // the moderator looking at stale state.
+  it('refreshes the cached decision state even when the reopen fails part-way', async () => {
+    api.deleteDecisions
+      .mockResolvedValueOnce({ deleted: 1, labelCleanupFailed: false })
+      .mockRejectedValueOnce(new Error('worker 500'));
+    const { invalidate } = renderDetail();
+    clickReopen();
+
+    await waitFor(() => expect(toast).toHaveBeenCalled());
+    expect(toast.mock.calls[0][0].variant).toBe('destructive');
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['decisions'] });
+  });
+});

--- a/src/components/ReportDetail.reopen.test.tsx
+++ b/src/components/ReportDetail.reopen.test.tsx
@@ -59,12 +59,31 @@ vi.mock('@/hooks/useUserSummary', () => ({
   useUserSummary: () => ({ data: null, isLoading: false }),
 }));
 vi.mock('@/hooks/useMediaStatus', () => ({ useMediaStatus: () => ({}) }));
+// Shaped against the real hook's return (src/hooks/useReportContext.ts). A
+// partial mock here silently drives the component into its "event not found"
+// branch, which still renders Reopen -- so the tests would pass while
+// exercising a degraded path rather than the normal one.
+const TARGET_EVENT_OBJ: NostrEvent = {
+  id: TARGET_EVENT,
+  pubkey: REPORTED_PUBKEY,
+  created_at: 1751000100,
+  kind: 1,
+  tags: [],
+  content: 'reported content',
+  sig: 'c'.repeat(128),
+};
 vi.mock('@/hooks/useReportContext', () => ({
   useReportContext: () => ({
     target: { type: 'event', value: TARGET_EVENT },
-    reportedUser: { pubkey: REPORTED_PUBKEY },
-    targetEvent: null,
+    thread: { event: TARGET_EVENT_OBJ, ancestors: [], replies: [] },
+    threadLoading: false,
+    reportedUser: { profile: undefined, pubkey: REPORTED_PUBKEY, isFunnelcakeUser: false },
+    userStats: undefined,
+    reporter: { profile: undefined, pubkey: 'a'.repeat(64), reportCount: 0, isFunnelcakeUser: false },
     isLoading: false,
+    error: null,
+    relayHint: undefined,
+    reportTags: REPORT.tags,
   }),
 }));
 
@@ -184,5 +203,19 @@ describe('ReportDetail reopen reporting', () => {
     await waitFor(() => expect(toast).toHaveBeenCalled());
     expect(toast.mock.calls[0][0].variant).toBe('destructive');
     expect(invalidate).toHaveBeenCalledWith({ queryKey: ['decisions'] });
+    // The labels drive whether the target is hidden, so they go stale on a
+    // part-way failure exactly as the decisions do.
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['resolution-labels'] });
+  });
+
+  // The tooltip makes the same promise the toast does, and is the copy a
+  // moderator reads BEFORE deciding to reopen.
+  it('does not promise the queue in the reopen tooltip either', async () => {
+    renderDetail();
+    fireEvent.focus(screen.getByRole('button', { name: /reopen/i }));
+
+    const tip = await screen.findByRole('tooltip');
+    expect(tip.textContent).not.toMatch(/back in the pending queue/i);
+    expect(tip.textContent).toMatch(/stays hidden until that is lifted/i);
   });
 });

--- a/src/components/ReportDetail.reopen.test.tsx
+++ b/src/components/ReportDetail.reopen.test.tsx
@@ -15,6 +15,17 @@ import type { NostrEvent } from '@nostrify/nostrify';
 const TARGET_EVENT = 'c'.repeat(64);
 const REPORTED_PUBKEY = 'd'.repeat(64);
 const MOD_PUBKEY = 'e'.repeat(64);
+// A second report, for the case where the moderator moves on while the
+// never-expiring degraded toast is still on screen.
+const OTHER_EVENT = '9'.repeat(64);
+const OTHER_PUBKEY = '8'.repeat(64);
+
+// Which target the mocked context currently resolves to. Mutable because
+// selecting another report RE-RENDERS ReportDetail rather than remounting it
+// (ErrorBoundary resetKeys clear a caught error; they do not remount children),
+// so the panel's hooks hand back a new target under the same component
+// instance. A fixed mock cannot express that.
+const ctx = vi.hoisted(() => ({ targetValue: 'c'.repeat(64), reportedPubkey: 'd'.repeat(64) }));
 
 const api = vi.hoisted(() => ({
   deleteEvent: vi.fn(),
@@ -75,10 +86,10 @@ const TARGET_EVENT_OBJ: NostrEvent = {
 };
 vi.mock('@/hooks/useReportContext', () => ({
   useReportContext: () => ({
-    target: { type: 'event', value: TARGET_EVENT },
+    target: { type: 'event', value: ctx.targetValue },
     thread: { event: TARGET_EVENT_OBJ, ancestors: [], replies: [] },
     threadLoading: false,
-    reportedUser: { profile: undefined, pubkey: REPORTED_PUBKEY, isFunnelcakeUser: false },
+    reportedUser: { profile: undefined, pubkey: ctx.reportedPubkey, isFunnelcakeUser: false },
     userStats: undefined,
     reporter: { profile: undefined, pubkey: 'a'.repeat(64), reportCount: 0, isFunnelcakeUser: false },
     isLoading: false,
@@ -115,6 +126,8 @@ const REPORT: NostrEvent = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  ctx.targetValue = TARGET_EVENT;
+  ctx.reportedPubkey = REPORTED_PUBKEY;
   api.deleteDecisions.mockResolvedValue({ deleted: 2, labelCleanupFailed: false });
 });
 
@@ -123,14 +136,17 @@ function renderDetail() {
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
   const invalidate = vi.spyOn(qc, 'invalidateQueries');
-  render(
+  const tree = () => (
     <QueryClientProvider client={qc}>
       <TooltipProvider>
         <ReportDetail report={REPORT} />
       </TooltipProvider>
     </QueryClientProvider>
   );
-  return { invalidate };
+  const { rerender } = render(tree());
+  // Same component instance, fresh props/hook results -- what selecting another
+  // report does to this panel.
+  return { invalidate, rerender: () => rerender(tree()) };
 }
 
 const clickReopen = () => fireEvent.click(screen.getByRole('button', { name: /reopen/i }));
@@ -199,6 +215,35 @@ describe('ReportDetail reopen reporting', () => {
     await waitFor(() =>
       expect(api.deleteDecisions.mock.calls.length).toBeGreaterThan(callsBefore)
     );
+  });
+
+  // The degraded toast never expires and TOAST_LIMIT is 1, so it is still on
+  // screen after the moderator moves to another report. mutate() rebuilds the
+  // mutation from the observer's LATEST options, so a mutationFn that read the
+  // target off `context` instead of off its own variables would send this retry
+  // at the report now selected -- deleting the decisions of a report nobody
+  // asked to reopen, and then reporting it as a clean reopen.
+  it('retries the target it was raised for, not the report selected afterwards', async () => {
+    api.deleteDecisions.mockResolvedValue({ deleted: 2, labelCleanupFailed: true });
+    const { rerender } = renderDetail();
+    clickReopen();
+
+    await waitFor(() => expect(toast).toHaveBeenCalled());
+    const action = toast.mock.calls[0][0].action;
+
+    ctx.targetValue = OTHER_EVENT;
+    ctx.reportedPubkey = OTHER_PUBKEY;
+    rerender();
+    api.deleteDecisions.mockClear();
+
+    const { container } = render(action);
+    fireEvent.click(within(container).getByRole('button'));
+
+    await waitFor(() => expect(api.deleteDecisions).toHaveBeenCalled());
+    expect(api.deleteDecisions).toHaveBeenNthCalledWith(1, TARGET_EVENT, 'event');
+    expect(api.deleteDecisions).toHaveBeenNthCalledWith(2, REPORTED_PUBKEY, 'pubkey');
+    expect(api.deleteDecisions).not.toHaveBeenCalledWith(OTHER_EVENT, 'event');
+    expect(api.deleteDecisions).not.toHaveBeenCalledWith(OTHER_PUBKEY, 'pubkey');
   });
 
   // An event report reopens two targets. A failure on the second must not be

--- a/src/components/ReportDetail.reopen.test.tsx
+++ b/src/components/ReportDetail.reopen.test.tsx
@@ -147,8 +147,11 @@ describe('ReportDetail reopen reporting', () => {
     const arg = toast.mock.calls[0][0];
     expect(arg.variant).not.toBe('destructive');
     const text = `${arg.title} ${arg.description}`;
-    expect(text).not.toMatch(/could not|may stay hidden/i);
     expect(text).not.toMatch(/back in the pending queue/i);
+    // The tooltip carries the ban/deletion caveat, but it is read before the
+    // click. The toast is what a moderator sees after it, so it carries the
+    // caveat too rather than reading as an unqualified success.
+    expect(text).toMatch(/ban|deletion|deleted/i);
   });
 
   // The label survived, so resolvedTargets still hides the target and the
@@ -162,7 +165,12 @@ describe('ReportDetail reopen reporting', () => {
     await waitFor(() => expect(toast).toHaveBeenCalled());
     const arg = toast.mock.calls[0][0];
     expect(arg.variant).toBe('destructive');
-    expect(`${arg.title} ${arg.description}`).toMatch(/may stay hidden/i);
+    const text = `${arg.title} ${arg.description}`;
+    expect(text).toMatch(/may stay hidden/i);
+    // One of the three causes is our own page cap, where the relay did exactly
+    // what it was asked. Naming the relay as the culprit would send a moderator
+    // chasing a relay problem that is not there.
+    expect(text).not.toMatch(/the relay did not/i);
   });
 
   // An event report reopens two targets. A failure on the second must not be

--- a/src/components/ReportDetail.reopen.test.tsx
+++ b/src/components/ReportDetail.reopen.test.tsx
@@ -246,6 +246,22 @@ describe('ReportDetail reopen reporting', () => {
     expect(api.deleteDecisions).not.toHaveBeenCalledWith(OTHER_PUBKEY, 'pubkey');
   });
 
+  // The other half of the same OR. With only the pubkey-side case below,
+  // returning `secondary.labelCleanupFailed` alone passes the whole suite --
+  // and then a failed cleanup on the event target reports a clean reopen,
+  // which is every pubkey-target report too, since those never make a second
+  // call for `secondary` to be assigned from.
+  it('reports incomplete cleanup when only the event target failed', async () => {
+    api.deleteDecisions
+      .mockResolvedValueOnce({ deleted: 1, labelCleanupFailed: true })
+      .mockResolvedValueOnce({ deleted: 1, labelCleanupFailed: false });
+    renderDetail();
+    clickReopen();
+
+    await waitFor(() => expect(toast).toHaveBeenCalled());
+    expect(toast.mock.calls[0][0].variant).toBe('destructive');
+  });
+
   // An event report reopens two targets. A failure on the second must not be
   // masked by a clean first result.
   it('reports incomplete cleanup when only the pubkey target failed', async () => {

--- a/src/components/ReportDetail.reopen.test.tsx
+++ b/src/components/ReportDetail.reopen.test.tsx
@@ -193,7 +193,11 @@ describe('ReportDetail reopen reporting', () => {
     // The decisions ARE deleted on this path, so hasDecisions goes false and
     // the Reopen button unmounts. Telling a moderator to retry without giving
     // them the means is a dead end, so the retry rides on the toast -- and it
-    // must not expire, since nothing else can reach this action afterwards.
+    // must not expire on a timer, since nothing else can reach this action
+    // afterwards. Single-use even so: ToastAction is a ToastClose, so the click
+    // that fires the retry also dismisses the toast, and only a retry that
+    // comes back still-degraded raises a replacement. These tests render the
+    // action outside a ToastProvider, so that dismissal does not run here.
     expect(arg.action).toBeDefined();
     expect(arg.duration).toBe(Infinity);
   });

--- a/src/components/ReportDetail.reopen.test.tsx
+++ b/src/components/ReportDetail.reopen.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -151,7 +151,7 @@ describe('ReportDetail reopen reporting', () => {
     // The tooltip carries the ban/deletion caveat, but it is read before the
     // click. The toast is what a moderator sees after it, so it carries the
     // caveat too rather than reading as an unqualified success.
-    expect(text).toMatch(/ban|deletion|deleted/i);
+    expect(text).toMatch(/stays hidden until that is lifted/i);
   });
 
   // The label survived, so resolvedTargets still hides the target and the
@@ -171,6 +171,29 @@ describe('ReportDetail reopen reporting', () => {
     // what it was asked. Naming the relay as the culprit would send a moderator
     // chasing a relay problem that is not there.
     expect(text).not.toMatch(/the relay did not/i);
+    // The decisions ARE deleted on this path, so hasDecisions goes false and
+    // the Reopen button unmounts. Telling a moderator to retry without giving
+    // them the means is a dead end, so the retry rides on the toast.
+    expect(arg.action).toBeDefined();
+  });
+
+  it('offers a working retry from the degraded toast, since the button is gone', async () => {
+    api.deleteDecisions.mockResolvedValue({ deleted: 2, labelCleanupFailed: true });
+    renderDetail();
+    clickReopen();
+
+    await waitFor(() => expect(toast).toHaveBeenCalled());
+    const callsBefore = api.deleteDecisions.mock.calls.length;
+
+    // Render the toast's action in isolation and click it: it must re-run the
+    // reopen rather than merely dismiss. Scoped to its own container, since the
+    // panel behind it already has buttons of its own.
+    const { container } = render(toast.mock.calls[0][0].action);
+    fireEvent.click(within(container).getByRole('button'));
+
+    await waitFor(() =>
+      expect(api.deleteDecisions.mock.calls.length).toBeGreaterThan(callsBefore)
+    );
   });
 
   // An event report reopens two targets. A failure on the second must not be

--- a/src/components/ReportDetail.reopen.test.tsx
+++ b/src/components/ReportDetail.reopen.test.tsx
@@ -5,11 +5,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ReportDetail } from './ReportDetail';
 import type { NostrEvent } from '@nostrify/nostrify';
 
-// Reopen is the one action that asserts a queue state rather than reporting an
-// outcome: it tells the moderator the report is "back in the pending queue".
-// Whether that is true depends on relay-side resolution labels the worker may
-// have failed to clear, so the degraded branch is the whole point of the flag
-// and needs to be pinned at the hop where the moderator actually reads it.
+// Reopen used to assert a queue state rather than report an outcome: it told
+// the moderator the report was "back in the pending queue". Whether that was
+// true depended on relay-side resolution labels the worker may have failed to
+// clear, and on relay bans reopen never touches at all. These tests pin the
+// replacement copy, and the degraded branch, at the hop where a moderator
+// actually reads it.
 
 const TARGET_EVENT = 'c'.repeat(64);
 const REPORTED_PUBKEY = 'd'.repeat(64);
@@ -152,6 +153,8 @@ describe('ReportDetail reopen reporting', () => {
     // click. The toast is what a moderator sees after it, so it carries the
     // caveat too rather than reading as an unqualified success.
     expect(text).toMatch(/stays hidden until that is lifted/i);
+    // Which makes it too long for Radix's 5s default to be read in.
+    expect(arg.duration).toBeGreaterThan(5000);
   });
 
   // The label survived, so resolvedTargets still hides the target and the
@@ -173,8 +176,10 @@ describe('ReportDetail reopen reporting', () => {
     expect(text).not.toMatch(/the relay did not/i);
     // The decisions ARE deleted on this path, so hasDecisions goes false and
     // the Reopen button unmounts. Telling a moderator to retry without giving
-    // them the means is a dead end, so the retry rides on the toast.
+    // them the means is a dead end, so the retry rides on the toast -- and it
+    // must not expire, since nothing else can reach this action afterwards.
     expect(arg.action).toBeDefined();
+    expect(arg.duration).toBe(Infinity);
   });
 
   it('offers a working retry from the degraded toast, since the button is gone', async () => {

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -263,13 +263,15 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
       // ban-resolved report stays hidden even on a fully clean run.
       toast(labelCleanupFailed
         ? {
-            title: "Reopened, but resolution labels could not be cleared",
-            description: "The relay did not clear them, so this report may stay hidden. Try reopening again.",
+            // Deliberately does not name the relay: one of the causes is our
+            // own page cap, where the relay did exactly what it was asked.
+            title: "Reopened, but resolution labels could not all be cleared",
+            description: "Some may remain, so this report may stay hidden. Try reopening again.",
             variant: "destructive" as const,
           }
         : {
             title: "Report reopened",
-            description: "Moderation decisions and resolution labels were cleared",
+            description: "Moderation decisions and resolution labels were cleared. A report hidden by a relay ban or deletion stays hidden until that is lifted.",
           });
     },
     onError: (error: Error) => {

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -262,7 +262,7 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
       toast(labelCleanupFailed
         ? {
             title: "Reopened, but resolution labels could not be cleared",
-            description: "The relay did not answer, so this report may stay hidden. Try reopening again.",
+            description: "The relay did not clear them, so this report may stay hidden. Try reopening again.",
             variant: "destructive" as const,
           }
         : {

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -266,12 +266,22 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
             // Deliberately does not name the relay: one of the causes is our
             // own page cap, where the relay did exactly what it was asked.
             title: "Reopened, but resolution labels could not all be cleared",
-            description: "Some may remain, so this report may stay hidden. Try reopening again.",
+            description: "Some may remain, so this report may stay hidden.",
             variant: "destructive" as const,
+            // The decisions ARE gone on this path, so hasDecisions goes false
+            // and the Reopen button unmounts. Retrying is the right advice and
+            // the cleanup is idempotent, so the retry has to come with it.
+            action: (
+              <ToastAction altText="Retry the reopen" onClick={() => reopenMutation.mutate()}>
+                Try again
+              </ToastAction>
+            ),
           }
         : {
             title: "Report reopened",
-            description: "Moderation decisions and resolution labels were cleared. A report hidden by a relay ban or deletion stays hidden until that is lifted.",
+            description: "Decisions and resolution labels cleared. A report hidden by a relay ban or deletion stays hidden until that is lifted.",
+            // Longer than the 5s Radix default can be read in.
+            duration: 10000,
           });
     },
     onError: (error: Error) => {

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -242,20 +242,33 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
     mutationFn: async () => {
       if (!context.target) throw new Error('No target');
       // Delete all decisions for this target
-      await deleteDecisions(context.target.value);
+      const primary = await deleteDecisions(context.target.value);
       // Also delete decisions for the pubkey if this is an event report
+      let secondary = { labelCleanupFailed: false };
       if (context.target.type === 'event' && context.reportedUser.pubkey) {
-        await deleteDecisions(context.reportedUser.pubkey);
+        secondary = await deleteDecisions(context.reportedUser.pubkey);
       }
+      return { labelCleanupFailed: primary.labelCleanupFailed || secondary.labelCleanupFailed };
     },
-    onSuccess: () => {
+    onSuccess: ({ labelCleanupFailed }) => {
       queryClient.invalidateQueries({ queryKey: ['decisions'] });
+      // Resolution labels also gate whether the report reappears, so a reopen
+      // that does not refresh them can leave the target hidden for a poll cycle.
+      queryClient.invalidateQueries({ queryKey: ['resolution-labels'] });
       decisionLog.refetch();
       pubkeyDecisionLog.refetch();
-      toast({
-        title: "Report reopened",
-        description: "This report is now back in the pending queue",
-      });
+      // The decisions are gone either way, but a surviving resolution label
+      // keeps the report out of the queue. Do not claim it is back.
+      toast(labelCleanupFailed
+        ? {
+            title: "Reopened, but resolution labels could not be cleared",
+            description: "The relay did not answer, so this report may stay hidden. Try reopening again.",
+            variant: "destructive" as const,
+          }
+        : {
+            title: "Report reopened",
+            description: "This report is now back in the pending queue",
+          });
     },
     onError: (error: Error) => {
       toast({

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -257,8 +257,10 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
       queryClient.invalidateQueries({ queryKey: ['resolution-labels'] });
       decisionLog.refetch();
       pubkeyDecisionLog.refetch();
-      // The decisions are gone either way, but a surviving resolution label
-      // keeps the report out of the queue. Do not claim it is back.
+      // Report what the reopen did, not where the report ends up. Whether it
+      // returns to the queue depends on resolvedTargets, which is also built
+      // from relay bans and deletions that reopen never undoes -- so a
+      // ban-resolved report stays hidden even on a fully clean run.
       toast(labelCleanupFailed
         ? {
             title: "Reopened, but resolution labels could not be cleared",
@@ -267,10 +269,18 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
           }
         : {
             title: "Report reopened",
-            description: "This report is now back in the pending queue",
+            description: "Moderation decisions and resolution labels were cleared",
           });
     },
     onError: (error: Error) => {
+      // The first delete may already have committed server-side before the
+      // second threw, so the cached decision state can be stale even though
+      // the action reports failure. Refresh it rather than leaving the panel
+      // showing decisions the server no longer has.
+      queryClient.invalidateQueries({ queryKey: ['decisions'] });
+      queryClient.invalidateQueries({ queryKey: ['resolution-labels'] });
+      decisionLog.refetch();
+      pubkeyDecisionLog.refetch();
       toast({
         title: "Failed to reopen",
         description: error.message,
@@ -1088,7 +1098,7 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent side="bottom" className="max-w-xs">
-                    <p>Reopen this report for review. Removes the dismiss decision and puts it back in the pending queue.</p>
+                    <p>Reopen this report for review. Clears its moderation decisions and resolution labels. A report hidden by a relay ban or deletion stays hidden until that is lifted.</p>
                   </TooltipContent>
                 </Tooltip>
               )}

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -270,9 +270,10 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
             variant: "destructive" as const,
             // The decisions ARE gone on this path, so hasDecisions goes false
             // and the Reopen button unmounts. Retrying is the right advice and
-            // the cleanup is idempotent, so the retry has to come with it --
-            // and it must not expire, because when it goes there is no other
-            // way back to this action short of re-resolving the report.
+            // the cleanup is idempotent, so the retry has to come with it, and
+            // it does not expire on a timer. That is not a guarantee it will
+            // still be there: TOAST_LIMIT is 1, so any later toast evicts it.
+            // The fallback is to resolve the report again and reopen.
             action: (
               <ToastAction altText="Retry the reopen" onClick={() => reopenMutation.mutate()}>
                 Try again

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -242,11 +242,11 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
     mutationFn: async () => {
       if (!context.target) throw new Error('No target');
       // Delete all decisions for this target
-      const primary = await deleteDecisions(context.target.value);
+      const primary = await deleteDecisions(context.target.value, context.target.type);
       // Also delete decisions for the pubkey if this is an event report
       let secondary = { labelCleanupFailed: false };
       if (context.target.type === 'event' && context.reportedUser.pubkey) {
-        secondary = await deleteDecisions(context.reportedUser.pubkey);
+        secondary = await deleteDecisions(context.reportedUser.pubkey, 'pubkey');
       }
       return { labelCleanupFailed: primary.labelCleanupFailed || secondary.labelCleanupFailed };
     },

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -280,9 +280,15 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
             // The decisions ARE gone on this path, so hasDecisions goes false
             // and the Reopen button unmounts. Retrying is the right advice and
             // the cleanup is idempotent, so the retry has to come with it, and
-            // it does not expire on a timer. That is not a guarantee it will
-            // still be there: TOAST_LIMIT is 1, so any later toast evicts it.
-            // The fallback is to resolve the report again and reopen.
+            // it does not expire on a timer.
+            //
+            // It is still single-use. Radix renders ToastAction as a
+            // ToastClose, so the click that fires the retry also dismisses this
+            // toast. A retry that comes back still-degraded raises a fresh one
+            // carrying a fresh action; a retry that THROWS lands in onError,
+            // which has no action, and ends the chain. TOAST_LIMIT is 1, so any
+            // later toast evicts it too. The fallback in both cases is to
+            // resolve the report again and reopen.
             //
             // Re-sends the target this toast was raised for, not whatever is
             // selected when it is clicked -- see ReopenTarget above.

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -270,12 +270,15 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
             variant: "destructive" as const,
             // The decisions ARE gone on this path, so hasDecisions goes false
             // and the Reopen button unmounts. Retrying is the right advice and
-            // the cleanup is idempotent, so the retry has to come with it.
+            // the cleanup is idempotent, so the retry has to come with it --
+            // and it must not expire, because when it goes there is no other
+            // way back to this action short of re-resolving the report.
             action: (
               <ToastAction altText="Retry the reopen" onClick={() => reopenMutation.mutate()}>
                 Try again
               </ToastAction>
             ),
+            duration: Infinity,
           }
         : {
             title: "Report reopened",

--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -238,19 +238,28 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
     },
   });
 
+  // What a reopen acts on, captured at click time rather than read from
+  // `context` when the mutation runs. The degraded toast below outlives this
+  // panel's selection (duration Infinity, and selecting another report
+  // re-renders ReportDetail rather than remounting it), and mutate() rebuilds
+  // the mutation from the observer's LATEST options -- so a mutationFn closing
+  // over `context` would send the retry at whichever report is selected when
+  // it is clicked, deleting that report's decisions instead.
+  type ReopenTarget = { type: 'event' | 'pubkey'; value: string; reportedPubkey?: string | null };
+
   const reopenMutation = useMutation({
-    mutationFn: async () => {
-      if (!context.target) throw new Error('No target');
+    mutationFn: async (target: ReopenTarget | null) => {
+      if (!target) throw new Error('No target');
       // Delete all decisions for this target
-      const primary = await deleteDecisions(context.target.value, context.target.type);
+      const primary = await deleteDecisions(target.value, target.type);
       // Also delete decisions for the pubkey if this is an event report
       let secondary = { labelCleanupFailed: false };
-      if (context.target.type === 'event' && context.reportedUser.pubkey) {
-        secondary = await deleteDecisions(context.reportedUser.pubkey, 'pubkey');
+      if (target.type === 'event' && target.reportedPubkey) {
+        secondary = await deleteDecisions(target.reportedPubkey, 'pubkey');
       }
       return { labelCleanupFailed: primary.labelCleanupFailed || secondary.labelCleanupFailed };
     },
-    onSuccess: ({ labelCleanupFailed }) => {
+    onSuccess: ({ labelCleanupFailed }, target) => {
       queryClient.invalidateQueries({ queryKey: ['decisions'] });
       // Resolution labels also gate whether the report reappears, so a reopen
       // that does not refresh them can leave the target hidden for a poll cycle.
@@ -274,8 +283,11 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
             // it does not expire on a timer. That is not a guarantee it will
             // still be there: TOAST_LIMIT is 1, so any later toast evicts it.
             // The fallback is to resolve the report again and reopen.
+            //
+            // Re-sends the target this toast was raised for, not whatever is
+            // selected when it is clicked -- see ReopenTarget above.
             action: (
-              <ToastAction altText="Retry the reopen" onClick={() => reopenMutation.mutate()}>
+              <ToastAction altText="Retry the reopen" onClick={() => reopenMutation.mutate(target)}>
                 Try again
               </ToastAction>
             ),
@@ -1106,7 +1118,9 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
                     <Button
                       variant="outline"
                       className="border-orange-500 text-orange-600 hover:bg-orange-50"
-                      onClick={() => reopenMutation.mutate()}
+                      onClick={() => reopenMutation.mutate(
+                        context.target && { ...context.target, reportedPubkey: context.reportedUser.pubkey }
+                      )}
                       disabled={reopenMutation.isPending}
                     >
                       <History className="h-4 w-4 mr-1" />

--- a/src/components/Reports.test.tsx
+++ b/src/components/Reports.test.tsx
@@ -209,6 +209,9 @@ describe('Reports resolution-state availability', () => {
 
     expect(await screen.findByText(pendingCount(0))).toBeInTheDocument();
     expect(screen.queryByText(/1 report$/)).not.toBeInTheDocument();
+    // Pins the negative side: a warning that is always on is a warning nobody
+    // reads, and an unconditional banner would otherwise pass every test here.
+    expect(screen.queryByText(/resolution state is unavailable/i)).not.toBeInTheDocument();
   });
 
   it('warns that resolution state is unavailable when the labels query fails on first load', async () => {

--- a/src/components/Reports.test.tsx
+++ b/src/components/Reports.test.tsx
@@ -231,4 +231,29 @@ describe('Reports resolution-state availability', () => {
     expect(await screen.findByText(pendingCount(1))).toBeInTheDocument();
     expect(await screen.findByText(/resolution state is unavailable/i)).toBeInTheDocument();
   });
+
+  // The warning claims handled work may be listed as pending, which is only
+  // true while resolvedTargets is actually filtering the list. With hide
+  // resolved off nothing is filtered by it, so the claim does not apply and
+  // the banner must stand down rather than cry wolf.
+  it('drops the warning when resolved targets are not being filtered anyway', async () => {
+    stubFetch(() => new Response(JSON.stringify({ success: false, error: 'Relay query timed out before EOSE' }), {
+      status: 502,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    render(
+      <TestApp>
+        <Reports relayUrl="wss://relay.example" />
+      </TestApp>
+    );
+
+    expect(await screen.findByText(/resolution state is unavailable/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('switch', { name: /hide resolved/i }));
+
+    await waitFor(() =>
+      expect(screen.queryByText(/resolution state is unavailable/i)).not.toBeInTheDocument()
+    );
+  });
 });

--- a/src/components/Reports.test.tsx
+++ b/src/components/Reports.test.tsx
@@ -101,3 +101,65 @@ describe('Reports crash degradation (#158)', () => {
     expect(screen.getByText(/this report failed to render/i)).toBeInTheDocument();
   });
 });
+
+// A failed poll must not blank a loaded queue. The worker now 502s when the
+// relay times out / closes before EOSE (instead of returning an empty success);
+// the list keeps rendering its last good data with a stale-data warning rather
+// than replacing the whole pane with the error alert. Surfaced by a slow
+// staging backend; applies to any slow relay in production.
+describe('Reports stale-data resilience', () => {
+  it('keeps the last loaded queue visible with a warning when a refresh fails', async () => {
+    let reportsCalls = 0;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.includes('/api/reports')) {
+        reportsCalls++;
+        if (reportsCalls === 1) return jsonResponse({ success: true, events: [REPORT] });
+        return new Response(JSON.stringify({ success: false, error: 'Relay query timed out before EOSE' }), {
+          status: 502,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/resolution-labels')) return jsonResponse({ success: true, events: [] });
+      if (url.includes('/api/decisions')) return jsonResponse({ success: true, decisions: [] });
+      if (url.includes('/api/relay-rpc')) return jsonResponse({ success: true, result: [] });
+      return jsonResponse({ success: true });
+    }));
+
+    render(
+      <TestApp>
+        <Reports relayUrl="wss://relay.example" />
+      </TestApp>
+    );
+
+    expect(await screen.findByText(/1 report$/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle(/last updated|refresh/i));
+
+    // Warning appears; the queue row is still there (not blanked, no full-pane error).
+    expect(await screen.findByText(/refresh is failing/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 report$/)).toBeInTheDocument();
+    expect(screen.queryByText(/failed to load reports/i)).not.toBeInTheDocument();
+  });
+
+  it('still shows the full error pane when the first load fails (no stale data to fall back on)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.includes('/api/reports')) {
+        return new Response(JSON.stringify({ success: false, error: 'Relay query timed out before EOSE' }), {
+          status: 502,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return jsonResponse({ success: true, events: [], decisions: [], result: [] });
+    }));
+
+    render(
+      <TestApp>
+        <Reports relayUrl="wss://relay.example" />
+      </TestApp>
+    );
+
+    expect(await screen.findByText(/failed to load reports/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/Reports.test.tsx
+++ b/src/components/Reports.test.tsx
@@ -163,3 +163,69 @@ describe('Reports stale-data resilience', () => {
     expect(await screen.findByText(/failed to load reports/i)).toBeInTheDocument();
   });
 });
+
+// resolvedTargets is subtractive: it hides work a moderator already handled.
+// When a source of it fails, the queue does not get smaller and safer, it gets
+// bigger and wrong, re-presenting handled targets as pending (#221). The list
+// still renders (a moderator with no queue can do nothing), but it must not
+// claim to be complete when the resolution state behind it is missing.
+describe('Reports resolution-state availability', () => {
+  const RESOLUTION_LABEL = {
+    id: '1'.repeat(64),
+    pubkey: '2'.repeat(64),
+    created_at: 1751000200,
+    kind: 1985,
+    tags: [['L', 'moderation/resolution'], ['e', 'c'.repeat(64)]],
+    content: '',
+    sig: 'e'.repeat(128),
+  };
+
+  function stubFetch(labelsResponse: () => Response) {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.includes('/api/resolution-labels')) return labelsResponse();
+      if (url.includes('/api/reports')) return jsonResponse({ success: true, events: [REPORT] });
+      if (url.includes('/api/decisions')) return jsonResponse({ success: true, decisions: [] });
+      if (url.includes('/api/relay-rpc')) return jsonResponse({ success: true, result: [] });
+      return jsonResponse({ success: true });
+    }));
+  }
+
+  // The pending count sits in a node with a sibling span, so match on the
+  // element's own normalized text rather than a bare string.
+  const pendingCount = (n: number) => (_: string, el: Element | null) =>
+    el?.tagName === 'P' && (el.textContent ?? '').trim().startsWith(`${n} pending`);
+
+  // Control: proves the label genuinely hides the target, so the test below is
+  // measuring a real un-hide rather than a report that was never filtered.
+  it('hides a target that a resolution label has already resolved', async () => {
+    stubFetch(() => jsonResponse({ success: true, events: [RESOLUTION_LABEL] }));
+
+    render(
+      <TestApp>
+        <Reports relayUrl="wss://relay.example" />
+      </TestApp>
+    );
+
+    expect(await screen.findByText(pendingCount(0))).toBeInTheDocument();
+    expect(screen.queryByText(/1 report$/)).not.toBeInTheDocument();
+  });
+
+  it('warns that resolution state is unavailable when the labels query fails on first load', async () => {
+    stubFetch(() => new Response(JSON.stringify({ success: false, error: 'Relay query timed out before EOSE' }), {
+      status: 502,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    render(
+      <TestApp>
+        <Reports relayUrl="wss://relay.example" />
+      </TestApp>
+    );
+
+    // The previously-resolved target is back in the list. That is tolerable
+    // only because the moderator is told the filter behind it is incomplete.
+    expect(await screen.findByText(pendingCount(1))).toBeInTheDocument();
+    expect(await screen.findByText(/resolution state is unavailable/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/Reports.test.tsx
+++ b/src/components/Reports.test.tsx
@@ -228,4 +228,32 @@ describe('Reports resolution filtering', () => {
 
     expect(await screen.findByText(pendingCount(1))).toBeInTheDocument();
   });
+
+  // The labels read is the one polling query here that retries. Measured
+  // against production it runs at p90 ~3.2s against a 5s cap, so a single slow
+  // read is common and would otherwise cost a moderator their whole resolution
+  // filter until the next poll -- re-presenting handled work as pending.
+  it('recovers the resolution filter when the labels read fails once', async () => {
+    let labelCalls = 0;
+    stubFetch(() => {
+      labelCalls++;
+      if (labelCalls === 1) {
+        return new Response(JSON.stringify({ success: false, error: 'Relay query timed out before EOSE' }), {
+          status: 502,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return jsonResponse({ success: true, events: [RESOLUTION_LABEL] });
+    });
+
+    render(
+      <TestApp>
+        <Reports relayUrl="wss://relay.example" />
+      </TestApp>
+    );
+
+    // The retry lands and the resolved target is hidden again.
+    expect(await screen.findByText(pendingCount(0))).toBeInTheDocument();
+    expect(labelCalls).toBeGreaterThan(1);
+  });
 });

--- a/src/components/Reports.test.tsx
+++ b/src/components/Reports.test.tsx
@@ -231,9 +231,10 @@ describe('Reports resolution filtering', () => {
 
   // The labels read is the one polling query here that retries. queryRelay
   // gives it a hard 5s cap, so a slow relay crosses it on ordinary variance
-  // (see #185 for the production timings behind that claim), and without a
-  // retry one slow read costs a moderator their whole resolution filter until
-  // the next poll -- re-presenting handled work as pending.
+  // (#185 measured that on staging; the matching production timings are in
+  // this PR's description), and without a retry one slow read costs a
+  // moderator their whole resolution filter until the next poll --
+  // re-presenting handled work as pending.
   it('recovers the resolution filter when the labels read fails once', async () => {
     let labelCalls = 0;
     stubFetch(() => {

--- a/src/components/Reports.test.tsx
+++ b/src/components/Reports.test.tsx
@@ -133,6 +133,10 @@ describe('Reports stale-data resilience', () => {
     );
 
     expect(await screen.findByText(/1 report$/)).toBeInTheDocument();
+    // Pins the negative side: a warning that is always on is a warning nobody
+    // reads, and an unconditional banner would otherwise pass every assertion
+    // below.
+    expect(screen.queryByText(/refresh is failing/i)).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByTitle(/last updated|refresh/i));
 
@@ -164,12 +168,14 @@ describe('Reports stale-data resilience', () => {
   });
 });
 
-// resolvedTargets is subtractive: it hides work a moderator already handled.
-// When a source of it fails, the queue does not get smaller and safer, it gets
-// bigger and wrong, re-presenting handled targets as pending (#221). The list
-// still renders (a moderator with no queue can do nothing), but it must not
-// claim to be complete when the resolution state behind it is missing.
-describe('Reports resolution-state availability', () => {
+// resolvedTargets is subtractive: it hides work a moderator already handled, so
+// a failed source makes the queue bigger and wrong rather than smaller and safe
+// (#221). Surfacing that incompleteness in the UI is #221's job, not this PR's
+// -- fix/221-resolution-state-completeness reports per-source completeness from
+// the worker and gates the queue on it, which supersedes the narrower banner
+// this branch briefly carried. What stays here is the control below, which
+// pins that a resolution label genuinely hides its target.
+describe('Reports resolution filtering', () => {
   const RESOLUTION_LABEL = {
     id: '1'.repeat(64),
     pubkey: '2'.repeat(64),
@@ -196,8 +202,6 @@ describe('Reports resolution-state availability', () => {
   const pendingCount = (n: number) => (_: string, el: Element | null) =>
     el?.tagName === 'P' && (el.textContent ?? '').trim().startsWith(`${n} pending`);
 
-  // Control: proves the label genuinely hides the target, so the test below is
-  // measuring a real un-hide rather than a report that was never filtered.
   it('hides a target that a resolution label has already resolved', async () => {
     stubFetch(() => jsonResponse({ success: true, events: [RESOLUTION_LABEL] }));
 
@@ -209,16 +213,12 @@ describe('Reports resolution-state availability', () => {
 
     expect(await screen.findByText(pendingCount(0))).toBeInTheDocument();
     expect(screen.queryByText(/1 report$/)).not.toBeInTheDocument();
-    // Pins the negative side: a warning that is always on is a warning nobody
-    // reads, and an unconditional banner would otherwise pass every test here.
-    expect(screen.queryByText(/resolution state is unavailable/i)).not.toBeInTheDocument();
   });
 
-  it('warns that resolution state is unavailable when the labels query fails on first load', async () => {
-    stubFetch(() => new Response(JSON.stringify({ success: false, error: 'Relay query timed out before EOSE' }), {
-      status: 502,
-      headers: { 'Content-Type': 'application/json' },
-    }));
+  // The inverse, and the reason the labels read is worth retrying: with no
+  // label set the same target is presented as pending work again.
+  it('lists the target as pending when its resolution label is missing', async () => {
+    stubFetch(() => jsonResponse({ success: true, events: [] }));
 
     render(
       <TestApp>
@@ -226,34 +226,6 @@ describe('Reports resolution-state availability', () => {
       </TestApp>
     );
 
-    // The previously-resolved target is back in the list. That is tolerable
-    // only because the moderator is told the filter behind it is incomplete.
     expect(await screen.findByText(pendingCount(1))).toBeInTheDocument();
-    expect(await screen.findByText(/resolution state is unavailable/i)).toBeInTheDocument();
-  });
-
-  // The warning claims handled work may be listed as pending, which is only
-  // true while resolvedTargets is actually filtering the list. With hide
-  // resolved off nothing is filtered by it, so the claim does not apply and
-  // the banner must stand down rather than cry wolf.
-  it('drops the warning when resolved targets are not being filtered anyway', async () => {
-    stubFetch(() => new Response(JSON.stringify({ success: false, error: 'Relay query timed out before EOSE' }), {
-      status: 502,
-      headers: { 'Content-Type': 'application/json' },
-    }));
-
-    render(
-      <TestApp>
-        <Reports relayUrl="wss://relay.example" />
-      </TestApp>
-    );
-
-    expect(await screen.findByText(/resolution state is unavailable/i)).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('switch', { name: /hide resolved/i }));
-
-    await waitFor(() =>
-      expect(screen.queryByText(/resolution state is unavailable/i)).not.toBeInTheDocument()
-    );
   });
 });

--- a/src/components/Reports.test.tsx
+++ b/src/components/Reports.test.tsx
@@ -229,10 +229,11 @@ describe('Reports resolution filtering', () => {
     expect(await screen.findByText(pendingCount(1))).toBeInTheDocument();
   });
 
-  // The labels read is the one polling query here that retries. Measured
-  // against production it runs at p90 ~3.2s against a 5s cap, so a single slow
-  // read is common and would otherwise cost a moderator their whole resolution
-  // filter until the next poll -- re-presenting handled work as pending.
+  // The labels read is the one polling query here that retries. queryRelay
+  // gives it a hard 5s cap, so a slow relay crosses it on ordinary variance
+  // (see #185 for the production timings behind that claim), and without a
+  // retry one slow read costs a moderator their whole resolution filter until
+  // the next poll -- re-presenting handled work as pending.
   it('recovers the resolution filter when the labels read fails once', async () => {
     let labelCalls = 0;
     stubFetch(() => {

--- a/src/components/Reports.tsx
+++ b/src/components/Reports.tsx
@@ -397,11 +397,13 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
     retry: false,
   });
 
-  // resolvedTargets is subtractive: these labels HIDE work already handled. A
-  // failed fetch therefore makes the queue bigger and wrong, not smaller and
-  // safe, so the error has to reach the UI (#221). One retry, because a single
-  // slow relay read should not cost a moderator their whole resolution filter.
-  const { data: resolutionLabels, error: labelsError } = useQuery({
+  // resolvedTargets is subtractive: these labels HIDE work already handled, so
+  // a failed fetch makes the queue bigger and wrong rather than smaller and
+  // safe (#221). One retry, because a single slow relay read should not cost a
+  // moderator their whole resolution filter -- this is the only polling query
+  // here that retries, for that reason. Surfacing the incompleteness in the UI
+  // belongs to #221, which reports per-source completeness from the worker.
+  const { data: resolutionLabels } = useQuery({
     queryKey: ['resolution-labels', relayUrl],
     queryFn: fetchResolutionLabels,
     refetchInterval: 15 * 1000,
@@ -447,8 +449,8 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
   // Query all moderation decisions from our D1 database.
   // retry: false is intentional — placeholderData keeps stale data visible on failure,
   // and refetchInterval (15s) provides automatic recovery. This avoids stacking retries
-  // on cold-start timeouts which compound latency. (Previously retry: 2, changed to
-  // match the resilience pattern across all polling queries in this component.)
+  // on cold-start timeouts which compound latency. (Previously retry: 2.) The
+  // resolution-labels query above is the one deliberate exception.
   const { data: allDecisions, isLoading: decisionsLoading } = useQuery({
     queryKey: ['decisions'],
     queryFn: async () => {
@@ -1016,21 +1018,6 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
             <Alert variant="destructive" className="mt-2 py-2">
               <AlertDescription className="text-xs">
                 Live refresh is failing. Showing reports loaded {lastUpdatedText || 'earlier'}; retrying automatically.
-              </AlertDescription>
-            </Alert>
-          )}
-
-          {/* Resolution labels never loaded, so nothing they would have hidden
-              is hidden. The count above is an overcount and some rows are work
-              already done. Only warn when there is no previous label data to
-              fall back on (a failed refresh still has the last good set), and
-              only while resolvedTargets is actually being applied: the pending
-              review queue and the hide-resolved-off view are not filtered by
-              it, so the warning would not be true there. */}
-          {labelsError && !resolutionLabels && hideResolved && !showPendingReview && (
-            <Alert variant="destructive" className="mt-2 py-2">
-              <AlertDescription className="text-xs">
-                Resolution state is unavailable, so reports you have already handled may be listed below as pending. Retrying automatically.
               </AlertDescription>
             </Alert>
           )}

--- a/src/components/Reports.tsx
+++ b/src/components/Reports.tsx
@@ -895,7 +895,12 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
     );
   }
 
-  if (error) {
+  // Full-pane error only when there is nothing to show. When a REFRESH fails
+  // (e.g. the worker 502s on a relay timeout), the last good list stays
+  // rendered with a stale-data warning below — replacing a populated queue
+  // with an error pane (or, before the worker fix, with silent emptiness)
+  // made one slow poll look like "no reports pending".
+  if (error && !reports) {
     return (
       <Alert variant="destructive">
         <AlertDescription>
@@ -1000,6 +1005,16 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
               </Button>
             </div>
           </div>
+
+          {/* Refresh failed but we still hold a previous list: warn instead of
+              blanking the queue. The poll keeps retrying every 15s. */}
+          {error && (
+            <Alert variant="destructive" className="mt-2 py-2">
+              <AlertDescription className="text-xs">
+                Live refresh is failing. Showing reports loaded {lastUpdatedText ?? 'earlier'}; retrying automatically.
+              </AlertDescription>
+            </Alert>
+          )}
 
           {/* View mode toggle */}
           <Tabs value={viewMode} onValueChange={(v) => setViewMode(v as 'consolidated' | 'individual')} className="mt-2">

--- a/src/components/Reports.tsx
+++ b/src/components/Reports.tsx
@@ -397,12 +397,16 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
     retry: false,
   });
 
-  const { data: resolutionLabels } = useQuery({
+  // resolvedTargets is subtractive: these labels HIDE work already handled. A
+  // failed fetch therefore makes the queue bigger and wrong, not smaller and
+  // safe, so the error has to reach the UI (#221). One retry, because a single
+  // slow relay read should not cost a moderator their whole resolution filter.
+  const { data: resolutionLabels, error: labelsError } = useQuery({
     queryKey: ['resolution-labels', relayUrl],
     queryFn: fetchResolutionLabels,
     refetchInterval: 15 * 1000,
     placeholderData: (previousData) => previousData,
-    retry: false,
+    retry: 1,
   });
 
   // Query banned pubkeys from relay (NIP-86 RPC)
@@ -1012,6 +1016,18 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
             <Alert variant="destructive" className="mt-2 py-2">
               <AlertDescription className="text-xs">
                 Live refresh is failing. Showing reports loaded {lastUpdatedText || 'earlier'}; retrying automatically.
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {/* Resolution labels never loaded, so nothing they would have hidden
+              is hidden. The count above is an overcount and some rows are work
+              already done. Only warn when there is no previous label data to
+              fall back on; a failed refresh still has the last good set. */}
+          {labelsError && !resolutionLabels && (
+            <Alert variant="destructive" className="mt-2 py-2">
+              <AlertDescription className="text-xs">
+                Resolution state is unavailable, so reports you have already handled may be listed below as pending. Retrying automatically.
               </AlertDescription>
             </Alert>
           )}

--- a/src/components/Reports.tsx
+++ b/src/components/Reports.tsx
@@ -1023,8 +1023,11 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
           {/* Resolution labels never loaded, so nothing they would have hidden
               is hidden. The count above is an overcount and some rows are work
               already done. Only warn when there is no previous label data to
-              fall back on; a failed refresh still has the last good set. */}
-          {labelsError && !resolutionLabels && (
+              fall back on (a failed refresh still has the last good set), and
+              only while resolvedTargets is actually being applied: the pending
+              review queue and the hide-resolved-off view are not filtered by
+              it, so the warning would not be true there. */}
+          {labelsError && !resolutionLabels && hideResolved && !showPendingReview && (
             <Alert variant="destructive" className="mt-2 py-2">
               <AlertDescription className="text-xs">
                 Resolution state is unavailable, so reports you have already handled may be listed below as pending. Retrying automatically.

--- a/src/components/Reports.tsx
+++ b/src/components/Reports.tsx
@@ -897,7 +897,7 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
 
   // Full-pane error only when there is nothing to show. When a REFRESH fails
   // (e.g. the worker 502s on a relay timeout), the last good list stays
-  // rendered with a stale-data warning below — replacing a populated queue
+  // rendered with a stale-data warning below. Replacing a populated queue
   // with an error pane (or, before the worker fix, with silent emptiness)
   // made one slow poll look like "no reports pending".
   if (error && !reports) {
@@ -1011,7 +1011,7 @@ export function Reports({ relayUrl, selectedReportId }: ReportsProps) {
           {error && (
             <Alert variant="destructive" className="mt-2 py-2">
               <AlertDescription className="text-xs">
-                Live refresh is failing. Showing reports loaded {lastUpdatedText ?? 'earlier'}; retrying automatically.
+                Live refresh is failing. Showing reports loaded {lastUpdatedText || 'earlier'}; retrying automatically.
               </AlertDescription>
             </Alert>
           )}

--- a/src/hooks/useAdminApi.test.ts
+++ b/src/hooks/useAdminApi.test.ts
@@ -1,0 +1,40 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useAdminApi } from './useAdminApi';
+
+// useAdminApi binds apiUrl onto each adminApi function. That binding is a hand
+// written argument list per function, so an argument added downstream is
+// silently dropped here unless the wrapper is updated too -- and TypeScript
+// cannot see it, because the wrapper's own signature still declares the
+// parameter it forgot to pass on. Component tests mock this hook wholesale, so
+// nothing else exercises the real wrapper.
+
+const API_URL = 'https://api.example';
+
+vi.mock('@/hooks/useAppContext', () => ({
+  useAppContext: () => ({ config: { apiUrl: API_URL, relayUrl: 'wss://relay.example' } }),
+}));
+
+const deleteDecisions = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/adminApi', async (orig) => ({
+  ...(await orig<typeof import('@/lib/adminApi')>()),
+  deleteDecisions,
+}));
+
+describe('useAdminApi', () => {
+  it('forwards the reopen target type through to adminApi', () => {
+    const { result } = renderHook(() => useAdminApi());
+
+    result.current.deleteDecisions('abc', 'pubkey');
+
+    expect(deleteDecisions).toHaveBeenCalledWith(API_URL, 'abc', 'pubkey');
+  });
+
+  it('leaves the target type undefined when the caller omits it', () => {
+    const { result } = renderHook(() => useAdminApi());
+
+    result.current.deleteDecisions('abc');
+
+    expect(deleteDecisions).toHaveBeenCalledWith(API_URL, 'abc', undefined);
+  });
+});

--- a/src/hooks/useAdminApi.ts
+++ b/src/hooks/useAdminApi.ts
@@ -97,8 +97,8 @@ export function useAdminApi() {
       adminApi.getDecisions(apiUrl, targetId),
     getAllDecisions: () =>
       adminApi.getAllDecisions(apiUrl),
-    deleteDecisions: (targetId: string) =>
-      adminApi.deleteDecisions(apiUrl, targetId),
+    deleteDecisions: (targetId: string, targetType?: 'event' | 'pubkey') =>
+      adminApi.deleteDecisions(apiUrl, targetId, targetType),
 
     // Classifier data (scene classification + topic profile)
     getClassifierData: (sha256: string) =>

--- a/src/lib/adminApi.test.ts
+++ b/src/lib/adminApi.test.ts
@@ -27,6 +27,7 @@ import {
   verifyAgeRestricted,
   logDecision,
   getDecisions,
+  deleteDecisions,
   extractMediaHashes,
   isBlockedMediaAction,
   updateAgeReviewCase,
@@ -1064,6 +1065,41 @@ describe('adminApi', () => {
       const result = await getDecisions(API_URL, 'event123');
 
       expect(result).toEqual([]);
+    });
+  });
+
+  // A reopen deletes the D1 decisions unconditionally but clears the relay's
+  // resolution labels best-effort. If this client drops the flag, the caller
+  // reports a clean reopen for a report that is still hidden.
+  describe('deleteDecisions', () => {
+    it('surfaces labelCleanupFailed so a partial reopen is not reported as clean', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, deleted: 3, labelCleanupFailed: true }),
+      });
+
+      const result = await deleteDecisions(API_URL, 'event123');
+
+      expect(result).toEqual({ deleted: 3, labelCleanupFailed: true });
+    });
+
+    it('reports a clean reopen when every label was cleared', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, deleted: 2, labelCleanupFailed: false }),
+      });
+
+      expect(await deleteDecisions(API_URL, 'event123')).toEqual({ deleted: 2, labelCleanupFailed: false });
+    });
+
+    // An older worker omits the field entirely; absence must not read as failure.
+    it('treats a missing labelCleanupFailed as no failure', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, deleted: 1 }),
+      });
+
+      expect(await deleteDecisions(API_URL, 'event123')).toEqual({ deleted: 1, labelCleanupFailed: false });
     });
   });
 

--- a/src/lib/adminApi.test.ts
+++ b/src/lib/adminApi.test.ts
@@ -1101,6 +1101,32 @@ describe('adminApi', () => {
 
       expect(await deleteDecisions(API_URL, 'event123')).toEqual({ deleted: 1, labelCleanupFailed: false });
     });
+
+    // A resolution label carries an 'e' tag or a 'p' tag, never both, so the
+    // type lets the worker skip the query that could not have matched. Without
+    // it the worker checks both, and a stall on the dead one reports a failed
+    // cleanup that no retry can fix.
+    it('names the target type so the worker skips the filter that cannot match', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, deleted: 1, labelCleanupFailed: false }),
+      });
+
+      await deleteDecisions(API_URL, 'event123', 'event');
+
+      expect(mockFetch.mock.calls[0][0]).toContain('/api/decisions/event123?targetType=event');
+    });
+
+    it('omits the target type when it is not known', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, deleted: 1, labelCleanupFailed: false }),
+      });
+
+      await deleteDecisions(API_URL, 'event123');
+
+      expect(mockFetch.mock.calls[0][0]).not.toContain('targetType');
+    });
   });
 
   describe('extractMediaHashes', () => {

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -572,10 +572,11 @@ export async function getAllDecisions(apiUrl: string): Promise<ModerationDecisio
 }
 
 // Delete all decisions for a target (reopens the report).
-// labelCleanupFailed means the relay-side resolution labels could not be read,
-// or were read but could not be removed, so some may survive and keep the
-// report hidden even though its decisions are gone. Callers must surface that
-// rather than reporting a clean reopen.
+// labelCleanupFailed means the relay-side resolution labels could not be fully
+// cleared -- the read failed, the read filled its page so there may be more
+// beyond it, or a label was read but could not be removed. Any of those leaves
+// labels alive that keep the report hidden even though its decisions are gone,
+// so callers must surface it rather than reporting a clean reopen.
 // targetType lets the worker query only the label tag that can match ('e' for
 // an event, 'p' for a pubkey). Omitting it is safe: the worker then checks
 // both, which is what an older frontend gets.

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -576,13 +576,18 @@ export async function getAllDecisions(apiUrl: string): Promise<ModerationDecisio
 // or were read but could not be removed, so some may survive and keep the
 // report hidden even though its decisions are gone. Callers must surface that
 // rather than reporting a clean reopen.
+// targetType lets the worker query only the label tag that can match ('e' for
+// an event, 'p' for a pubkey). Omitting it is safe: the worker then checks
+// both, which is what an older frontend gets.
 export async function deleteDecisions(
   apiUrl: string,
-  targetId: string
+  targetId: string,
+  targetType?: 'event' | 'pubkey'
 ): Promise<{ deleted: number; labelCleanupFailed: boolean }> {
+  const qs = targetType ? `?targetType=${targetType}` : '';
   const data = await apiRequest<{ success: boolean; deleted: number; labelCleanupFailed?: boolean }>(
     apiUrl,
-    `/api/decisions/${targetId}`,
+    `/api/decisions/${targetId}${qs}`,
     'DELETE'
   );
   return { deleted: data.deleted || 0, labelCleanupFailed: data.labelCleanupFailed === true };

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -573,8 +573,9 @@ export async function getAllDecisions(apiUrl: string): Promise<ModerationDecisio
 
 // Delete all decisions for a target (reopens the report).
 // labelCleanupFailed means the relay-side resolution labels could not be read,
-// so some may survive and keep the report hidden even though its decisions are
-// gone. Callers must surface that rather than reporting a clean reopen.
+// or were read but could not be removed, so some may survive and keep the
+// report hidden even though its decisions are gone. Callers must surface that
+// rather than reporting a clean reopen.
 export async function deleteDecisions(
   apiUrl: string,
   targetId: string

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -571,14 +571,20 @@ export async function getAllDecisions(apiUrl: string): Promise<ModerationDecisio
   return data.decisions || [];
 }
 
-// Delete all decisions for a target (reopens the report)
-export async function deleteDecisions(apiUrl: string, targetId: string): Promise<number> {
-  const data = await apiRequest<{ success: boolean; deleted: number }>(
+// Delete all decisions for a target (reopens the report).
+// labelCleanupFailed means the relay-side resolution labels could not be read,
+// so some may survive and keep the report hidden even though its decisions are
+// gone. Callers must surface that rather than reporting a clean reopen.
+export async function deleteDecisions(
+  apiUrl: string,
+  targetId: string
+): Promise<{ deleted: number; labelCleanupFailed: boolean }> {
+  const data = await apiRequest<{ success: boolean; deleted: number; labelCleanupFailed?: boolean }>(
     apiUrl,
     `/api/decisions/${targetId}`,
     'DELETE'
   );
-  return data.deleted || 0;
+  return { deleted: data.deleted || 0, labelCleanupFailed: data.labelCleanupFailed === true };
 }
 
 // Verify that a pubkey was actually banned on the relay

--- a/src/test/TestApp.tsx
+++ b/src/test/TestApp.tsx
@@ -12,7 +12,10 @@ interface TestAppProps {
 export function TestApp({ children }: TestAppProps) {
   const queryClient = new QueryClient({
     defaultOptions: {
-      queries: { retry: false },
+      // retryDelay too: a component that overrides `retry` reinstates the
+      // default 1000ms backoff, which pushes an error-state assertion right up
+      // against the 1000ms findBy timeout and flakes under CI load.
+      queries: { retry: false, retryDelay: 0 },
       mutations: { retry: false },
     },
   });

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1583,6 +1583,7 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
   // the cleanup loop then bans. One reopen would wipe resolution labels
   // queue-wide and still report success.
   it('falls back to both filters when the target type is not a recognised value', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.stubGlobal('fetch', vi.fn(async () =>
       new Response(JSON.stringify({ result: true }), { status: 200 })
     ));
@@ -1611,6 +1612,9 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
     expect(filters[0]['#e']).toEqual([ 'a'.repeat(64) ]);
     expect(filters[1]['#p']).toEqual([ 'a'.repeat(64) ]);
     for (const f of filters) expect(Object.keys(f)).not.toContain('undefined');
+    // Degrading safely is right, but silently would make a client-side typo
+    // invisible in production.
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('unrecognised targetType'), 'EVENT');
   });
 
   // Worker and Pages deploy separately, so a new worker serves an old frontend
@@ -1723,16 +1727,54 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
     expect(body.labelCleanupFailed).toBe(true);
   });
 
+  // The message listener has no resolved-guard, so a frame can still arrive
+  // after a failure path has handed its events to the caller. Handing back the
+  // live array would let that late frame join a set the caller is already
+  // iterating and banning -- a label the caller never saw in its own count.
+  it('does not ban a label that arrived after the read had already failed', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ result: true }), { status: 200 })
+    ));
+    const LATE_LABEL = { ...LABEL_A, id: 'd'.repeat(64) };
+
+    const resPromise = worker.fetch(
+      reopenRequest(),
+      { ...(reportsEnv as object), DB: reopenDb(), NOSTR_NSEC: TEST_NSEC } as never,
+      ctx,
+    );
+    for (let i = 0; i < 2; i++) {
+      for (let t = 0; t < 100 && !FakeRelaySocket.instances[i]; t++) {
+        await new Promise((r) => setTimeout(r, 0));
+      }
+      const sock = FakeRelaySocket.instances[i];
+      expect(sock).toBeDefined();
+      if (i === 0) {
+        sock.message(['EVENT', sock.subId(), LABEL_A]);
+        sock.emit('close', {});           // read fails, caller gets its events
+        sock.message(['EVENT', sock.subId(), LATE_LABEL]); // too late to count
+      } else {
+        sock.emit('close', {});
+      }
+    }
+
+    const res = await resPromise;
+    const body = await res.json() as { labelsDeleted: number };
+    expect(body.labelsDeleted).toBe(1);
+  });
+
   // A completed read that fills the page is indistinguishable from a truncated
   // one, so it must report an incomplete cleanup even though EOSE arrived. The
-  // 200 is written out rather than imported: the cap being high enough to make
-  // truncation implausible is part of what the test pins.
+  // 50 is written out rather than imported: the page size doubles as the
+  // worst-case number of sequential signed round-trips in one reopen, so it is
+  // bounded by the client's 30s timeout and the Workers subrequest budget --
+  // that bound is part of what the test pins.
   it('reports incomplete cleanup when the label read fills the page', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.stubGlobal('fetch', vi.fn(async () =>
       new Response(JSON.stringify({ result: true }), { status: 200 })
     ));
-    const fullPage = Array.from({ length: 200 }, (_, i) => ({
+    const fullPage = Array.from({ length: 50 }, (_, i) => ({
       ...LABEL_A,
       id: i.toString(16).padStart(64, '0'),
     }));
@@ -1758,11 +1800,11 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
     // The cap is what makes truncation implausible rather than merely
     // detectable, so the requested page size is pinned too: detection only
     // fires on our own limit, never on a lower one the relay imposes.
-    expect(JSON.parse(FakeRelaySocket.instances[0].sent[0])[2].limit).toBe(200);
+    expect(JSON.parse(FakeRelaySocket.instances[0].sent[0])[2].limit).toBe(50);
 
     const res = await resPromise;
     const body = await res.json() as { labelsDeleted: number; labelCleanupFailed: boolean };
-    expect(body.labelsDeleted).toBe(200); // every label on the page was removed
+    expect(body.labelsDeleted).toBe(50); // every label on the page was removed
     expect(body.labelCleanupFailed).toBe(true); // but there may be more beyond it
   });
 

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1516,6 +1516,133 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
     expect(body.labelCleanupFailed).toBe(true); // and the read is still reported incomplete
   });
 
+  // Each failure path carries its events independently, so each is pinned
+  // independently. The timeout is the one this branch is named for.
+  it('bans a label received before the read timed out', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ result: true }), { status: 200 })
+    ));
+
+    const resPromise = worker.fetch(
+      reopenRequest(),
+      { ...(reportsEnv as object), DB: reopenDb(), NOSTR_NSEC: TEST_NSEC } as never,
+      ctx,
+    );
+    for (let i = 0; i < 2; i++) {
+      for (let t = 0; t < 100 && !FakeRelaySocket.instances[i]; t++) {
+        await vi.advanceTimersByTimeAsync(0);
+      }
+      const sock = FakeRelaySocket.instances[i];
+      expect(sock).toBeDefined();
+      if (i === 0) sock.message(['EVENT', sock.subId(), LABEL_A]);
+      await vi.advanceTimersByTimeAsync(5000);
+    }
+
+    const res = await resPromise;
+    const body = await res.json() as { labelsDeleted: number; labelCleanupFailed: boolean };
+    expect(body.labelsDeleted).toBe(1);
+    expect(body.labelCleanupFailed).toBe(true);
+  });
+
+  it('bans a label received before the relay CLOSED the subscription', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ result: true }), { status: 200 })
+    ));
+
+    const resPromise = worker.fetch(
+      reopenRequest(),
+      { ...(reportsEnv as object), DB: reopenDb(), NOSTR_NSEC: TEST_NSEC } as never,
+      ctx,
+    );
+    for (let i = 0; i < 2; i++) {
+      for (let t = 0; t < 100 && !FakeRelaySocket.instances[i]; t++) {
+        await new Promise((r) => setTimeout(r, 0));
+      }
+      const sock = FakeRelaySocket.instances[i];
+      expect(sock).toBeDefined();
+      if (i === 0) sock.message(['EVENT', sock.subId(), LABEL_A]);
+      sock.message(['CLOSED', sock.subId(), 'error: could not complete query']);
+    }
+
+    const res = await resPromise;
+    const body = await res.json() as { labelsDeleted: number; labelCleanupFailed: boolean };
+    expect(body.labelsDeleted).toBe(1);
+    expect(body.labelCleanupFailed).toBe(true);
+  });
+
+  it('bans a label received before the socket errored', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ result: true }), { status: 200 })
+    ));
+
+    const resPromise = worker.fetch(
+      reopenRequest(),
+      { ...(reportsEnv as object), DB: reopenDb(), NOSTR_NSEC: TEST_NSEC } as never,
+      ctx,
+    );
+    for (let i = 0; i < 2; i++) {
+      for (let t = 0; t < 100 && !FakeRelaySocket.instances[i]; t++) {
+        await new Promise((r) => setTimeout(r, 0));
+      }
+      const sock = FakeRelaySocket.instances[i];
+      expect(sock).toBeDefined();
+      if (i === 0) sock.message(['EVENT', sock.subId(), LABEL_A]);
+      sock.emit('error', {});
+    }
+
+    const res = await resPromise;
+    const body = await res.json() as { labelsDeleted: number; labelCleanupFailed: boolean };
+    expect(body.labelsDeleted).toBe(1);
+    expect(body.labelCleanupFailed).toBe(true);
+  });
+
+  // A completed read that fills the page is indistinguishable from a truncated
+  // one, so it must report an incomplete cleanup even though EOSE arrived. The
+  // 200 is written out rather than imported: the cap being high enough to make
+  // truncation implausible is part of what the test pins.
+  it('reports incomplete cleanup when the label read fills the page', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ result: true }), { status: 200 })
+    ));
+    const fullPage = Array.from({ length: 200 }, (_, i) => ({
+      ...LABEL_A,
+      id: i.toString(16).padStart(64, '0'),
+    }));
+
+    const resPromise = worker.fetch(
+      reopenRequest(),
+      { ...(reportsEnv as object), DB: reopenDb(), NOSTR_NSEC: TEST_NSEC } as never,
+      ctx,
+    );
+    for (let i = 0; i < 2; i++) {
+      // A full page means 200 sequential banevent round-trips before the second
+      // filter opens its socket, so this wait needs a far bigger budget than
+      // the single-label cases above.
+      for (let t = 0; t < 5000 && !FakeRelaySocket.instances[i]; t++) {
+        await new Promise((r) => setTimeout(r, 0));
+      }
+      const sock = FakeRelaySocket.instances[i];
+      expect(sock).toBeDefined();
+      if (i === 0) for (const label of fullPage) sock.message(['EVENT', sock.subId(), label]);
+      sock.message(['EOSE', sock.subId()]);
+    }
+
+    // The cap is what makes truncation implausible rather than merely
+    // detectable, so the requested page size is pinned too: detection only
+    // fires on our own limit, never on a lower one the relay imposes.
+    expect(JSON.parse(FakeRelaySocket.instances[0].sent[0])[2].limit).toBe(200);
+
+    const res = await resPromise;
+    const body = await res.json() as { labelsDeleted: number; labelCleanupFailed: boolean };
+    expect(body.labelsDeleted).toBe(200); // every label on the page was removed
+    expect(body.labelCleanupFailed).toBe(true); // but there may be more beyond it
+  });
+
   it('returns 502 when the relay closes before EOSE on resolution labels', async () => {
     const resPromise = worker.fetch(labelsRequest(), reportsEnv, ctx);
     await new Promise((r) => setTimeout(r, 0));

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1450,6 +1450,30 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
     headers: { 'X-Admin-Key': 'test-admin-key' },
   });
 
+  // The positive control for the flag. Every other case below asserts it goes
+  // TRUE; without this one, flagging any reopen that touched a label at all
+  // still passes -- and that mutation puts a destructive "may stay hidden"
+  // toast on the ordinary successful reopen, which is the failure mode this
+  // flag exists to avoid in the other direction.
+  it('reports a clean reopen when the labels it found were removed', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ result: true }), { status: 200 })
+    ));
+
+    const resPromise = worker.fetch(
+      reopenRequest(),
+      { ...(reportsEnv as object), DB: reopenDb(), NOSTR_NSEC: TEST_NSEC } as never,
+      ctx,
+    );
+    await feedLabelToEachFilter();
+
+    const res = await resPromise;
+    const body = await res.json() as { labelsDeleted: number; labelCleanupFailed: boolean };
+    // A label was genuinely removed -- this is not the vacuous empty-read case.
+    expect(body.labelsDeleted).toBeGreaterThan(0);
+    expect(body.labelCleanupFailed).toBe(false);
+  });
+
   // The label read can succeed while the delete fails. A relay admin key
   // mismatch 403s every management command but leaves reads working, and that
   // refusal does NOT throw: the RPC comes back success:false. The label

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1238,6 +1238,62 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
     expect(body.error).toMatch(/timed out/i);
   });
 
+  // The deep-link path, which changed materially and lost its only coverage
+  // when isUnconfirmedTargetedMiss went. That guard 502'd a targeted lookup
+  // that came back empty AND unconfirmed; queryRelay now fails the read itself,
+  // so a targeted lookup 502s even when events DID arrive -- Reports.tsx turns
+  // that into "Relay unavailable" (retry) where it used to render "found".
+  // Deliberate: a truncated targeted read is not proof of what it found. It is
+  // also the one behavior change here a moderator sees on a deep link, so it
+  // gets pinned at the endpoint rather than only argued in the description.
+  it('returns 502 for a targeted lookup that received events and then timed out', async () => {
+    vi.useFakeTimers();
+    const resPromise = worker.fetch(
+      new Request(`https://api.example/api/reports?event=${'a'.repeat(64)}`, {
+        headers: { 'X-Admin-Key': 'test-admin-key' },
+      }),
+      reportsEnv,
+      ctx,
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    const sock = FakeRelaySocket.instances[0];
+    expect(sock).toBeDefined();
+    // The filter really is the targeted one, not the bulk window.
+    expect(JSON.parse(sock.sent[0])[2]['#e']).toEqual([ 'a'.repeat(64) ]);
+    sock.message(['EVENT', sock.subId(), EVENT_A]);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    const res = await resPromise;
+    expect(res.status).toBe(502);
+    const body = await res.json() as { success: boolean; events?: unknown[] };
+    expect(body.success).toBe(false);
+    // Not handed back as a find: an unconfirmed hit must not read as "found".
+    expect(body.events).toBeUndefined();
+  });
+
+  // The complement, so the 502 above is not just "targeted lookups always
+  // fail": an EOSE-confirmed targeted hit is still a find.
+  it('returns the event for a targeted lookup the relay confirmed', async () => {
+    const resPromise = worker.fetch(
+      new Request(`https://api.example/api/reports?event=${'a'.repeat(64)}`, {
+        headers: { 'X-Admin-Key': 'test-admin-key' },
+      }),
+      reportsEnv,
+      ctx,
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    const sock = FakeRelaySocket.instances[0];
+    expect(sock).toBeDefined();
+    sock.message(['EVENT', sock.subId(), EVENT_A]);
+    sock.message(['EOSE', sock.subId()]);
+
+    const res = await resPromise;
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean; events: unknown[] };
+    expect(body.success).toBe(true);
+    expect(body.events).toHaveLength(1);
+  });
+
   it('returns 502 when the relay closes before EOSE', async () => {
     const resPromise = worker.fetch(reportsRequest(), reportsEnv, ctx);
     await new Promise((r) => setTimeout(r, 0));

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1344,6 +1344,50 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
     expect(body.labelCleanupFailed).toBe(true); // but the reopen is not clean
   });
 
+  // The label read can succeed while the delete fails: a relay admin key
+  // mismatch 403s every management command but leaves reads working. The label
+  // survives and keeps the report hidden, so this reopen is no cleaner than a
+  // failed read and must not report one.
+  it('flags labelCleanupFailed when the label is found but banevent fails', async () => {
+    const db = {
+      prepare: () => {
+        const stmt: Record<string, unknown> = {
+          bind: () => stmt,
+          run: async () => ({ success: true, meta: { changes: 2 } }),
+          first: async () => null,
+          all: async () => ({ results: [] }),
+        };
+        return stmt;
+      },
+    };
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const resPromise = worker.fetch(
+      new Request(`https://api.example/api/decisions/${'a'.repeat(64)}`, {
+        method: 'DELETE',
+        headers: { 'X-Admin-Key': 'test-admin-key' },
+      }),
+      // No NOSTR_NSEC, so the NIP-86 banevent cannot be signed and fails.
+      { ...(reportsEnv as object), DB: db } as never,
+      ctx,
+    );
+
+    // Both label queries return a label and complete cleanly; only the delete fails.
+    for (let i = 0; i < 2; i++) {
+      await new Promise((r) => setTimeout(r, 0));
+      const sock = FakeRelaySocket.instances[i];
+      if (!sock) break;
+      sock.message(['EVENT', sock.subId(), LABEL_A]);
+      sock.message(['EOSE', sock.subId()]);
+    }
+
+    const res = await resPromise;
+    const body = await res.json() as { success: boolean; labelsDeleted: number; labelCleanupFailed: boolean };
+    expect(body.labelsDeleted).toBe(0); // nothing was actually removed
+    expect(body.labelCleanupFailed).toBe(true);
+  });
+
   it('returns 502 when the relay closes before EOSE on resolution labels', async () => {
     const resPromise = worker.fetch(labelsRequest(), reportsEnv, ctx);
     await new Promise((r) => setTimeout(r, 0));

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1516,6 +1516,91 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
     expect(body.labelCleanupFailed).toBe(true); // and the read is still reported incomplete
   });
 
+  // publishLabel writes exactly one target tag -- 'e' for an event, 'p' for a
+  // pubkey, never both -- so of the two filters the worker runs, one can never
+  // match. That was harmless when a stalled read was an empty success; now that
+  // it is a failure, a stall on the dead filter reports a failed cleanup and
+  // tells the moderator to retry something that cannot help. Naming the target
+  // type removes the query that was never going to match.
+  it('queries only the filter that can match when the target type is known', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ result: true }), { status: 200 })
+    ));
+
+    const resPromise = worker.fetch(
+      new Request(`https://api.example/api/decisions/${'a'.repeat(64)}?targetType=event`, {
+        method: 'DELETE',
+        headers: { 'X-Admin-Key': 'test-admin-key' },
+      }),
+      { ...(reportsEnv as object), DB: reopenDb(), NOSTR_NSEC: TEST_NSEC } as never,
+      ctx,
+    );
+    for (let t = 0; t < 100 && !FakeRelaySocket.instances[0]; t++) {
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    const sock = FakeRelaySocket.instances[0];
+    expect(sock).toBeDefined();
+    sock.message(['EOSE', sock.subId()]);
+
+    const res = await resPromise;
+    const body = await res.json() as { labelCleanupFailed: boolean };
+    expect(body.labelCleanupFailed).toBe(false);
+    // One socket, and it asked about the e-tag.
+    expect(FakeRelaySocket.instances).toHaveLength(1);
+    expect(JSON.parse(sock.sent[0])[2]['#e']).toEqual([ 'a'.repeat(64) ]);
+  });
+
+  it('queries the pubkey filter alone for a pubkey target', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ result: true }), { status: 200 })
+    ));
+
+    const resPromise = worker.fetch(
+      new Request(`https://api.example/api/decisions/${'a'.repeat(64)}?targetType=pubkey`, {
+        method: 'DELETE',
+        headers: { 'X-Admin-Key': 'test-admin-key' },
+      }),
+      { ...(reportsEnv as object), DB: reopenDb(), NOSTR_NSEC: TEST_NSEC } as never,
+      ctx,
+    );
+    for (let t = 0; t < 100 && !FakeRelaySocket.instances[0]; t++) {
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    const sock = FakeRelaySocket.instances[0];
+    expect(sock).toBeDefined();
+    sock.message(['EOSE', sock.subId()]);
+
+    await resPromise;
+    expect(FakeRelaySocket.instances).toHaveLength(1);
+    expect(JSON.parse(sock.sent[0])[2]['#p']).toEqual([ 'a'.repeat(64) ]);
+  });
+
+  // Worker and Pages deploy separately, so a new worker serves an old frontend
+  // that sends no targetType. It must keep checking both tags rather than
+  // guessing one and silently skipping the labels that matter.
+  it('still queries both filters when the target type is not given', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ result: true }), { status: 200 })
+    ));
+
+    const resPromise = worker.fetch(
+      reopenRequest(),
+      { ...(reportsEnv as object), DB: reopenDb(), NOSTR_NSEC: TEST_NSEC } as never,
+      ctx,
+    );
+    for (let i = 0; i < 2; i++) {
+      for (let t = 0; t < 100 && !FakeRelaySocket.instances[i]; t++) {
+        await new Promise((r) => setTimeout(r, 0));
+      }
+      const sock = FakeRelaySocket.instances[i];
+      expect(sock).toBeDefined();
+      sock.message(['EOSE', sock.subId()]);
+    }
+
+    await resPromise;
+    expect(FakeRelaySocket.instances).toHaveLength(2);
+  });
+
   // Each failure path carries its events independently, so each is pinned
   // independently. The timeout is the one this branch is named for.
   it('bans a label received before the read timed out', async () => {

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1727,6 +1727,41 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
     expect(body.labelCleanupFailed).toBe(true);
   });
 
+  // The same window exists on the success path, and it is the common one: the
+  // worker sends REQ and never CLOSE, so between EOSE and the socket actually
+  // closing the relay can stream a newly published matching label. Counting it
+  // would ban a label the read never reported.
+  it('does not ban a label that arrived after EOSE', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ result: true }), { status: 200 })
+    ));
+    const LATE_LABEL = { ...LABEL_A, id: 'd'.repeat(64) };
+
+    const resPromise = worker.fetch(
+      reopenRequest(),
+      { ...(reportsEnv as object), DB: reopenDb(), NOSTR_NSEC: TEST_NSEC } as never,
+      ctx,
+    );
+    for (let i = 0; i < 2; i++) {
+      for (let t = 0; t < 100 && !FakeRelaySocket.instances[i]; t++) {
+        await new Promise((r) => setTimeout(r, 0));
+      }
+      const sock = FakeRelaySocket.instances[i];
+      expect(sock).toBeDefined();
+      if (i === 0) {
+        sock.message(['EVENT', sock.subId(), LABEL_A]);
+        sock.message(['EOSE', sock.subId()]);
+        sock.message(['EVENT', sock.subId(), LATE_LABEL]); // too late to count
+      } else {
+        sock.message(['EOSE', sock.subId()]);
+      }
+    }
+
+    const res = await resPromise;
+    const body = await res.json() as { labelsDeleted: number };
+    expect(body.labelsDeleted).toBe(1);
+  });
+
   // The message listener has no resolved-guard, so a frame can still arrive
   // after a failure path has handed its events to the caller. Handing back the
   // live array would let that late frame join a set the caller is already

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1284,6 +1284,26 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
     expect(body.error).toMatch(/timed out/i);
   });
 
+  // NIP-01 CLOSED is how a relay says it refused or killed the subscription.
+  // funnelcake sends "error: could not complete query" when its store fails a
+  // query, which is exactly the incident behind this fix. Waiting out the 5s
+  // timeout on a failure the relay already reported is both slow and mislabeled.
+  it('fails immediately with the relay reason when the subscription is CLOSED', async () => {
+    vi.useFakeTimers();
+    const resPromise = worker.fetch(reportsRequest(), reportsEnv, ctx);
+    await vi.advanceTimersByTimeAsync(0);
+    const sock = FakeRelaySocket.instances[0];
+    expect(sock).toBeDefined();
+    sock.message(['CLOSED', sock.subId(), 'error: could not complete query']);
+    // Resolves without needing the 5s timer to run down.
+    const res = await resPromise;
+    expect(res.status).toBe(502);
+    const body = await res.json() as { success: boolean; error?: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/could not complete query/i);
+    expect(body.error).not.toMatch(/timed out/i); // reported as what the relay said
+  });
+
   // A reopen deletes the D1 decisions unconditionally, but clearing the relay's
   // resolution labels is best-effort. When that read fails the label survives and
   // keeps the report hidden, so the response has to say so or the UI reports a

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1344,12 +1344,8 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
     expect(body.labelCleanupFailed).toBe(true); // but the reopen is not clean
   });
 
-  // The label read can succeed while the delete fails: a relay admin key
-  // mismatch 403s every management command but leaves reads working. The label
-  // survives and keeps the report hidden, so this reopen is no cleaner than a
-  // failed read and must not report one.
-  it('flags labelCleanupFailed when the label is found but banevent fails', async () => {
-    const db = {
+  function reopenDb() {
+    return {
       prepare: () => {
         const stmt: Record<string, unknown> = {
           bind: () => stmt,
@@ -1360,31 +1356,95 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
         return stmt;
       },
     };
+  }
+
+  // Each label filter opens its own socket, and the second only exists after the
+  // first query resolves. Polling for it keeps the feed from racing ahead.
+  async function feedLabelToEachFilter() {
+    for (let i = 0; i < 2; i++) {
+      for (let t = 0; t < 100 && !FakeRelaySocket.instances[i]; t++) {
+        await new Promise((r) => setTimeout(r, 0));
+      }
+      const sock = FakeRelaySocket.instances[i];
+      expect(sock).toBeDefined();
+      sock.message(['EVENT', sock.subId(), LABEL_A]);
+      sock.message(['EOSE', sock.subId()]);
+    }
+  }
+
+  const reopenRequest = () => new Request(`https://api.example/api/decisions/${'a'.repeat(64)}`, {
+    method: 'DELETE',
+    headers: { 'X-Admin-Key': 'test-admin-key' },
+  });
+
+  // The label read can succeed while the delete fails. A relay admin key
+  // mismatch 403s every management command but leaves reads working, and that
+  // refusal does NOT throw: the RPC comes back success:false. The label
+  // survives and keeps the report hidden, so this reopen is no cleaner than a
+  // failed read and must not report one.
+  it('flags labelCleanupFailed when the label is found but banevent is refused', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Signing succeeds; the relay refuses the management command.
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('forbidden', { status: 403 })));
 
     const resPromise = worker.fetch(
-      new Request(`https://api.example/api/decisions/${'a'.repeat(64)}`, {
-        method: 'DELETE',
-        headers: { 'X-Admin-Key': 'test-admin-key' },
-      }),
-      // No NOSTR_NSEC, so the NIP-86 banevent cannot be signed and fails.
-      { ...(reportsEnv as object), DB: db } as never,
+      reopenRequest(),
+      { ...(reportsEnv as object), DB: reopenDb(), NOSTR_NSEC: TEST_NSEC } as never,
       ctx,
     );
+    await feedLabelToEachFilter();
 
-    // Both label queries return a label and complete cleanly; only the delete fails.
+    const res = await resPromise;
+    const body = await res.json() as { labelsDeleted: number; labelCleanupFailed: boolean };
+    expect(body.labelsDeleted).toBe(0); // nothing was actually removed
+    expect(body.labelCleanupFailed).toBe(true);
+  });
+
+  // Events arrive off the wire unvalidated, so a label with no id reaches the
+  // cleanup loop. It cannot be banned, so it survives exactly like a refused
+  // delete and must not report a clean reopen either.
+  it('flags labelCleanupFailed when a resolution label has no id to ban', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { id: _dropped, ...LABEL_WITHOUT_ID } = LABEL_A;
+
+    const resPromise = worker.fetch(
+      reopenRequest(),
+      { ...(reportsEnv as object), DB: reopenDb(), NOSTR_NSEC: TEST_NSEC } as never,
+      ctx,
+    );
     for (let i = 0; i < 2; i++) {
-      await new Promise((r) => setTimeout(r, 0));
+      for (let t = 0; t < 100 && !FakeRelaySocket.instances[i]; t++) {
+        await new Promise((r) => setTimeout(r, 0));
+      }
       const sock = FakeRelaySocket.instances[i];
-      if (!sock) break;
-      sock.message(['EVENT', sock.subId(), LABEL_A]);
+      expect(sock).toBeDefined();
+      sock.message(['EVENT', sock.subId(), LABEL_WITHOUT_ID]);
       sock.message(['EOSE', sock.subId()]);
     }
 
     const res = await resPromise;
-    const body = await res.json() as { success: boolean; labelsDeleted: number; labelCleanupFailed: boolean };
-    expect(body.labelsDeleted).toBe(0); // nothing was actually removed
+    const body = await res.json() as { labelsDeleted: number; labelCleanupFailed: boolean };
+    expect(body.labelsDeleted).toBe(0);
+    expect(body.labelCleanupFailed).toBe(true);
+  });
+
+  // The other way the delete can fail: signing itself throws, so the RPC never
+  // gets made. Reaches the flag through the catch rather than the refusal
+  // branch, which is why both cases are pinned separately.
+  it('flags labelCleanupFailed when the banevent call throws', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const resPromise = worker.fetch(
+      reopenRequest(),
+      // No NOSTR_NSEC, so the banevent cannot be signed at all.
+      { ...(reportsEnv as object), DB: reopenDb() } as never,
+      ctx,
+    );
+    await feedLabelToEachFilter();
+
+    const res = await resPromise;
+    const body = await res.json() as { labelsDeleted: number; labelCleanupFailed: boolean };
+    expect(body.labelsDeleted).toBe(0);
     expect(body.labelCleanupFailed).toBe(true);
   });
 

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1157,7 +1157,7 @@ describe('scheduled cron — DB-unavailable alert', () => {
 // API returns 502 and the frontend keeps its last good data. Surfaced by a
 // slow staging backend, but any relay answer past the timeout does the same
 // in production.
-describe('/api/reports relay-query integrity', () => {
+describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', () => {
   class FakeRelaySocket {
     static instances: FakeRelaySocket[] = [];
     url: string;
@@ -1190,8 +1190,13 @@ describe('/api/reports relay-query integrity', () => {
     headers: { 'X-Admin-Key': 'test-admin-key' },
   });
 
+  const labelsRequest = () => new Request('https://api.example/api/resolution-labels', {
+    headers: { 'X-Admin-Key': 'test-admin-key' },
+  });
+
   const EVENT_A = { id: 'a'.repeat(64), kind: 1984, pubkey: 'b'.repeat(64), tags: [], content: '', sig: 'c'.repeat(128), created_at: 1 };
   const EVENT_B = { id: 'd'.repeat(64), kind: 1984, pubkey: 'b'.repeat(64), tags: [], content: '', sig: 'c'.repeat(128), created_at: 2 };
+  const LABEL_A = { id: 'e'.repeat(64), kind: 1985, pubkey: 'f'.repeat(64), tags: [['L', 'moderation/resolution']], content: '', sig: 'c'.repeat(128), created_at: 3 };
 
   beforeEach(() => {
     FakeRelaySocket.instances = [];
@@ -1239,6 +1244,52 @@ describe('/api/reports relay-query integrity', () => {
     const sock = FakeRelaySocket.instances[0];
     expect(sock).toBeDefined();
     sock.message(['EVENT', sock.subId(), EVENT_A]);
+    sock.emit('close', {});
+    const res = await resPromise;
+    expect(res.status).toBe(502);
+    const body = await res.json() as { success: boolean; error?: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/closed before/i);
+  });
+
+  // /api/resolution-labels feeds the queue's resolvedTargets set, which decides
+  // whether a handled target stays hidden. A truncated read here is worse than
+  // an error: it silently re-presents resolved work as pending (#221).
+  it('returns labels on an EOSE-complete result', async () => {
+    const resPromise = worker.fetch(labelsRequest(), reportsEnv, ctx);
+    await new Promise((r) => setTimeout(r, 0));
+    const sock = FakeRelaySocket.instances[0];
+    expect(sock).toBeDefined();
+    sock.message(['EVENT', sock.subId(), LABEL_A]);
+    sock.message(['EOSE', sock.subId()]);
+    const res = await resPromise;
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean; events: unknown[] };
+    expect(body.success).toBe(true);
+    expect(body.events).toHaveLength(1);
+  });
+
+  it('returns 502 when the resolution-label query times out before EOSE', async () => {
+    vi.useFakeTimers();
+    const resPromise = worker.fetch(labelsRequest(), reportsEnv, ctx);
+    await vi.advanceTimersByTimeAsync(0);
+    const sock = FakeRelaySocket.instances[0];
+    expect(sock).toBeDefined();
+    sock.message(['EVENT', sock.subId(), LABEL_A]); // partial labels arrived, then the relay stalls
+    await vi.advanceTimersByTimeAsync(5000);
+    const res = await resPromise;
+    expect(res.status).toBe(502);
+    const body = await res.json() as { success: boolean; error?: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/timed out/i);
+  });
+
+  it('returns 502 when the relay closes before EOSE on resolution labels', async () => {
+    const resPromise = worker.fetch(labelsRequest(), reportsEnv, ctx);
+    await new Promise((r) => setTimeout(r, 0));
+    const sock = FakeRelaySocket.instances[0];
+    expect(sock).toBeDefined();
+    sock.message(['EVENT', sock.subId(), LABEL_A]);
     sock.emit('close', {});
     const res = await resPromise;
     expect(res.status).toBe(502);

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1304,6 +1304,47 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
     expect(body.error).not.toMatch(/timed out/i); // reported as what the relay said
   });
 
+  // Every exit clears the timeout and marks itself resolved before closing the
+  // socket, so if close() throws there is nothing left to settle the promise:
+  // queryRelay hangs forever and /api/reports never answers, stalling the
+  // moderator's poll until the client's 30s abort. Two of these exits sit
+  // inside the message listener's parse-error catch, so the throw is swallowed
+  // and there is not even a log. Resolving before closing removes the class.
+  describe('settles even when the socket refuses to close', () => {
+    const breakClose = (sock: FakeRelaySocket) => {
+      sock.close = () => { throw new Error('close failed'); };
+    };
+
+    it('on EOSE', async () => {
+      const resPromise = worker.fetch(reportsRequest(), reportsEnv, ctx);
+      await new Promise((r) => setTimeout(r, 0));
+      const sock = FakeRelaySocket.instances[0];
+      breakClose(sock);
+      sock.message(['EVENT', sock.subId(), EVENT_A]);
+      sock.message(['EOSE', sock.subId()]);
+      expect((await resPromise).status).toBe(200);
+    });
+
+    it('on CLOSED', async () => {
+      const resPromise = worker.fetch(reportsRequest(), reportsEnv, ctx);
+      await new Promise((r) => setTimeout(r, 0));
+      const sock = FakeRelaySocket.instances[0];
+      breakClose(sock);
+      sock.message(['CLOSED', sock.subId(), 'error: could not complete query']);
+      expect((await resPromise).status).toBe(502);
+    });
+
+    it('on timeout', async () => {
+      vi.useFakeTimers();
+      const resPromise = worker.fetch(reportsRequest(), reportsEnv, ctx);
+      await vi.advanceTimersByTimeAsync(0);
+      const sock = FakeRelaySocket.instances[0];
+      breakClose(sock);
+      await vi.advanceTimersByTimeAsync(5000);
+      expect((await resPromise).status).toBe(502);
+    });
+  });
+
   // The subscription id is what makes CLOSED ours. A relay multiplexes frames
   // for every open subscription down one socket, so an unmatched CLOSED must
   // not end a query that is still legitimately running.

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1884,11 +1884,20 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
   });
 
   // A frame can still arrive after a failure path has handed its events to the
-  // caller: the socket is closing, not closed. The message listener's
-  // resolved-guard is what stops that late label joining a set the caller is
-  // already iterating and banning -- a label the read never reported and never
-  // counted. Pinned on the failure path as well as the success path below,
-  // because the guard is one line and covers both.
+  // caller: the socket is closing, not closed. Two independent things stop that
+  // late label joining a set the caller is already iterating and banning, and on
+  // this path either alone suffices -- the message listener's resolved-guard
+  // blocks the push, and all four socket failure exits (timeout, CLOSED, error,
+  // close) resolve with `events.slice()`, a snapshot the late frame cannot
+  // reach. The outer catch carries no events at all; it fires before the array
+  // is in scope.
+  //
+  // So this test dies only to the conjunction: drop the guard and it passes,
+  // drop the slice and it passes, drop both and it fails. The after-EOSE case
+  // ABOVE is the guard's sole-custody pin, because the success exit hands back
+  // the live `events` array and the snapshot is not there to cover it. Neither
+  // mechanism is redundant: removing the copies would leave the guard as the
+  // only thing standing between a late frame and the caller's set.
   it('does not ban a label that arrived after the read had already failed', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.stubGlobal('fetch', vi.fn(async () =>

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1827,10 +1827,12 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
     expect(body.labelsDeleted).toBe(1);
   });
 
-  // The message listener has no resolved-guard, so a frame can still arrive
-  // after a failure path has handed its events to the caller. Handing back the
-  // live array would let that late frame join a set the caller is already
-  // iterating and banning -- a label the caller never saw in its own count.
+  // A frame can still arrive after a failure path has handed its events to the
+  // caller: the socket is closing, not closed. The message listener's
+  // resolved-guard is what stops that late label joining a set the caller is
+  // already iterating and banning -- a label the read never reported and never
+  // counted. Pinned on the failure path as well as the success path below,
+  // because the guard is one line and covers both.
   it('does not ban a label that arrived after the read had already failed', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.stubGlobal('fetch', vi.fn(async () =>

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1861,9 +1861,9 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
       ctx,
     );
     for (let i = 0; i < 2; i++) {
-      // A full page means 200 sequential banevent round-trips before the second
-      // filter opens its socket, so this wait needs a far bigger budget than
-      // the single-label cases above.
+      // A full page means LABEL_CLEANUP_LIMIT sequential banevent round-trips
+      // before the second filter opens its socket, so this wait needs a far
+      // bigger budget than the single-label cases above.
       for (let t = 0; t < 5000 && !FakeRelaySocket.instances[i]; t++) {
         await new Promise((r) => setTimeout(r, 0));
       }

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1284,6 +1284,46 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
     expect(body.error).toMatch(/timed out/i);
   });
 
+  // A reopen deletes the D1 decisions unconditionally, but clearing the relay's
+  // resolution labels is best-effort. When that read fails the label survives and
+  // keeps the report hidden, so the response has to say so or the UI reports a
+  // clean reopen that did not happen.
+  it('flags labelCleanupFailed when the resolution-label query fails during a reopen', async () => {
+    const db = {
+      prepare: () => {
+        const stmt: Record<string, unknown> = {
+          bind: () => stmt,
+          run: async () => ({ success: true, meta: { changes: 3 } }),
+          first: async () => null,
+          all: async () => ({ results: [] }),
+        };
+        return stmt;
+      },
+    };
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const resPromise = worker.fetch(
+      new Request(`https://api.example/api/decisions/${'a'.repeat(64)}`, {
+        method: 'DELETE',
+        headers: { 'X-Admin-Key': 'test-admin-key' },
+      }),
+      { ...(reportsEnv as object), DB: db } as never,
+      ctx,
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    // Both label filters close before EOSE, so neither cleanup can run.
+    for (const sock of FakeRelaySocket.instances) sock.emit('close', {});
+    await new Promise((r) => setTimeout(r, 0));
+    for (const sock of FakeRelaySocket.instances) sock.emit('close', {});
+
+    const res = await resPromise;
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean; deleted: number; labelCleanupFailed: boolean };
+    expect(body.success).toBe(true);
+    expect(body.deleted).toBe(3); // the decisions really were deleted
+    expect(body.labelCleanupFailed).toBe(true); // but the reopen is not clean
+  });
+
   it('returns 502 when the relay closes before EOSE on resolution labels', async () => {
     const resPromise = worker.fetch(labelsRequest(), reportsEnv, ctx);
     await new Promise((r) => setTimeout(r, 0));

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1150,3 +1150,100 @@ describe('scheduled cron — DB-unavailable alert', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 });
+
+// A relay whose backing store is slow or dying must not make the moderation
+// queue render as legitimately empty. queryRelay() may only report success on
+// an EOSE-complete result; timeout and close-before-EOSE are errors so the
+// API returns 502 and the frontend keeps its last good data. Surfaced by a
+// slow staging backend, but any relay answer past the timeout does the same
+// in production.
+describe('/api/reports relay-query integrity', () => {
+  class FakeRelaySocket {
+    static instances: FakeRelaySocket[] = [];
+    url: string;
+    sent: string[] = [];
+    private listeners: Record<string, ((ev: unknown) => void)[]> = {};
+    constructor(url: string) {
+      this.url = url;
+      FakeRelaySocket.instances.push(this);
+      queueMicrotask(() => this.emit('open', {}));
+    }
+    addEventListener(type: string, cb: (ev: unknown) => void) {
+      (this.listeners[type] ??= []).push(cb);
+    }
+    send(data: string) { this.sent.push(data); }
+    close() { queueMicrotask(() => this.emit('close', {})); }
+    emit(type: string, ev: unknown) {
+      for (const cb of this.listeners[type] ?? []) cb(ev);
+    }
+    subId(): string { return JSON.parse(this.sent[0])[1] as string; }
+    message(payload: unknown) { this.emit('message', { data: JSON.stringify(payload) }); }
+  }
+
+  const reportsEnv = {
+    ALLOWED_ORIGINS: 'https://app.divine.video',
+    RELAY_URL: 'wss://relay.example',
+    ADMIN_API_KEY: 'test-admin-key',
+  } as never;
+
+  const reportsRequest = () => new Request('https://api.example/api/reports', {
+    headers: { 'X-Admin-Key': 'test-admin-key' },
+  });
+
+  const EVENT_A = { id: 'a'.repeat(64), kind: 1984, pubkey: 'b'.repeat(64), tags: [], content: '', sig: 'c'.repeat(128), created_at: 1 };
+  const EVENT_B = { id: 'd'.repeat(64), kind: 1984, pubkey: 'b'.repeat(64), tags: [], content: '', sig: 'c'.repeat(128), created_at: 2 };
+
+  beforeEach(() => {
+    FakeRelaySocket.instances = [];
+    vi.stubGlobal('WebSocket', FakeRelaySocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('returns events on an EOSE-complete result', async () => {
+    const resPromise = worker.fetch(reportsRequest(), reportsEnv, ctx);
+    await new Promise((r) => setTimeout(r, 0));
+    const sock = FakeRelaySocket.instances[0];
+    expect(sock).toBeDefined();
+    sock.message(['EVENT', sock.subId(), EVENT_A]);
+    sock.message(['EVENT', sock.subId(), EVENT_B]);
+    sock.message(['EOSE', sock.subId()]);
+    const res = await resPromise;
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean; events: unknown[] };
+    expect(body.success).toBe(true);
+    expect(body.events).toHaveLength(2);
+  });
+
+  it('returns 502 when the relay query times out before EOSE (partial data must not read as an empty queue)', async () => {
+    vi.useFakeTimers();
+    const resPromise = worker.fetch(reportsRequest(), reportsEnv, ctx);
+    await vi.advanceTimersByTimeAsync(0);
+    const sock = FakeRelaySocket.instances[0];
+    expect(sock).toBeDefined();
+    sock.message(['EVENT', sock.subId(), EVENT_A]); // partial data arrived, then the relay stalls
+    await vi.advanceTimersByTimeAsync(5000);
+    const res = await resPromise;
+    expect(res.status).toBe(502);
+    const body = await res.json() as { success: boolean; error?: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/timed out/i);
+  });
+
+  it('returns 502 when the relay closes before EOSE', async () => {
+    const resPromise = worker.fetch(reportsRequest(), reportsEnv, ctx);
+    await new Promise((r) => setTimeout(r, 0));
+    const sock = FakeRelaySocket.instances[0];
+    expect(sock).toBeDefined();
+    sock.message(['EVENT', sock.subId(), EVENT_A]);
+    sock.emit('close', {});
+    const res = await resPromise;
+    expect(res.status).toBe(502);
+    const body = await res.json() as { success: boolean; error?: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/closed before/i);
+  });
+});

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1304,6 +1304,38 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
     expect(body.error).not.toMatch(/timed out/i); // reported as what the relay said
   });
 
+  // The subscription id is what makes CLOSED ours. A relay multiplexes frames
+  // for every open subscription down one socket, so an unmatched CLOSED must
+  // not end a query that is still legitimately running.
+  it('ignores a CLOSED naming a different subscription', async () => {
+    vi.useFakeTimers();
+    const resPromise = worker.fetch(reportsRequest(), reportsEnv, ctx);
+    await vi.advanceTimersByTimeAsync(0);
+    const sock = FakeRelaySocket.instances[0];
+    expect(sock).toBeDefined();
+    sock.message(['CLOSED', 'some-other-subscription', 'error: could not complete query']);
+    // Still running: only the 5s timeout ends it, and it ends as a timeout.
+    await vi.advanceTimersByTimeAsync(5000);
+    const res = await resPromise;
+    const body = await res.json() as { error?: string };
+    expect(body.error).toMatch(/timed out/i);
+    expect(body.error).not.toMatch(/closed the subscription/i);
+  });
+
+  // NIP-01 makes the CLOSED message a required field, but a relay that sends an
+  // empty one must still produce a readable error rather than "undefined".
+  it('reports a CLOSED with no reason as an unexplained close', async () => {
+    const resPromise = worker.fetch(reportsRequest(), reportsEnv, ctx);
+    await new Promise((r) => setTimeout(r, 0));
+    const sock = FakeRelaySocket.instances[0];
+    expect(sock).toBeDefined();
+    sock.message(['CLOSED', sock.subId()]);
+    const res = await resPromise;
+    expect(res.status).toBe(502);
+    const body = await res.json() as { error?: string };
+    expect(body.error).toMatch(/no reason given/i);
+  });
+
   // A reopen deletes the D1 decisions unconditionally, but clearing the relay's
   // resolution labels is best-effort. When that read fails the label survives and
   // keeps the report hidden, so the response has to say so or the UI reports a
@@ -1446,6 +1478,42 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
     const body = await res.json() as { labelsDeleted: number; labelCleanupFailed: boolean };
     expect(body.labelsDeleted).toBe(0);
     expect(body.labelCleanupFailed).toBe(true);
+  });
+
+  // An incomplete read is not an empty one. Before this PR a timeout resolved
+  // success:true with whatever had arrived, so the cleanup banned those labels;
+  // treating the read as a failure must not also throw them away, because the
+  // D1 delete below runs either way. A label received and left alive keeps the
+  // report hidden, so discarding it makes reopen strictly worse than not
+  // changing queryRelay at all.
+  it('bans the resolution labels it received even when the read did not complete', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ result: true }), { status: 200 })
+    ));
+
+    const resPromise = worker.fetch(
+      reopenRequest(),
+      { ...(reportsEnv as object), DB: reopenDb(), NOSTR_NSEC: TEST_NSEC } as never,
+      ctx,
+    );
+
+    // First filter delivers a label, then the socket drops before EOSE.
+    // Second filter closes empty. Neither read completed.
+    for (let i = 0; i < 2; i++) {
+      for (let t = 0; t < 100 && !FakeRelaySocket.instances[i]; t++) {
+        await new Promise((r) => setTimeout(r, 0));
+      }
+      const sock = FakeRelaySocket.instances[i];
+      expect(sock).toBeDefined();
+      if (i === 0) sock.message(['EVENT', sock.subId(), LABEL_A]);
+      sock.emit('close', {});
+    }
+
+    const res = await resPromise;
+    const body = await res.json() as { labelsDeleted: number; labelCleanupFailed: boolean };
+    expect(body.labelsDeleted).toBe(1); // the label that arrived was still removed
+    expect(body.labelCleanupFailed).toBe(true); // and the read is still reported incomplete
   });
 
   it('returns 502 when the relay closes before EOSE on resolution labels', async () => {

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1575,6 +1575,44 @@ describe('bulk relay-query integrity (/api/reports, /api/resolution-labels)', ()
     expect(JSON.parse(sock.sent[0])[2]['#p']).toEqual([ 'a'.repeat(64) ]);
   });
 
+  // The whitelist at the route is load-bearing, not defensive tidiness. An
+  // unrecognised value must fall back to both filters, because the alternative
+  // -- trusting the raw string -- indexes the tag map with a miss and builds a
+  // filter keyed "undefined". That is an UNTARGETED query: the relay ignores
+  // the unknown key and returns resolution labels for arbitrary targets, which
+  // the cleanup loop then bans. One reopen would wipe resolution labels
+  // queue-wide and still report success.
+  it('falls back to both filters when the target type is not a recognised value', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ result: true }), { status: 200 })
+    ));
+
+    const resPromise = worker.fetch(
+      new Request(`https://api.example/api/decisions/${'a'.repeat(64)}?targetType=EVENT`, {
+        method: 'DELETE',
+        headers: { 'X-Admin-Key': 'test-admin-key' },
+      }),
+      { ...(reportsEnv as object), DB: reopenDb(), NOSTR_NSEC: TEST_NSEC } as never,
+      ctx,
+    );
+    for (let i = 0; i < 2; i++) {
+      for (let t = 0; t < 100 && !FakeRelaySocket.instances[i]; t++) {
+        await new Promise((r) => setTimeout(r, 0));
+      }
+      const sock = FakeRelaySocket.instances[i];
+      expect(sock).toBeDefined();
+      sock.message(['EOSE', sock.subId()]);
+    }
+
+    await resPromise;
+    expect(FakeRelaySocket.instances).toHaveLength(2);
+    const filters = FakeRelaySocket.instances.map((s) => JSON.parse(s.sent[0])[2]);
+    // Every filter is anchored to the target. None may be an open query.
+    expect(filters[0]['#e']).toEqual([ 'a'.repeat(64) ]);
+    expect(filters[1]['#p']).toEqual([ 'a'.repeat(64) ]);
+    for (const f of filters) expect(Object.keys(f)).not.toContain('undefined');
+  });
+
   // Worker and Pages deploy separately, so a new worker serves an old frontend
   // that sends no targetType. It must keep checking both tags rather than
   // guessing one and silently skipping the labels that matter.

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1723,11 +1723,30 @@ async function queryRelay(
       // partial data is worthless. A caller removing what it can (reopen's
       // label cleanup) is strictly better off acting on a received event than
       // discarding it, so the two concerns stay separate.
+
+      // Closing is best-effort cleanup, so a throw from it must not escape.
+      // Before this, close() ran BEFORE resolve() on four of the five exits: a
+      // throw then stranded the promise with the timeout already cleared and
+      // nothing left to settle it, and on the two exits inside the message
+      // listener the parse-error catch swallowed it so there was not even a
+      // log. queryRelay would hang and /api/reports would never answer.
+      //
+      // Swallowing here is what guarantees settlement; every exit also resolves
+      // before closing, which is belt-and-braces rather than load-bearing.
+      const closeQuietly = () => {
+        try {
+          ws.close();
+        } catch {
+          // Nothing to do: the read is already reported and the socket is going
+          // away with the request either way.
+        }
+      };
+
       const timeout = setTimeout(() => {
         if (!resolved) {
           resolved = true;
-          ws.close();
           resolve({ success: false, events: events.slice(), error: `Relay query timed out before EOSE (${events.length} events received)` });
+          closeQuietly();
         }
       }, 5000);
 
@@ -1749,9 +1768,9 @@ async function queryRelay(
           } else if (data[0] === 'EOSE' && data[1] === subId) {
             clearTimeout(timeout);
             resolved = true;
-            ws.close();
             // EOSE = relay confirmed end of stored events, so an empty result is real.
             resolve({ success: true, events });
+            closeQuietly();
           } else if (data[0] === 'CLOSED' && data[1] === subId) {
             // NIP-01: the relay ended the subscription instead of fulfilling it,
             // with a machine-readable reason (funnelcake sends
@@ -1761,9 +1780,9 @@ async function queryRelay(
             // 5s later than it needed to be.
             clearTimeout(timeout);
             resolved = true;
-            ws.close();
             const reason = typeof data[2] === 'string' && data[2] ? data[2] : 'no reason given';
             resolve({ success: false, events: events.slice(), error: `Relay closed the subscription: ${reason}` });
+            closeQuietly();
           }
         } catch {
           // Ignore parse errors
@@ -1774,10 +1793,8 @@ async function queryRelay(
         if (!resolved) {
           clearTimeout(timeout);
           resolved = true;
-          // Resolve first: a throw from close() would otherwise leave the
-          // promise permanently pending, with the timeout already cleared.
           resolve({ success: false, events: events.slice(), error: 'WebSocket error' });
-          ws.close();
+          closeQuietly();
         }
       });
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -349,6 +349,9 @@ interface ApiResponse {
   eventId?: string;
   deleted?: number;
   labelsDeleted?: number;
+  // Reopen could not clear every relay-side resolution label, so the report
+  // may stay hidden even though its decisions were deleted.
+  labelCleanupFailed?: boolean;
   // Realness proxy pass-through
   details?: string;
   // Zendesk parse-report responses
@@ -1452,8 +1455,16 @@ async function handleDeleteDecisions(
               const rpcResult = await rpcResponse.json() as { success: boolean };
               if (rpcResult.success) {
                 labelsDeleted++;
+              } else {
+                // The label was found but could not be removed (a relay admin
+                // key mismatch 403s every management command while reads keep
+                // working). It survives and keeps the report hidden, so this
+                // reopen is no cleaner than a failed read.
+                labelCleanupFailed = true;
+                console.warn('[reopen] banevent failed for resolution label:', eventId);
               }
             } catch (err) {
+              labelCleanupFailed = true;
               console.error('Failed to delete resolution label:', eventId, err);
             }
           }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -490,7 +490,10 @@ export default {
 
       if (path.startsWith('/api/decisions/') && request.method === 'DELETE') {
         const targetId = path.replace('/api/decisions/', '');
-        return handleDeleteDecisions(targetId, env, corsHeaders);
+        // Optional: an older frontend omits it, and then both tags are checked.
+        const rawType = url.searchParams.get('targetType');
+        const targetType = rawType === 'event' || rawType === 'pubkey' ? rawType : undefined;
+        return handleDeleteDecisions(targetId, env, corsHeaders, targetType);
       }
 
       if (path.startsWith('/api/check-result/') && request.method === 'GET') {
@@ -1412,7 +1415,8 @@ const LABEL_CLEANUP_LIMIT = 200;
 async function handleDeleteDecisions(
   targetId: string,
   env: Env,
-  corsHeaders: Record<string, string>
+  corsHeaders: Record<string, string>,
+  targetType?: 'event' | 'pubkey'
 ): Promise<Response> {
   try {
     if (!env.DB) {
@@ -1424,12 +1428,19 @@ async function handleDeleteDecisions(
     let labelsDeleted = 0;
     let labelCleanupFailed = false;
 
-    // First, query for and delete any resolution labels (kind 1985) on the relay
-    // Try both 'e' tag (event target) and 'p' tag (pubkey target)
-    const labelFilters = [
-      { kinds: [1985], '#e': [targetId], '#L': ['moderation/resolution'], limit: LABEL_CLEANUP_LIMIT },
-      { kinds: [1985], '#p': [targetId], '#L': ['moderation/resolution'], limit: LABEL_CLEANUP_LIMIT },
-    ];
+    // Query for and delete any resolution labels (kind 1985) on the relay.
+    // publishLabel tags a label with 'e' for an event target or 'p' for a
+    // pubkey target, never both, so naming the type skips a query that could
+    // not have matched. Without a type (an older frontend) both are checked:
+    // guessing wrong would silently skip the labels that do exist.
+    const tagForType = { event: '#e', pubkey: '#p' } as const;
+    const labelTags = targetType ? [tagForType[targetType]] : ['#e', '#p'];
+    const labelFilters = labelTags.map((tag) => ({
+      kinds: [1985],
+      [tag]: [targetId],
+      '#L': ['moderation/resolution'],
+      limit: LABEL_CLEANUP_LIMIT,
+    }));
 
     for (const filter of labelFilters) {
       const queryResult = await queryRelay(filter, env.RELAY_URL);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1467,6 +1467,12 @@ async function handleDeleteDecisions(
               labelCleanupFailed = true;
               console.error('Failed to delete resolution label:', eventId, err);
             }
+          } else {
+            // Events come off the wire unvalidated, so an id-less label is
+            // possible. It cannot be banned, so it survives and keeps the
+            // report hidden: the same outcome as any other failed cleanup.
+            labelCleanupFailed = true;
+            console.warn('[reopen] resolution label has no id, cannot remove it');
           }
         }
       }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1414,16 +1414,25 @@ async function handleGetDecisions(
 // Kind 1985 is a regular event, not replaceable, so review/reopen cycles
 // accumulate resolution labels on one target. A real target carries one or two,
 // so this is far above the expected count -- but it is NOT set by that. Every
-// label costs one sequential signed NIP-86 round-trip at roughly 200-400ms, so
-// the page size is the worst-case work in one reopen: ~10-20s per filter, and
-// both filters run when the client sends no targetType, so budget 2x. The
-// binding constraint is the client's 30s abort (API_TIMEOUT_MS in adminApi.ts),
-// which a cap of 200 would have blown -- aborting a reopen the worker had
-// already completed and reporting it as a failure. Subrequests are not the
-// constraint: this is Workers Paid, so the budget is 1000/request and a reopen
-// spends ~54. A full page is reported as an incomplete cleanup rather than
-// assumed complete, so a target somehow past the cap still gets cleared over
-// successive reopens instead of silently half-cleared.
+// label costs one sequential signed NIP-86 round-trip at roughly 200-400ms, and
+// each filter also spends up to the 5s queryRelay cap on its read, so a full
+// page is ~15-25s of work per filter.
+//
+// The binding constraint is the client's 30s abort (API_TIMEOUT_MS in
+// adminApi.ts): blowing it aborts a reopen the worker had already completed and
+// reports it as a failure. A cap of 200 blows it outright. 50 fits the path
+// every current caller takes, which is one filter -- ReportDetail always sends
+// targetType. It does NOT fit the two-filter fallback at the top of the range;
+// that path is reachable only by a frontend older than this deploy, and only
+// against a target carrying tens of labels.
+//
+// Subrequests are not the constraint: this is Workers Paid, so the budget is
+// 1000/request and even the two-filter worst case spends ~102 (two sockets plus
+// two full pages of bans).
+//
+// A full page is reported as an incomplete cleanup rather than assumed
+// complete, so a target somehow past the cap still gets cleared over successive
+// reopens instead of silently half-cleared.
 const LABEL_CLEANUP_LIMIT = 50;
 
 async function handleDeleteDecisions(

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -491,8 +491,13 @@ export default {
       if (path.startsWith('/api/decisions/') && request.method === 'DELETE') {
         const targetId = path.replace('/api/decisions/', '');
         // Optional: an older frontend omits it, and then both tags are checked.
+        // A present-but-unrecognised value takes the same safe path, but that
+        // means a client-side typo is invisible in production, so it is logged.
         const rawType = url.searchParams.get('targetType');
         const targetType = rawType === 'event' || rawType === 'pubkey' ? rawType : undefined;
+        if (rawType !== null && targetType === undefined) {
+          console.warn('[reopen] unrecognised targetType, querying both label tags:', rawType);
+        }
         return handleDeleteDecisions(targetId, env, corsHeaders, targetType);
       }
 
@@ -1407,10 +1412,17 @@ async function handleGetDecisions(
 }
 
 // Kind 1985 is a regular event, not replaceable, so review/reopen cycles
-// accumulate resolution labels on one target. The cap is high enough that
-// hitting it means something unusual; a full page is reported as an incomplete
-// cleanup rather than assumed complete.
-const LABEL_CLEANUP_LIMIT = 200;
+// accumulate resolution labels on one target. A real target carries one or two,
+// so this is far above the expected count -- but it is NOT set by that. Every
+// label costs a sequential signed NIP-86 round-trip, so the page size is also
+// the worst-case work in one reopen, bounded by the client's 30s timeout
+// (API_TIMEOUT_MS in adminApi.ts) and by the Workers per-request subrequest
+// budget. Exceeding either would abort a reopen the worker had already
+// completed and report it as a failure. A full page is reported as an
+// incomplete cleanup rather than assumed complete, so a target somehow past
+// the cap still gets cleared over successive reopens instead of silently
+// half-cleared.
+const LABEL_CLEANUP_LIMIT = 50;
 
 async function handleDeleteDecisions(
   targetId: string,
@@ -1713,7 +1725,7 @@ async function queryRelay(
         if (!resolved) {
           resolved = true;
           ws.close();
-          resolve({ success: false, events, error: `Relay query timed out before EOSE (${events.length} events received)` });
+          resolve({ success: false, events: events.slice(), error: `Relay query timed out before EOSE (${events.length} events received)` });
         }
       }, 5000);
 
@@ -1743,7 +1755,7 @@ async function queryRelay(
             resolved = true;
             ws.close();
             const reason = typeof data[2] === 'string' && data[2] ? data[2] : 'no reason given';
-            resolve({ success: false, events, error: `Relay closed the subscription: ${reason}` });
+            resolve({ success: false, events: events.slice(), error: `Relay closed the subscription: ${reason}` });
           }
         } catch {
           // Ignore parse errors
@@ -1754,7 +1766,8 @@ async function queryRelay(
         if (!resolved) {
           clearTimeout(timeout);
           resolved = true;
-          resolve({ success: false, events, error: 'WebSocket error' });
+          ws.close();
+          resolve({ success: false, events: events.slice(), error: 'WebSocket error' });
         }
       });
 
@@ -1763,7 +1776,7 @@ async function queryRelay(
           clearTimeout(timeout);
           resolved = true;
           // Closed before EOSE: absence is unconfirmed, so this is a failure.
-          resolve({ success: false, events, error: `Relay closed before EOSE (${events.length} events received)` });
+          resolve({ success: false, events: events.slice(), error: `Relay closed before EOSE (${events.length} events received)` });
         }
       });
     } catch (error) {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1734,11 +1734,13 @@ async function queryRelay(
       // discarding it, so the two concerns stay separate.
 
       // Closing is best-effort cleanup, so a throw from it must not escape.
-      // Before this, close() ran BEFORE resolve() on four of the five exits: a
-      // throw then stranded the promise with the timeout already cleared and
-      // nothing left to settle it, and on the two exits inside the message
-      // listener the parse-error catch swallowed it so there was not even a
-      // log. queryRelay would hang and /api/reports would never answer.
+      // Of the five exits, close() used to run BEFORE resolve() on three --
+      // timeout, EOSE and CLOSED (the error exit was reordered a commit
+      // earlier; the close exit never calls close() at all). A throw then
+      // stranded the promise with the timeout already cleared and nothing left
+      // to settle it, and on the two inside the message listener the
+      // parse-error catch swallowed it so there was not even a log. queryRelay
+      // would hang and /api/reports would never answer.
       //
       // Swallowing here is what guarantees settlement; every exit also resolves
       // before closing, which is belt-and-braces rather than load-bearing.

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1736,9 +1736,12 @@ async function queryRelay(
       const closeQuietly = () => {
         try {
           ws.close();
-        } catch {
-          // Nothing to do: the read is already reported and the socket is going
-          // away with the request either way.
+        } catch (err) {
+          // Nothing to recover: the read is already reported and the socket
+          // goes away with the request either way. Logged only because a
+          // close() that throws says something odd about the runtime rather
+          // than about the relay, and is otherwise invisible.
+          console.warn('[queryRelay] socket close threw:', err);
         }
       };
 
@@ -1803,6 +1806,8 @@ async function queryRelay(
           clearTimeout(timeout);
           resolved = true;
           // Closed before EOSE: absence is unconfirmed, so this is a failure.
+          // The only exit that does not closeQuietly() -- the socket is
+          // already closing, which is why we are here.
           resolve({ success: false, events: events.slice(), error: `Relay closed before EOSE (${events.length} events received)` });
         }
       });

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1424,6 +1424,11 @@ async function handleDeleteDecisions(
 
     for (const filter of labelFilters) {
       const queryResult = await queryRelay(filter, env.RELAY_URL);
+      if (!queryResult.success) {
+        // Best-effort cleanup: a timed-out label query means some resolution
+        // labels may survive this reopen. Log it; a later reopen retries.
+        console.warn('[reopen] resolution-label query failed, labels may remain:', queryResult.error);
+      }
       if (queryResult.success && queryResult.events && queryResult.events.length > 0) {
         for (const labelEvent of queryResult.events) {
           const eventId = (labelEvent as { id?: string }).id;
@@ -1640,12 +1645,18 @@ async function queryRelay(
       const events: object[] = [];
       const subId = `query-${Date.now()}`;
 
+      // Timeout and close-before-EOSE are failures, not results: only an
+      // EOSE-complete response may report success. A relay answering slower
+      // than this timeout must stay distinguishable from "the queue is
+      // empty", or one slow poll silently blanks the moderation queue.
+      // Known residual: a backend that kills the query but still sends an
+      // empty EOSE is indistinguishable here; that needs a relay-side error
+      // signal to fix.
       const timeout = setTimeout(() => {
         if (!resolved) {
           resolved = true;
           ws.close();
-          // Timed out without EOSE: results may be truncated, so absence is unconfirmed.
-          resolve({ success: true, events, complete: false });
+          resolve({ success: false, error: `Relay query timed out before EOSE (${events.length} events received)` });
         }
       }, 5000);
 
@@ -1682,8 +1693,8 @@ async function queryRelay(
         if (!resolved) {
           clearTimeout(timeout);
           resolved = true;
-          // Closed before EOSE: absence is unconfirmed.
-          resolve({ success: true, events, complete: false });
+          // Closed before EOSE: absence is unconfirmed, so this is a failure.
+          resolve({ success: false, error: `Relay closed before EOSE (${events.length} events received)` });
         }
       });
     } catch (error) {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1414,14 +1414,16 @@ async function handleGetDecisions(
 // Kind 1985 is a regular event, not replaceable, so review/reopen cycles
 // accumulate resolution labels on one target. A real target carries one or two,
 // so this is far above the expected count -- but it is NOT set by that. Every
-// label costs a sequential signed NIP-86 round-trip, so the page size is also
-// the worst-case work in one reopen, bounded by the client's 30s timeout
-// (API_TIMEOUT_MS in adminApi.ts) and by the Workers per-request subrequest
-// budget. Exceeding either would abort a reopen the worker had already
-// completed and report it as a failure. A full page is reported as an
-// incomplete cleanup rather than assumed complete, so a target somehow past
-// the cap still gets cleared over successive reopens instead of silently
-// half-cleared.
+// label costs one sequential signed NIP-86 round-trip at roughly 200-400ms, so
+// the page size is the worst-case work in one reopen: ~10-20s per filter, and
+// both filters run when the client sends no targetType, so budget 2x. The
+// binding constraint is the client's 30s abort (API_TIMEOUT_MS in adminApi.ts),
+// which a cap of 200 would have blown -- aborting a reopen the worker had
+// already completed and reporting it as a failure. Subrequests are not the
+// constraint: this is Workers Paid, so the budget is 1000/request and a reopen
+// spends ~54. A full page is reported as an incomplete cleanup rather than
+// assumed complete, so a target somehow past the cap still gets cleared over
+// successive reopens instead of silently half-cleared.
 const LABEL_CLEANUP_LIMIT = 50;
 
 async function handleDeleteDecisions(
@@ -1535,7 +1537,7 @@ async function handleDeleteDecisions(
       labelCleanupFailed,
     }, 200, corsHeaders);
   } catch (error) {
-    console.error('Delete decisions error:', error);
+    console.error('[reopen] delete decisions failed:', error);
     return jsonResponse(
       { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
       500,
@@ -1734,6 +1736,12 @@ async function queryRelay(
       });
 
       ws.addEventListener('message', (msg) => {
+        // Once the result is handed to the caller the set is final. We send REQ
+        // and never CLOSE, so the relay can still stream a newly published
+        // matching label between EOSE and the socket actually closing; counting
+        // it would ban a label this read never reported, and would move
+        // events.length after the truncation check read it.
+        if (resolved) return;
         try {
           const data = JSON.parse(msg.data as string);
           if (data[0] === 'EVENT' && data[1] === subId) {
@@ -1766,8 +1774,10 @@ async function queryRelay(
         if (!resolved) {
           clearTimeout(timeout);
           resolved = true;
-          ws.close();
+          // Resolve first: a throw from close() would otherwise leave the
+          // promise permanently pending, with the timeout already cleared.
           resolve({ success: false, events: events.slice(), error: 'WebSocket error' });
+          ws.close();
         }
       });
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -9,7 +9,7 @@ import {
   type SecretStoreSecret,
 } from './nip86';
 import { ensureSchema } from './db';
-import { buildReportsFilter, isUnconfirmedTargetedMiss } from './reports-filter';
+import { buildReportsFilter } from './reports-filter';
 import { generatePreAuthToken, verifyPreAuthToken, base64UrlEncode } from './zendesk-preauth';
 import { deriveFunnelcakeApiUrl, proxyFunnelcakeRequest } from './funnelcake-proxy';
 import type { KeycastEnv } from './keycast-client';
@@ -523,13 +523,12 @@ export default {
       if (path === '/api/reports' && request.method === 'GET') {
         const filter = buildReportsFilter(url.searchParams);
         const result = await queryRelay(filter, env.RELAY_URL);
+        // An unconfirmed read is now a failure inside queryRelay itself, so a
+        // targeted lookup can no longer come back empty-but-unconfirmed here:
+        // that case 502s below, and the client still shows "unavailable"
+        // rather than a false "deleted".
         if (!result.success) {
           return jsonResponse({ success: false, error: result.error }, 502, corsHeaders);
-        }
-        // A targeted lookup that came back empty but unconfirmed (relay never sent EOSE) is
-        // ambiguous — 502 so the client shows "unavailable" (retry), not a false "deleted".
-        if (isUnconfirmedTargetedMiss(url.searchParams, result)) {
-          return jsonResponse({ success: false, error: 'Relay did not confirm results (timeout)' }, 502, corsHeaders);
         }
         return jsonResponse({ success: true, events: result.events }, 200, corsHeaders);
       }
@@ -1414,6 +1413,7 @@ async function handleDeleteDecisions(
     await ensureSchemaOnce(env.DB);
 
     let labelsDeleted = 0;
+    let labelCleanupFailed = false;
 
     // First, query for and delete any resolution labels (kind 1985) on the relay
     // Try both 'e' tag (event target) and 'p' tag (pubkey target)
@@ -1425,8 +1425,12 @@ async function handleDeleteDecisions(
     for (const filter of labelFilters) {
       const queryResult = await queryRelay(filter, env.RELAY_URL);
       if (!queryResult.success) {
-        // Best-effort cleanup: a timed-out label query means some resolution
-        // labels may survive this reopen. Log it; a later reopen retries.
+        // Best-effort cleanup, but the caller has to hear about it. The D1
+        // delete below is unconditional, so a surviving resolution label
+        // leaves the report hidden by resolvedTargets even though its
+        // decisions are gone. Reporting a clean reopen would tell the
+        // moderator the report is back in the queue when it is not.
+        labelCleanupFailed = true;
         console.warn('[reopen] resolution-label query failed, labels may remain:', queryResult.error);
       }
       if (queryResult.success && queryResult.events && queryResult.events.length > 0) {
@@ -1468,6 +1472,7 @@ async function handleDeleteDecisions(
       success: true,
       deleted: result.meta.changes || 0,
       labelsDeleted,
+      labelCleanupFailed,
     }, 200, corsHeaders);
   } catch (error) {
     console.error('Delete decisions error:', error);
@@ -1637,7 +1642,7 @@ async function handleModerateMedia(
 async function queryRelay(
   filter: object,
   relayUrl: string
-): Promise<{ success: boolean; events?: object[]; error?: string; complete?: boolean }> {
+): Promise<{ success: boolean; events?: object[]; error?: string }> {
   return new Promise((resolve) => {
     try {
       const ws = new WebSocket(relayUrl);
@@ -1674,7 +1679,19 @@ async function queryRelay(
             resolved = true;
             ws.close();
             // EOSE = relay confirmed end of stored events, so an empty result is real.
-            resolve({ success: true, events, complete: true });
+            resolve({ success: true, events });
+          } else if (data[0] === 'CLOSED' && data[1] === subId) {
+            // NIP-01: the relay ended the subscription instead of fulfilling it,
+            // with a machine-readable reason (funnelcake sends
+            // "error: could not complete query" when its store fails the query).
+            // Without this branch the socket just sits until the timeout, so a
+            // failure the relay already reported gets called a timeout instead,
+            // 5s later than it needed to be.
+            clearTimeout(timeout);
+            resolved = true;
+            ws.close();
+            const reason = typeof data[2] === 'string' && data[2] ? data[2] : 'no reason given';
+            resolve({ success: false, error: `Relay closed the subscription: ${reason}` });
           }
         } catch {
           // Ignore parse errors

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1403,6 +1403,12 @@ async function handleGetDecisions(
   }
 }
 
+// Kind 1985 is a regular event, not replaceable, so review/reopen cycles
+// accumulate resolution labels on one target. The cap is high enough that
+// hitting it means something unusual; a full page is reported as an incomplete
+// cleanup rather than assumed complete.
+const LABEL_CLEANUP_LIMIT = 200;
+
 async function handleDeleteDecisions(
   targetId: string,
   env: Env,
@@ -1421,8 +1427,8 @@ async function handleDeleteDecisions(
     // First, query for and delete any resolution labels (kind 1985) on the relay
     // Try both 'e' tag (event target) and 'p' tag (pubkey target)
     const labelFilters = [
-      { kinds: [1985], '#e': [targetId], '#L': ['moderation/resolution'], limit: 10 },
-      { kinds: [1985], '#p': [targetId], '#L': ['moderation/resolution'], limit: 10 },
+      { kinds: [1985], '#e': [targetId], '#L': ['moderation/resolution'], limit: LABEL_CLEANUP_LIMIT },
+      { kinds: [1985], '#p': [targetId], '#L': ['moderation/resolution'], limit: LABEL_CLEANUP_LIMIT },
     ];
 
     for (const filter of labelFilters) {
@@ -1435,8 +1441,22 @@ async function handleDeleteDecisions(
         // moderator the report is back in the queue when it is not.
         labelCleanupFailed = true;
         console.warn('[reopen] resolution-label query failed, labels may remain:', queryResult.error);
+      } else if ((queryResult.events?.length ?? 0) >= LABEL_CLEANUP_LIMIT) {
+        // A full page is indistinguishable from a truncated one, so any labels
+        // past the cap are invisible here and would survive silently. Same
+        // outcome as a failed read, so it reports the same way.
+        //
+        // This detects our own cap, not the relay's: a relay enforcing a lower
+        // maximum returns a short page and truncation stays invisible. Raising
+        // the cap well above any plausible label count is what makes that
+        // remote, rather than this check.
+        labelCleanupFailed = true;
+        console.warn('[reopen] resolution-label read hit the page limit, labels may remain');
       }
-      if (queryResult.success && queryResult.events && queryResult.events.length > 0) {
+      // Deliberately not gated on success: an incomplete read still hands back
+      // the labels it did receive, and removing those is strictly progress.
+      // labelCleanupFailed above already records that the set may be partial.
+      if (queryResult.events && queryResult.events.length > 0) {
         for (const labelEvent of queryResult.events) {
           const eventId = (labelEvent as { id?: string }).id;
           if (eventId) {
@@ -1465,7 +1485,7 @@ async function handleDeleteDecisions(
               }
             } catch (err) {
               labelCleanupFailed = true;
-              console.error('Failed to delete resolution label:', eventId, err);
+              console.error('[reopen] banevent threw for resolution label:', eventId, err);
             }
           } else {
             // Events come off the wire unvalidated, so an id-less label is
@@ -1671,14 +1691,18 @@ async function queryRelay(
       // EOSE-complete response may report success. A relay answering slower
       // than this timeout must stay distinguishable from "the queue is
       // empty", or one slow poll silently blanks the moderation queue.
-      // Known residual: a backend that kills the query but still sends an
-      // empty EOSE is indistinguishable here; that needs a relay-side error
-      // signal to fix.
+      //
+      // Every outcome still carries the events that did arrive. `success`
+      // answers "did the relay confirm the end of the set?", which is the only
+      // question absence-sensitive callers may act on; it does not mean the
+      // partial data is worthless. A caller removing what it can (reopen's
+      // label cleanup) is strictly better off acting on a received event than
+      // discarding it, so the two concerns stay separate.
       const timeout = setTimeout(() => {
         if (!resolved) {
           resolved = true;
           ws.close();
-          resolve({ success: false, error: `Relay query timed out before EOSE (${events.length} events received)` });
+          resolve({ success: false, events, error: `Relay query timed out before EOSE (${events.length} events received)` });
         }
       }, 5000);
 
@@ -1708,7 +1732,7 @@ async function queryRelay(
             resolved = true;
             ws.close();
             const reason = typeof data[2] === 'string' && data[2] ? data[2] : 'no reason given';
-            resolve({ success: false, error: `Relay closed the subscription: ${reason}` });
+            resolve({ success: false, events, error: `Relay closed the subscription: ${reason}` });
           }
         } catch {
           // Ignore parse errors
@@ -1719,7 +1743,7 @@ async function queryRelay(
         if (!resolved) {
           clearTimeout(timeout);
           resolved = true;
-          resolve({ success: false, error: 'WebSocket error' });
+          resolve({ success: false, events, error: 'WebSocket error' });
         }
       });
 
@@ -1728,7 +1752,7 @@ async function queryRelay(
           clearTimeout(timeout);
           resolved = true;
           // Closed before EOSE: absence is unconfirmed, so this is a failure.
-          resolve({ success: false, error: `Relay closed before EOSE (${events.length} events received)` });
+          resolve({ success: false, events, error: `Relay closed before EOSE (${events.length} events received)` });
         }
       });
     } catch (error) {

--- a/worker/src/reports-filter.test.ts
+++ b/worker/src/reports-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildReportsFilter, isUnconfirmedTargetedMiss } from './reports-filter';
+import { buildReportsFilter } from './reports-filter';
 
 describe('buildReportsFilter', () => {
   it('defaults to the bulk 200 window when no target param', () => {
@@ -17,21 +17,5 @@ describe('buildReportsFilter', () => {
   it('lowercases uppercase-hex target params so the relay filter still matches', () => {
     expect(buildReportsFilter(new URLSearchParams('event=ABC123'))).toEqual({ kinds: [1984], '#e': ['abc123'], limit: 200 });
     expect(buildReportsFilter(new URLSearchParams('pubkey=DEADBEEF'))).toEqual({ kinds: [1984], '#p': ['deadbeef'], limit: 200 });
-  });
-});
-
-describe('isUnconfirmedTargetedMiss', () => {
-  it('true for a targeted empty result the relay never confirmed (timeout/close)', () => {
-    expect(isUnconfirmedTargetedMiss(new URLSearchParams('event=abc'), { events: [], complete: false })).toBe(true);
-    expect(isUnconfirmedTargetedMiss(new URLSearchParams('pubkey=def'), { events: [], complete: false })).toBe(true);
-  });
-  it('false when the relay confirmed the empty result via EOSE (a real "gone")', () => {
-    expect(isUnconfirmedTargetedMiss(new URLSearchParams('event=abc'), { events: [], complete: true })).toBe(false);
-  });
-  it('false when the targeted lookup returned results', () => {
-    expect(isUnconfirmedTargetedMiss(new URLSearchParams('event=abc'), { events: [{}], complete: false })).toBe(false);
-  });
-  it('false for a bulk request (no target param), even if unconfirmed and empty', () => {
-    expect(isUnconfirmedTargetedMiss(new URLSearchParams(''), { events: [], complete: false })).toBe(false);
   });
 });

--- a/worker/src/reports-filter.ts
+++ b/worker/src/reports-filter.ts
@@ -22,15 +22,3 @@ export function buildReportsFilter(params: URLSearchParams): {
   }
   return { kinds: [REPORT_KIND], limit: BULK_LIMIT };
 }
-
-// A targeted deep-link lookup (?event=/?pubkey=) that came back empty without the relay
-// confirming end-of-stored-events (no EOSE — a timeout or early close) is ambiguous, not
-// proof of absence. The caller should surface it as "unavailable" (retry), never as a
-// deletion. Bulk requests (no target param) are exempt: they self-correct on the next poll.
-export function isUnconfirmedTargetedMiss(
-  params: URLSearchParams,
-  result: { events?: unknown[]; complete?: boolean }
-): boolean {
-  const isTargeted = params.has('event') || params.has('pubkey');
-  return isTargeted && !result.complete && (result.events?.length ?? 0) === 0;
-}


### PR DESCRIPTION
## Summary

One slow relay response could blank the moderation queue. `queryRelay()` resolved `success: true` with whatever events had arrived when its 5 second timeout fired or the socket closed before EOSE, so the API returned an empty 200 that the UI rendered as "no reports pending." With the list polling every 15 seconds and each poll replacing data wholesale, a single slow response wiped a populated queue mid-session.

Now only an EOSE-complete result reports success, and the relay's own failure signal is honored: NIP-01 `CLOSED` fails immediately with the reason the relay gave, instead of waiting out the timeout and reporting it as something else.

## Motivation

For a moderation tool an empty queue is a load-bearing claim: it tells a moderator there is no work left. Returning a partial read as a successful one lets a slow relay make that claim falsely, and the failure is silent and self-correcting on the next poll, which is what let it survive this long.

Measured against the production relay over 45 trials, the resolution-labels query runs at p50 2831ms and p90 3177ms, with a maximum of 4595ms against the hard 5 second cap. One trial timed out and returned zero events as a success. This is not a staging-only condition; production sits close enough to the cap that ordinary variance crosses it.

Closes #185.

## An incomplete read is not an empty one

`success` now answers exactly one question: did the relay confirm the end of the set? That is the only question an absence-sensitive caller may act on, and `/api/reports` and `/api/resolution-labels` still 502 on anything less.

It does not mean the partial data is worthless, and an earlier revision of this branch conflated the two. Every failure path now carries the events that did arrive, because the one caller that removes things rather than counting them is strictly better off acting on a label it received than discarding it.

That distinction is load-bearing for reopen. `handleDeleteDecisions` deletes the D1 decision rows unconditionally while relay-side label cleanup is best-effort, so discarding the labels made a slow relay *worse* than before this branch: every reopen destroyed the decision rows, cleared no labels, and left the report hidden. On `main` the same read returned `complete: false` and the labels it saw were removed.

## Reopen stops asserting a queue state it cannot verify

`resolvedTargets` hides a report using four sources: resolution labels, banned pubkeys, banned events, and auto-hide decisions. Reopen clears two of them. Delete-event and ban-pubkey are the most common resolution paths, so a report resolved either way stays hidden after a completely successful reopen, while the toast said it was back in the queue. The tooltip made the same promise.

Both now report what the action did rather than where the report ends up, and the tooltip names the case it cannot fix.

Three narrower reopen failures close with it:

- A label read that fills its page is indistinguishable from a truncated one, so it now reports an incomplete cleanup rather than a clean reopen. The cap was 10, against an event kind that accumulates per review cycle; it is now 50, and the check is honest that it detects our own limit rather than one the relay might impose. 50 is not set by the expected label count (a real target carries one or two) but by the client's 30s abort: every label costs one sequential signed NIP-86 round-trip, so a full page is ~15-25s of work per filter.
- `publishLabel` tags a label `e` **or** `p`, never both, so of the two filters reopen ran against every target, one could never match. Harmless when a stall was an empty success; with a stall now a failure it produced a destructive "try reopening again" toast for a query that never had anything to find. The client names the type it already knows; omitting it stays valid and checks both, because worker and Pages deploy separately.
- The two deletes are sequential and the first commits server-side before the second runs, so a failure on the second left the panel rendering decisions the server no longer had.

## Resolution-state completeness belongs to #221

An earlier revision added a banner for an unavailable resolution filter. It only fired when the labels query had *never* succeeded — `placeholderData` keeps the last good set, so one success made it permanently silent, which is the shape the outage actually takes: labels load when the tool opens, then start failing mid-session.

Rather than patch the condition, the banner is gone. `fix/221-resolution-state-completeness` reports per-source truncation and coverage from the worker and gates the queue on every source, covering this case and the three sibling sources (`banned-pubkeys`, `banned-events`, `decisions`) that fail just as silently. A second competing signal in the same component would have to be reconciled or ripped out. `retry: 1` on the labels query stays; its justification never depended on the banner.

## Relay behavior, verified rather than assumed

An earlier draft recorded a residual: that a backend killing a query while still sending an empty EOSE is indistinguishable from an empty queue. Checking the relay implementation, that is not what happens — on a store failure funnelcake sends `CLOSED` with `error: could not complete query` and never sends EOSE, which is exactly the signal NIP-01 defines. The gap was on our side: `queryRelay` parsed only `EVENT` and `EOSE`, so a failure the relay had already reported sat until the timeout and was then reported as a timeout.

The residual that genuinely remains is narrower: a relay returning a truly empty EOSE after an internal failure is still indistinguishable at the protocol level. That is not the current relay behavior. (Thanks @realmeylisdev for confirming the second `stored replay timed out` path also skips EOSE and is caught by the same branch.)

## Behavior changes worth calling out

**Deep links.** A targeted `?event=`/`?pubkey=` lookup that received events and *then* timed out previously rendered as "found". It now renders "Relay unavailable". That is deliberate — a truncated targeted read is not proof of what it found — but it is a real change, and an earlier version of this description wrongly called deep-link behavior unchanged.

**Zendesk enrichment.** `handleParseReport`'s kind-0 and event lookups now get `success: false` where a close-before-EOSE previously yielded partial data. Best-effort path; the note still posts, without the display name or restored-OG-Vine flag.

## Removed

`isUnconfirmedTargetedMiss` and the `complete` field it read. Success now implies an EOSE-confirmed result, so its `!complete` branch was unreachable while its unit tests kept passing, which read as coverage for a live guard.

## API changes

`DELETE /api/decisions/:id` gains an optional `?targetType=event|pubkey` and a `labelCleanupFailed` field. Any value other than `event` or `pubkey` — including empty, wrong case, or junk — falls back to querying both tags, which is the same behavior an older frontend gets.

```jsonc
// DELETE /api/decisions/<id>?targetType=event  -> 200
{ "success": true, "deleted": 3, "labelsDeleted": 1, "labelCleanupFailed": false }

// same, when a label was found but could not be removed -> 200
{ "success": true, "deleted": 3, "labelsDeleted": 0, "labelCleanupFailed": true }

// GET /api/reports, relay timed out before EOSE -> 502 (was 200 with partial events)
{ "success": false, "error": "Relay query timed out before EOSE (2 events received)" }

// GET /api/reports, relay refused the subscription -> 502
{ "success": false, "error": "Relay closed the subscription: error: could not complete query" }
```

## UI changes

One new alert strip, three copy changes, and one new interactive affordance (the degraded toast's `Try again`). No layout or component changes.

The degraded toast deliberately does not name the relay: one of the three causes is our own page cap, where the relay did exactly what it was asked, so blaming it would send a moderator chasing a problem that is not there. `ReportDetail.reopen.test.tsx` pins that wording.

| Surface | Before | After |
|---|---|---|
| Reports header (new) | queue silently blanked | `Live refresh is failing. Showing reports loaded 2m ago; retrying automatically.` |
| Reopen toast, clean | `Report reopened` / `This report is now back in the pending queue` | `Report reopened` / `Decisions and resolution labels cleared. A report hidden by a relay ban or deletion stays hidden until that is lifted.` (10s, since the caveat does not fit Radix's 5s default) |
| Reopen toast, degraded (new) | — | `Reopened, but resolution labels could not all be cleared` / `Some may remain, so this report may stay hidden.` (destructive, with a `Try again` action and `duration: Infinity`) |
| Reopen tooltip | `Reopen this report for review. Removes the dismiss decision and puts it back in the pending queue.` | `Reopen this report for review. Clears its moderation decisions and resolution labels. A report hidden by a relay ban or deletion stays hidden until that is lifted.` |

## Validation

Every guard was mutation-tested individually — one guard per mutation, so a coarse mutation cannot certify an inert test.

The first pass was not sufficient, and it is worth naming why. Adversarial re-review found six guards that could be reverted with a fully green suite, all of them behavior the commit messages had already claimed. The worst: only one of the four `events` passthrough paths was pinned — including, unpinned, the timeout path this branch is named after — and the truncation guard, the entire argument for raising the label cap, had no test at all. A commit message is not coverage. Each now dies to exactly one mutation.

A second round found one more, and it was the most dangerous thing in the branch. The `targetType` whitelist had no test, and replacing it with the cast it invites survived all 386 tests while producing a filter keyed `"undefined"` — an untargeted query. The relay ignores the unknown key and returns resolution labels for arbitrary targets, which the cleanup loop then bans: one reopen would wipe resolution labels queue-wide and still report success. Pinned now.

Two review findings worth carrying beyond this PR:

- `useAdminApi` is a silent-drop trap for any new argument. Its wrapper signature keeps declaring the parameter it forgets to forward, so TypeScript sees nothing, and every component test mocks the hook wholesale. It now has its own test; the same exposure applies to the other bound functions in that file.
- A guard sitting upstream of a computed object key fails open into a *broader* query rather than a narrower one, which is the direction that does damage.

Two further rounds found two more, both in fixes made by earlier rounds. Resolving before closing the socket was applied to one exit and not the four beside it — and on two of those a throwing `close()` is swallowed by the parse-error catch, so `queryRelay` hangs and `/api/reports` never answers, stalling the poll to the client's 30s abort. That is this PR's own failure arriving by a different door, and it is demonstrated rather than argued: those tests hang to the runner's timeout. Closing now goes through a helper that swallows and logs, which is what actually guarantees settlement. The same round caught the longer toast duration sitting on the wrong toast — the destructive one carrying the retry kept the 5s default, so the affordance expired while the Reopen button was already unmounted.

Gates: frontend 522 passed + 1 skipped, worker 395 passed, worker D1 21 passed, frontend build, both typechecks and eslint clean.

One follow-up found and deliberately left out: `publishToRelay` carries the identical latent hang on both its exits, and it is awaited on the label-publish path that backs `markAsReviewed`. Filed as #225 rather than widened into this PR.

**Manual validation plan (staging).** The queue holds its last data across a failing poll with the stale-data warning rather than blanking. A reopen against a slow relay removes the labels it did receive and reports cleanup as incomplete. A cold load against a healthy relay renders normally. Screenshots of the three states to be captured during this pass.

## Merge order

This should land before #222. That branch relocates `queryRelay` into `worker/src/relay-profile.ts` carrying the pre-fix semantics, and `relay-profile.ts:134` reads `res.complete === true` — a field this PR removes. Rebasing onto this simplifies it: `success` already means EOSE-confirmed, so the check becomes `res.success`. Left as-is it silently evaluates false forever, with no type error, and identity capture never stamps.

#221 has recorded its own rebase plan against this branch; this PR moved toward it rather than against it.

