### PR TITLE
Content report note: carry its own context (nip05, event type, restored-OG flag)

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -32,6 +32,7 @@ import { handleAccountStatus } from './account-status';
 import { handleBulkModerateEnqueue, handleBulkJobStatus, processBulkJob } from './bulk-moderate';
 import type { BulkJobMessage } from '../../shared/bulk-moderation';
 import { ensureZendeskTable, addZendeskInternalNote, syncZendeskAfterAction } from './zendesk-sync';
+import { buildReportNote, parseKind0Profile, type ReportedProfile } from './report-note';
 
 let schemaReady = false;
 async function ensureSchemaOnce(db: D1Database): Promise<void> {
@@ -2351,25 +2352,39 @@ async function handleParseReport(
       `).bind(ticket_id, event_id, author_pubkey, violation_type).run();
     }
 
-    // Generate internal note with links
-    const envParam = env.ENVIRONMENT ? `&env=${env.ENVIRONMENT}` : '';
-    const lines = ['📋 **Content Report Links**', ''];
-    if (violation_type) {
-      lines.push(`**Violation Type:** ${violation_type}`, '');
-    }
-    if (event_id) {
-      lines.push('**Reported Event:**');
-      lines.push(`• [View in Relay Admin](https://relay.admin.divine.video/reports?event=${event_id}${envParam})`);
-      lines.push(`• Event ID: \`${event_id}\``);
-      lines.push('');
-    }
-    if (author_pubkey) {
-      lines.push('**Reported Author:**');
-      lines.push(`• [View in Relay Admin](https://relay.admin.divine.video/reports?pubkey=${author_pubkey}${envParam})`);
-      lines.push(`• Pubkey: \`${author_pubkey}\``);
+    // Enrich the note with profile + event context (best-effort; never block the note).
+    // The reported subject's kind-0 gives a human-legible name/nip05 and flags restored OG
+    // Vine accounts; the reported event's kind labels the content type (video/note/etc).
+    let profile: ReportedProfile | null = null;
+    let reportedEventKind: number | null = null;
+    try {
+      const [profRes, evtRes] = await Promise.all([
+        author_pubkey
+          ? queryRelay({ authors: [author_pubkey], kinds: [0], limit: 1 }, env.RELAY_URL)
+          : Promise.resolve(null),
+        event_id
+          ? queryRelay({ ids: [event_id], limit: 1 }, env.RELAY_URL)
+          : Promise.resolve(null),
+      ]);
+      if (profRes?.success && profRes.events?.length) {
+        profile = parseKind0Profile(profRes.events[0] as { content?: string; tags?: string[][] });
+      }
+      if (evtRes?.success && evtRes.events?.length) {
+        const kind = (evtRes.events[0] as { kind?: number }).kind;
+        reportedEventKind = typeof kind === 'number' ? kind : null;
+      }
+    } catch (err) {
+      console.warn('[handleParseReport] enrichment fetch failed (continuing without it):', err);
     }
 
-    const note = lines.join('\n');
+    const note = buildReportNote({
+      eventId: event_id,
+      authorPubkey: author_pubkey,
+      violationType: violation_type,
+      environment: env.ENVIRONMENT,
+      profile,
+      reportedEventKind,
+    });
 
     // Add internal note to Zendesk
     await addZendeskInternalNote(ticket_id, note, env);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2401,6 +2401,7 @@ async function handleParseReport(
       authorPubkey: author_pubkey,
       violationType: violation_type,
       environment: env.ENVIRONMENT,
+      keycastUrl: env.KEYCAST_URL,
       profile,
       reportedEventKind,
     });

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2285,6 +2285,19 @@ async function handleZendeskRoutes(
   return jsonResponse({ success: false, error: 'Not found' }, 404, corsHeaders);
 }
 
+// Cap best-effort report-note enrichment so a slow relay can't push the Zendesk webhook
+// handler toward Zendesk's delivery timeout. On timeout we post the note without enrichment.
+const ENRICHMENT_TIMEOUT_MS = 3000;
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<null>((resolve) => {
+    timer = setTimeout(() => resolve(null), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer);
+  });
+}
+
 // Parse content report ticket and store mapping, add helpful links as internal note
 async function handleParseReport(
   request: Request,
@@ -2360,10 +2373,16 @@ async function handleParseReport(
     try {
       const [profRes, evtRes] = await Promise.all([
         author_pubkey
-          ? queryRelay({ authors: [author_pubkey], kinds: [0], limit: 1 }, env.RELAY_URL)
+          ? withTimeout(
+              queryRelay({ authors: [author_pubkey], kinds: [0], limit: 1 }, env.RELAY_URL),
+              ENRICHMENT_TIMEOUT_MS,
+            )
           : Promise.resolve(null),
         event_id
-          ? queryRelay({ ids: [event_id], limit: 1 }, env.RELAY_URL)
+          ? withTimeout(
+              queryRelay({ ids: [event_id], limit: 1 }, env.RELAY_URL),
+              ENRICHMENT_TIMEOUT_MS,
+            )
           : Promise.resolve(null),
       ]);
       if (profRes?.success && profRes.events?.length) {

--- a/worker/src/report-note.test.ts
+++ b/worker/src/report-note.test.ts
@@ -9,8 +9,10 @@ describe('eventKindLabel', () => {
   it('labels known kinds and falls back for the rest', () => {
     expect(eventKindLabel(0)).toBe('profile');
     expect(eventKindLabel(1)).toBe('note');
+    expect(eventKindLabel(1111)).toBe('comment');
+    expect(eventKindLabel(34235)).toBe('video');
     expect(eventKindLabel(34236)).toBe('video');
-    expect(eventKindLabel(1111)).toBe('kind 1111');
+    expect(eventKindLabel(30023)).toBe('kind 30023');
     expect(eventKindLabel(null)).toBe('event');
     expect(eventKindLabel(undefined)).toBe('event');
   });
@@ -58,6 +60,24 @@ describe('parseKind0Profile', () => {
       vineUsername: undefined,
     });
   });
+
+  it('sanitizes attacker-controlled name/nip05/vine_username (no newline or markdown injection)', () => {
+    const p = parseKind0Profile({
+      content: JSON.stringify({
+        display_name: 'evil\n\n**Filed by:** nobody [click](https://evil.test)',
+        nip05: '`x`@e.com',
+      }),
+      tags: [['vine_username', 'a]b[c']],
+    });
+    // Newlines gone (can't forge note structure); markdown link/emphasis/span chars stripped.
+    expect(p.name).not.toContain('\n');
+    expect(p.name).not.toContain('[');
+    expect(p.name).not.toContain('](');
+    expect(p.name).not.toContain('*');
+    expect(p.nip05).not.toContain('`');
+    expect(p.vineUsername).not.toContain('[');
+    expect(p.vineUsername).not.toContain(']');
+  });
 });
 
 describe('buildReportNote', () => {
@@ -77,6 +97,7 @@ describe('buildReportNote', () => {
     expect(note).toContain('Profile: **kofi** · nip05 `_@kofi.divine.video`');
     expect(note).toContain('Restored OG Vine account');
     expect(note).toContain('vine_username `kofi`');
+    expect(note).toContain('confirm in Relay Manager');
     expect(note).toContain(`support-admin](https://login.divine.video/support-admin?q=${KOFI_HEX})`);
     expect(note).toContain(`npub: \`${KOFI_NPUB}\``);
     expect(note).toContain(`hex: \`${KOFI_HEX}\``);

--- a/worker/src/report-note.test.ts
+++ b/worker/src/report-note.test.ts
@@ -87,6 +87,7 @@ describe('buildReportNote', () => {
       authorPubkey: KOFI_HEX,
       violationType: 'other',
       environment: 'production',
+      keycastUrl: 'https://login.divine.video',
       profile: { name: 'kofi', nip05: '_@kofi.divine.video', isVineImport: true, vineUsername: 'kofi' },
       reportedEventKind: null,
     });
@@ -94,11 +95,15 @@ describe('buildReportNote', () => {
     expect(note).toContain('RELAY REPORT');
     expect(note).toContain('Scope: **account-level (whole profile)**');
     expect(note).toContain('the subject of this report, *not* the person who filed it');
-    expect(note).toContain('Profile: **kofi** · nip05 `_@kofi.divine.video`');
-    expect(note).toContain('Restored OG Vine account');
+    // Name is a code span (not bold); nip05 is flagged claimed/unverified.
+    expect(note).toContain('Profile: `kofi` · nip05 `_@kofi.divine.video` (claimed, unverified)');
+    // Import markers are presented as evidence, not a verdict.
+    expect(note).toContain('Vine-archive import markers');
     expect(note).toContain('vine_username `kofi`');
-    expect(note).toContain('confirm in Relay Manager');
-    expect(note).toContain(`support-admin](https://login.divine.video/support-admin?q=${KOFI_HEX})`);
+    expect(note).toContain("Verify the reporter's ownership");
+    expect(note).not.toContain('name mix-up, not impersonation');
+    // Visible host and href agree, both derived from the configured Keycast URL.
+    expect(note).toContain(`Look up in login.divine.video → [support-admin](https://login.divine.video/support-admin?q=${KOFI_HEX})`);
     expect(note).toContain(`npub: \`${KOFI_NPUB}\``);
     expect(note).toContain(`hex: \`${KOFI_HEX}\``);
     // No content block for an account-level report.
@@ -124,8 +129,8 @@ describe('buildReportNote', () => {
     expect(note).toContain(`**→ [Open this report in Relay Manager](https://relay.admin.divine.video/reports?event=${eventId}&env=production)**`);
     // Author block still present.
     expect(note).toContain('**Reported account**');
-    expect(note).toContain('Profile: **poster**');
-    expect(note).not.toContain('Restored OG Vine account');
+    expect(note).toContain('Profile: `poster`');
+    expect(note).not.toContain('Vine-archive import markers');
   });
 
   it('degrades gracefully with no enrichment (still shows npub/hex, no Profile/OG lines)', () => {
@@ -141,19 +146,39 @@ describe('buildReportNote', () => {
     expect(note).toContain('Reason: **unspecified**');
     expect(note).toContain(`npub: \`${KOFI_NPUB}\``);
     expect(note).not.toContain('• Profile:');
-    expect(note).not.toContain('Restored OG Vine account');
+    expect(note).not.toContain('Vine-archive import markers');
   });
 
-  it('uses the staging keycast host and env param on staging', () => {
+  it('derives keycast host + link from the configured URL (staging); label and href agree', () => {
     const note = buildReportNote({
       eventId: null,
       authorPubkey: KOFI_HEX,
       violationType: 'spam',
       environment: 'staging',
+      keycastUrl: 'https://login.staging.dvines.org',
       profile: null,
       reportedEventKind: null,
     });
-    expect(note).toContain(`https://login.staging.dvines.org/support-admin?q=${KOFI_HEX}`);
+    expect(note).toContain(
+      `Look up in login.staging.dvines.org → [support-admin](https://login.staging.dvines.org/support-admin?q=${KOFI_HEX})`,
+    );
+    // The old bug rendered "login.divine.video" as the label while linking to staging.
+    expect(note).not.toContain('login.divine.video');
     expect(note).toContain('&env=staging');
+  });
+
+  it('renders a bare URL in the name inertly (code span, not auto-linkable)', () => {
+    const note = buildReportNote({
+      eventId: null,
+      authorPubkey: KOFI_HEX,
+      violationType: 'other',
+      environment: 'production',
+      keycastUrl: 'https://login.divine.video',
+      profile: { name: 'click https://evil.test now', nip05: undefined, isVineImport: false },
+      reportedEventKind: null,
+    });
+    // Name (incl. its URL) is wrapped in a code span, which does not auto-link in Zendesk.
+    expect(note).toContain('• Profile: `click https://evil.test now`');
+    expect(note).not.toContain('**click https://evil.test now**');
   });
 });

--- a/worker/src/report-note.test.ts
+++ b/worker/src/report-note.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { buildReportNote, eventKindLabel, parseKind0Profile } from './report-note';
+
+// Real Kofi OG-import account (public) — lets us assert the npub encoding end-to-end.
+const KOFI_HEX = '9f59c820aa2ad80ce8c0e28a4e640b9cd0487b4a510da95be7cd4bfd3ecda0bd';
+const KOFI_NPUB = 'npub1navusg929tvqe6xqu29yueqtnngys7622yx6jkl8e49l60kd5z7syxq58u';
+
+describe('eventKindLabel', () => {
+  it('labels known kinds and falls back for the rest', () => {
+    expect(eventKindLabel(0)).toBe('profile');
+    expect(eventKindLabel(1)).toBe('note');
+    expect(eventKindLabel(34236)).toBe('video');
+    expect(eventKindLabel(1111)).toBe('kind 1111');
+    expect(eventKindLabel(null)).toBe('event');
+    expect(eventKindLabel(undefined)).toBe('event');
+  });
+});
+
+describe('parseKind0Profile', () => {
+  it('extracts name/nip05 and flags a vine-archive import', () => {
+    const p = parseKind0Profile({
+      content: JSON.stringify({ name: 'kofi', display_name: 'kofi', nip05: '_@kofi.divine.video' }),
+      tags: [
+        ['i', 'vine:1133875566232367104'],
+        ['vine_username', 'kofi'],
+        ['client', 'vine-archive-importer'],
+      ],
+    });
+    expect(p).toEqual({
+      name: 'kofi',
+      nip05: '_@kofi.divine.video',
+      isVineImport: true,
+      vineUsername: 'kofi',
+    });
+  });
+
+  it('prefers display_name and does not flag a normal account', () => {
+    const p = parseKind0Profile({
+      content: JSON.stringify({ name: 'raw', display_name: 'Pretty', nip05: 'x@divine.video' }),
+      tags: [['client', 'divine-mobile']],
+    });
+    expect(p.name).toBe('Pretty');
+    expect(p.isVineImport).toBe(false);
+    expect(p.vineUsername).toBeUndefined();
+  });
+
+  it('still detects the OG-import flag when kind-0 content is malformed', () => {
+    const p = parseKind0Profile({ content: 'not json', tags: [['i', 'vine:42']] });
+    expect(p.name).toBeUndefined();
+    expect(p.isVineImport).toBe(true);
+  });
+
+  it('handles a missing event without throwing', () => {
+    expect(parseKind0Profile(null)).toEqual({
+      name: undefined,
+      nip05: undefined,
+      isVineImport: false,
+      vineUsername: undefined,
+    });
+  });
+});
+
+describe('buildReportNote', () => {
+  it('account-level report surfaces subject, identity, and the restored-OG flag', () => {
+    const note = buildReportNote({
+      eventId: null,
+      authorPubkey: KOFI_HEX,
+      violationType: 'other',
+      environment: 'production',
+      profile: { name: 'kofi', nip05: '_@kofi.divine.video', isVineImport: true, vineUsername: 'kofi' },
+      reportedEventKind: null,
+    });
+
+    expect(note).toContain('RELAY REPORT');
+    expect(note).toContain('Scope: **account-level (whole profile)**');
+    expect(note).toContain('the subject of this report, *not* the person who filed it');
+    expect(note).toContain('Profile: **kofi** · nip05 `_@kofi.divine.video`');
+    expect(note).toContain('Restored OG Vine account');
+    expect(note).toContain('vine_username `kofi`');
+    expect(note).toContain(`support-admin](https://login.divine.video/support-admin?q=${KOFI_HEX})`);
+    expect(note).toContain(`npub: \`${KOFI_NPUB}\``);
+    expect(note).toContain(`hex: \`${KOFI_HEX}\``);
+    // No content block for an account-level report.
+    expect(note).not.toContain('Reported content');
+  });
+
+  it('content report shows the event block with kind label plus the author block', () => {
+    const eventId = 'a'.repeat(64);
+    const note = buildReportNote({
+      eventId,
+      authorPubkey: KOFI_HEX,
+      violationType: 'sexualContent',
+      environment: 'production',
+      profile: { name: 'poster', nip05: undefined, isVineImport: false },
+      reportedEventKind: 34236,
+    });
+
+    expect(note).toContain('Scope: **content (specific event)**');
+    expect(note).toContain('**Reported content (video):**');
+    expect(note).toContain('• Kind: `34236`');
+    expect(note).toContain(`reports?event=${eventId}`);
+    // Primary CTA points at the event view for content reports.
+    expect(note).toContain(`**→ [Open this report in Relay Manager](https://relay.admin.divine.video/reports?event=${eventId}&env=production)**`);
+    // Author block still present.
+    expect(note).toContain('**Reported account**');
+    expect(note).toContain('Profile: **poster**');
+    expect(note).not.toContain('Restored OG Vine account');
+  });
+
+  it('degrades gracefully with no enrichment (still shows npub/hex, no Profile/OG lines)', () => {
+    const note = buildReportNote({
+      eventId: null,
+      authorPubkey: KOFI_HEX,
+      violationType: null,
+      environment: 'production',
+      profile: null,
+      reportedEventKind: null,
+    });
+
+    expect(note).toContain('Reason: **unspecified**');
+    expect(note).toContain(`npub: \`${KOFI_NPUB}\``);
+    expect(note).not.toContain('• Profile:');
+    expect(note).not.toContain('Restored OG Vine account');
+  });
+
+  it('uses the staging keycast host and env param on staging', () => {
+    const note = buildReportNote({
+      eventId: null,
+      authorPubkey: KOFI_HEX,
+      violationType: 'spam',
+      environment: 'staging',
+      profile: null,
+      reportedEventKind: null,
+    });
+    expect(note).toContain(`https://login.staging.dvines.org/support-admin?q=${KOFI_HEX}`);
+    expect(note).toContain('&env=staging');
+  });
+});

--- a/worker/src/report-note.ts
+++ b/worker/src/report-note.ts
@@ -23,8 +23,10 @@ export interface ReportNoteInput {
   authorPubkey: string | null;
   /** Report category, verbatim from the ticket (e.g. "other", "sexualContent"). */
   violationType: string | null;
-  /** Worker environment, drives link env params + keycast host. */
+  /** Worker environment, drives the relay-admin `env` link param. */
   environment?: string;
+  /** Configured Keycast base URL (env.KEYCAST_URL); the note's lookup host + link derive from it. */
+  keycastUrl?: string;
   /** Reported account's profile (enrichment); null/undefined if the fetch failed. */
   profile?: ReportedProfile | null;
   /** Kind of the reported event (enrichment); null/undefined if unknown. */
@@ -115,10 +117,17 @@ function toNpub(hex: string): string {
   }
 }
 
-function keycastBase(environment?: string): string {
-  return environment === 'staging'
-    ? 'https://login.staging.dvines.org'
-    : 'https://login.divine.video';
+/** Normalize the configured Keycast URL and derive its visible host, so the note's
+ *  label and link always agree with the deployed environment. */
+function keycastTarget(keycastUrl?: string): { url: string; host: string } {
+  const url = (keycastUrl || 'https://login.divine.video').replace(/\/+$/, '');
+  let host = url;
+  try {
+    host = new URL(url).host;
+  } catch {
+    // Not a parseable URL: fall back to showing the raw value.
+  }
+  return { url, host };
 }
 
 /**
@@ -131,6 +140,7 @@ function keycastBase(environment?: string): string {
 export function buildReportNote(input: ReportNoteInput): string {
   const { eventId, authorPubkey, violationType, environment, profile, reportedEventKind } = input;
   const envParam = environment ? `&env=${environment}` : '';
+  const keycast = keycastTarget(input.keycastUrl);
   const scope = eventId ? 'content (specific event)' : 'account-level (whole profile)';
   const primaryLink = eventId
     ? `${RELAY_ADMIN}/reports?event=${eventId}${envParam}`
@@ -155,18 +165,19 @@ export function buildReportNote(input: ReportNoteInput): string {
     lines.push('**Reported account** — the subject of this report, *not* the person who filed it:');
     if (profile?.name || profile?.nip05) {
       const bits: string[] = [];
-      if (profile.name) bits.push(`**${profile.name}**`);
-      if (profile.nip05) bits.push(`nip05 \`${profile.nip05}\``);
+      // Code span (not bold) so a name containing a bare URL can't auto-link in Zendesk.
+      if (profile.name) bits.push(`\`${profile.name}\``);
+      if (profile.nip05) bits.push(`nip05 \`${profile.nip05}\` (claimed, unverified)`);
       lines.push(`• Profile: ${bits.join(' · ')}`);
     }
     if (profile?.isVineImport) {
       const uname = profile.vineUsername ? ` (vine_username \`${profile.vineUsername}\`)` : '';
       lines.push(
-        `• ⚠️ **Restored OG Vine account**${uname} — self-reported import markers; likely a name mix-up, not impersonation, but confirm in Relay Manager before applying the "Recovered OG account" macro`,
+        `• 🏷️ **Vine-archive import markers**${uname} — self-reported on the account's own kind-0, so a signal, not proof. Verify the reporter's ownership before resolving; if confirmed, the "Recovered OG account" macro applies.`,
       );
     }
     lines.push(
-      `• Look up in login.divine.video → [support-admin](${keycastBase(environment)}/support-admin?q=${authorPubkey})`,
+      `• Look up in ${keycast.host} → [support-admin](${keycast.url}/support-admin?q=${authorPubkey})`,
     );
     lines.push(`• Public profile → https://divine.video/profile/${authorPubkey}`);
     lines.push(`• npub: \`${toNpub(authorPubkey)}\``);

--- a/worker/src/report-note.ts
+++ b/worker/src/report-note.ts
@@ -6,7 +6,7 @@ import { nip19 } from 'nostr-tools';
 
 /** Profile facts pulled from the reported account's kind-0 event (best-effort enrichment). */
 export interface ReportedProfile {
-  /** display_name || name from kind-0 content, if any. */
+  /** display_name || name from kind-0 content, if any (sanitized for note interpolation). */
   name?: string;
   /** nip05 from kind-0 content, if any (as claimed by the account; not verified here). */
   nip05?: string;
@@ -40,11 +40,35 @@ export function eventKindLabel(kind: number | null | undefined): string {
       return 'profile';
     case 1:
       return 'note';
+    case 1111:
+      return 'comment';
+    case 34235:
     case 34236:
       return 'video';
     default:
       return kind == null ? 'event' : `kind ${kind}`;
   }
+}
+
+/**
+ * Neutralize attacker-controlled kind-0 text (name / nip05 / vine_username) before it is
+ * interpolated into the Markdown note. The reported account fully controls its own kind-0,
+ * so strip anything that could forge note structure (newlines / control chars) or inject
+ * Markdown links, images, code spans, emphasis, or raw HTML. Underscores, dots, and @ are
+ * kept so legitimate nip05 values (e.g. `_@name.divine.video`) survive intact.
+ */
+function sanitizeInline(value: string | undefined, maxLen = 80): string | undefined {
+  if (!value) return undefined;
+  const cleaned = Array.from(value, (ch) => {
+    const code = ch.charCodeAt(0);
+    return code < 0x20 || code === 0x7f ? ' ' : ch; // control chars / newlines -> space
+  })
+    .join('')
+    .replace(/[`[\]*<>|]/g, '') // markdown link/image/span/emphasis + html/table
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!cleaned) return undefined;
+  return cleaned.length > maxLen ? `${cleaned.slice(0, maxLen)}…` : cleaned;
 }
 
 /** Parse a raw kind-0 event into the profile facts the note needs. Never throws. */
@@ -74,7 +98,13 @@ export function parseKind0Profile(
     // Malformed kind-0 content: fall back to tag-derived facts (e.g. the OG-import flag).
   }
 
-  return { name, nip05, isVineImport, vineUsername: tagValue('vine_username') };
+  // Sanitize every attacker-controlled field before it reaches the note.
+  return {
+    name: sanitizeInline(name),
+    nip05: sanitizeInline(nip05),
+    isVineImport,
+    vineUsername: sanitizeInline(tagValue('vine_username')),
+  };
 }
 
 function toNpub(hex: string): string {
@@ -95,15 +125,16 @@ function keycastBase(environment?: string): string {
  * Build the internal note for a content-report ticket. Self-contained and unambiguous:
  * names the report source, distinguishes the reported subject from the reporter, and
  * surfaces human-legible identity + the restored-OG signal so an agent needs no prior context.
+ *
+ * The caller guarantees at least one of `eventId` / `authorPubkey` is set.
  */
 export function buildReportNote(input: ReportNoteInput): string {
   const { eventId, authorPubkey, violationType, environment, profile, reportedEventKind } = input;
   const envParam = environment ? `&env=${environment}` : '';
   const scope = eventId ? 'content (specific event)' : 'account-level (whole profile)';
-  const primaryLink =
-    eventId
-      ? `${RELAY_ADMIN}/reports?event=${eventId}${envParam}`
-      : `${RELAY_ADMIN}/reports?pubkey=${authorPubkey}${envParam}`;
+  const primaryLink = eventId
+    ? `${RELAY_ADMIN}/reports?event=${eventId}${envParam}`
+    : `${RELAY_ADMIN}/reports?pubkey=${authorPubkey}${envParam}`;
 
   const lines: string[] = [];
   lines.push('**🛡️ RELAY REPORT — INTERNAL LOOKUP**', '');
@@ -121,9 +152,7 @@ export function buildReportNote(input: ReportNoteInput): string {
   }
 
   if (authorPubkey) {
-    lines.push(
-      '**Reported account** — the subject of this report, *not* the person who filed it:',
-    );
+    lines.push('**Reported account** — the subject of this report, *not* the person who filed it:');
     if (profile?.name || profile?.nip05) {
       const bits: string[] = [];
       if (profile.name) bits.push(`**${profile.name}**`);
@@ -133,7 +162,7 @@ export function buildReportNote(input: ReportNoteInput): string {
     if (profile?.isVineImport) {
       const uname = profile.vineUsername ? ` (vine_username \`${profile.vineUsername}\`)` : '';
       lines.push(
-        `• ⚠️ **Restored OG Vine account**${uname} — likely a name mix-up, not impersonation; consider the "Recovered OG account" macro`,
+        `• ⚠️ **Restored OG Vine account**${uname} — self-reported import markers; likely a name mix-up, not impersonation, but confirm in Relay Manager before applying the "Recovered OG account" macro`,
       );
     }
     lines.push(

--- a/worker/src/report-note.ts
+++ b/worker/src/report-note.ts
@@ -1,0 +1,149 @@
+// ABOUTME: Builds the internal "relay report" note posted into Zendesk content-report tickets
+// ABOUTME: Pure helpers (buildReportNote, parseKind0Profile, eventKindLabel) + their types, kept
+// ABOUTME: separate from index.ts so the note formatting can be unit-tested without the worker.
+
+import { nip19 } from 'nostr-tools';
+
+/** Profile facts pulled from the reported account's kind-0 event (best-effort enrichment). */
+export interface ReportedProfile {
+  /** display_name || name from kind-0 content, if any. */
+  name?: string;
+  /** nip05 from kind-0 content, if any (as claimed by the account; not verified here). */
+  nip05?: string;
+  /** True when the reported account is a Divine Vine-archive import (a restored OG account). */
+  isVineImport: boolean;
+  /** vine_username tag value, when the account carries one. */
+  vineUsername?: string;
+}
+
+export interface ReportNoteInput {
+  /** Reported event hash (content reports); null for account-level reports. */
+  eventId: string | null;
+  /** Reported account pubkey (hex); the subject of the report. */
+  authorPubkey: string | null;
+  /** Report category, verbatim from the ticket (e.g. "other", "sexualContent"). */
+  violationType: string | null;
+  /** Worker environment, drives link env params + keycast host. */
+  environment?: string;
+  /** Reported account's profile (enrichment); null/undefined if the fetch failed. */
+  profile?: ReportedProfile | null;
+  /** Kind of the reported event (enrichment); null/undefined if unknown. */
+  reportedEventKind?: number | null;
+}
+
+const RELAY_ADMIN = 'https://relay.admin.divine.video';
+
+/** Human label for a reported event's kind. Always pair with the raw kind number for certainty. */
+export function eventKindLabel(kind: number | null | undefined): string {
+  switch (kind) {
+    case 0:
+      return 'profile';
+    case 1:
+      return 'note';
+    case 34236:
+      return 'video';
+    default:
+      return kind == null ? 'event' : `kind ${kind}`;
+  }
+}
+
+/** Parse a raw kind-0 event into the profile facts the note needs. Never throws. */
+export function parseKind0Profile(
+  event: { content?: string; tags?: string[][] } | null | undefined,
+): ReportedProfile {
+  const tags = event?.tags ?? [];
+  const tagValue = (name: string): string | undefined => tags.find((t) => t[0] === name)?.[1];
+
+  // A restored OG account is written by the vine-archive-importer and carries vine origin tags.
+  const isVineImport =
+    tags.some((t) => t[0] === 'client' && t[1] === 'vine-archive-importer') ||
+    tags.some((t) => t[0] === 'i' && (t[1] ?? '').startsWith('vine:')) ||
+    tags.some((t) => t[0] === 'origin' && t[1] === 'vine');
+
+  let name: string | undefined;
+  let nip05: string | undefined;
+  try {
+    const meta = JSON.parse(event?.content ?? '{}') as {
+      name?: string;
+      display_name?: string;
+      nip05?: string;
+    };
+    name = meta.display_name || meta.name || undefined;
+    nip05 = meta.nip05 || undefined;
+  } catch {
+    // Malformed kind-0 content: fall back to tag-derived facts (e.g. the OG-import flag).
+  }
+
+  return { name, nip05, isVineImport, vineUsername: tagValue('vine_username') };
+}
+
+function toNpub(hex: string): string {
+  try {
+    return nip19.npubEncode(hex);
+  } catch {
+    return hex;
+  }
+}
+
+function keycastBase(environment?: string): string {
+  return environment === 'staging'
+    ? 'https://login.staging.dvines.org'
+    : 'https://login.divine.video';
+}
+
+/**
+ * Build the internal note for a content-report ticket. Self-contained and unambiguous:
+ * names the report source, distinguishes the reported subject from the reporter, and
+ * surfaces human-legible identity + the restored-OG signal so an agent needs no prior context.
+ */
+export function buildReportNote(input: ReportNoteInput): string {
+  const { eventId, authorPubkey, violationType, environment, profile, reportedEventKind } = input;
+  const envParam = environment ? `&env=${environment}` : '';
+  const scope = eventId ? 'content (specific event)' : 'account-level (whole profile)';
+  const primaryLink =
+    eventId
+      ? `${RELAY_ADMIN}/reports?event=${eventId}${envParam}`
+      : `${RELAY_ADMIN}/reports?pubkey=${authorPubkey}${envParam}`;
+
+  const lines: string[] = [];
+  lines.push('**🛡️ RELAY REPORT — INTERNAL LOOKUP**', '');
+  lines.push(
+    'Reported on the Divine relay. Full report details (reporter, reason, timeline, prior actions) live in Relay Manager:',
+  );
+  lines.push(`**→ [Open this report in Relay Manager](${primaryLink})**`, '');
+  lines.push(`Reason: **${violationType || 'unspecified'}** · Scope: **${scope}**`, '', '---', '');
+
+  if (eventId) {
+    lines.push(`**Reported content (${eventKindLabel(reportedEventKind)}):**`);
+    lines.push(`• [View in Relay Manager](${RELAY_ADMIN}/reports?event=${eventId}${envParam})`);
+    if (reportedEventKind != null) lines.push(`• Kind: \`${reportedEventKind}\``);
+    lines.push(`• Event ID: \`${eventId}\``, '');
+  }
+
+  if (authorPubkey) {
+    lines.push(
+      '**Reported account** — the subject of this report, *not* the person who filed it:',
+    );
+    if (profile?.name || profile?.nip05) {
+      const bits: string[] = [];
+      if (profile.name) bits.push(`**${profile.name}**`);
+      if (profile.nip05) bits.push(`nip05 \`${profile.nip05}\``);
+      lines.push(`• Profile: ${bits.join(' · ')}`);
+    }
+    if (profile?.isVineImport) {
+      const uname = profile.vineUsername ? ` (vine_username \`${profile.vineUsername}\`)` : '';
+      lines.push(
+        `• ⚠️ **Restored OG Vine account**${uname} — likely a name mix-up, not impersonation; consider the "Recovered OG account" macro`,
+      );
+    }
+    lines.push(
+      `• Look up in login.divine.video → [support-admin](${keycastBase(environment)}/support-admin?q=${authorPubkey})`,
+    );
+    lines.push(`• Public profile → https://divine.video/profile/${authorPubkey}`);
+    lines.push(`• npub: \`${toNpub(authorPubkey)}\``);
+    lines.push(`• hex: \`${authorPubkey}\``, '');
+  }
+
+  lines.push('**Filed by:** the ticket requester above.');
+  return lines.join('\n');
+}


### PR DESCRIPTION
Closes #187.

## Why
Working the support queue, we found the content-report internal note in Zendesk had lost clarity as the context around it shifted. On ticket #3991 it showed only a bare hex "Reported Author" line — an agent couldn't tell which account was reported, that the pubkey was the subject (not the reporter), or that the "impersonator" was actually the reporter's own restored OG Vine account. Establishing that took a manual investigation.

## What
The note now carries its own context regardless of who reads it:
- Clear heading + "open the full report in Relay Manager" CTA.
- Explicit "reported subject, not the reporter" labeling.
- Scope (account vs content) and the reported event's kind (video / comment / note / ...).
- Human-legible identity: profile name + nip05, alongside npub and hex.
- A restored-OG-Vine-account flag when the subject is a vine-archive import — the exact signal that would have resolved #3991 at a glance — pointing to the "Recovered OG account" macro with a confirm-first caveat.
- Direct lookups: Relay Manager report view, login.divine.video support-admin (?q=), and the public divine.video profile.

## How
- Note formatting is a pure, unit-tested module (report-note.ts).
- handleParseReport fetches the subject's kind-0 and the reported event's kind best-effort via queryRelay, in parallel, each capped at 3s; on a slow/unreachable relay the note still posts with pubkey/npub/links, minus enrichment.
- Profile fields (name / nip05 / vine_username) come from the reported account's own kind-0, so they're sanitized before interpolation (control chars/newlines to space; markdown link/image/span/emphasis/html stripped) to stop the reported party forging note structure or injecting links.
- Event-kind labels (comment = 1111, video = 34235/34236) verified against divine-web and moderation-service source.

## Rendered example (account report, restored OG account)

    **🛡️ RELAY REPORT — INTERNAL LOOKUP**

    Reported on the Divine relay. Full report details (reporter, reason, timeline, prior actions) live in Relay Manager:
    **→ [Open this report in Relay Manager](https://relay.admin.divine.video/reports?pubkey=9f59c820...&env=production)**

    Reason: **other** · Scope: **account-level (whole profile)**

    ---

    **Reported account** — the subject of this report, *not* the person who filed it:
    • Profile: **kofi** · nip05 `_@kofi.divine.video`
    • ⚠️ **Restored OG Vine account** (vine_username `kofi`) — self-reported import markers; likely a name mix-up, not impersonation, but confirm in Relay Manager before applying the "Recovered OG account" macro
    • Look up in login.divine.video → [support-admin](https://login.divine.video/support-admin?q=9f59c820...)
    • Public profile → https://divine.video/profile/9f59c820...
    • npub: `npub1navusg9...`
    • hex: `9f59c820...`

    **Filed by:** the ticket requester above.

## Known limitation (accepted)
The `support-admin?q=<hex>` lookup link becomes one-click only once keycast divinevideo/keycast#299 is deployed to prod. Until then it lands on a blank support-admin search box and the agent pastes the hex/npub — both printed in the note. That is a graceful degradation, not a break, and the whole note is a large net improvement over the version that has been augmenting these tickets since December. We accept this transitional state; #299 is tracked and lands the one-click behavior.

## Testing
- report-note unit tests cover account / content / no-enrichment / staging + kind-0 parsing + sanitization; full worker suite 330/330; typecheck clean.
- The injection sanitization was verified end-to-end against adversarial kind-0 input.
- Not yet exercised against a live ticket (relay fetch + Zendesk render); planned at deploy.
