### PR TITLE
fix(nip98): accept allowlisted public host on the mobile minor-review endpoints (#173)

### DIFF
--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -937,6 +937,18 @@ describe('mobile NIP-98 endpoint host allowlist (#173)', () => {
     expect(res.status).toBe(200);
   });
 
+  // Config is user-edited free text (unlike URL.hostname, which the platform always
+  // lowercases), so a mixed-case entry must still normalize to match at compare time.
+  it('accepts a public host configured with mixed case (config is case-insensitive)', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const res = await worker.fetch(
+      new Request(OWN_HOST_URL, { method: 'GET', headers: { Authorization: nip98Header(PUBLIC_HOST_URL) } }),
+      { NIP98_PUBLIC_HOST_ALLOWLIST: 'API.Divine.Video' } as never,
+      ctx,
+    );
+    expect(res.status).toBe(200);
+  });
+
   it('accepts an own-host-signed request with no allowlist configured (regression)', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     const res = await worker.fetch(

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { finalizeEvent, generateSecretKey } from 'nostr-tools';
 import worker from './index';
 
 const env = {
@@ -902,5 +903,93 @@ describe('summarize-user cache validation', () => {
     const response = await worker.fetch(summarizeRequest(), env, ctx);
     expect(await response.json()).toEqual({ summary: 'fresh', riskLevel: 'low' }); // write failure did not collapse it
     expect(kv.put).toHaveBeenCalled();
+  });
+});
+
+describe('mobile NIP-98 endpoint host allowlist (#173)', () => {
+  const OWN_HOST_URL = 'https://api-relay-prod.divine.video/v1/account/moderation-status';
+  const PUBLIC_HOST_URL = 'https://api.divine.video/v1/account/moderation-status';
+
+  function nip98Header(u: string): string {
+    const sk = generateSecretKey();
+    const evt = finalizeEvent(
+      { kind: 27235, content: '', tags: [['u', u], ['method', 'GET']], created_at: Math.floor(Date.now() / 1000) },
+      sk,
+    );
+    return 'Nostr ' + btoa(JSON.stringify(evt));
+  }
+
+  // No DB in env → handleGetModerationStatus fails open to 200 (age-review.ts:581-584),
+  // so a 200 here proves the auth gate passed, with no D1 harness needed.
+  it('accepts a public-host-signed request when the host is allowlisted (the fix, end-to-end)', async () => {
+    const res = await worker.fetch(
+      new Request(OWN_HOST_URL, { method: 'GET', headers: { Authorization: nip98Header(PUBLIC_HOST_URL) } }),
+      { NIP98_PUBLIC_HOST_ALLOWLIST: 'api.divine.video' } as never,
+      ctx,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts an own-host-signed request with no allowlist configured (regression)', async () => {
+    const res = await worker.fetch(
+      new Request(OWN_HOST_URL, { method: 'GET', headers: { Authorization: nip98Header(OWN_HOST_URL) } }),
+      {} as never,
+      ctx,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects a public-host-signed request when the host is NOT allowlisted', async () => {
+    const res = await worker.fetch(
+      new Request(OWN_HOST_URL, { method: 'GET', headers: { Authorization: nip98Header(PUBLIC_HOST_URL) } }),
+      {} as never,
+      ctx,
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('zendesk pre-auth NIP-98 scope boundary (#173)', () => {
+  const OWN_HOST_PREAUTH_URL = 'https://api-relay-prod.divine.video/api/zendesk/pre-auth';
+  const PUBLIC_HOST_PREAUTH_URL = 'https://api.divine.video/api/zendesk/pre-auth';
+
+  // Tolerates ensureSchemaOnce's DDL (db.ts: a sequence of `.prepare(sql).run()`
+  // calls, no `.bind()`/`.first()` needed for schema setup) as async no-ops. The
+  // pre-auth nonce INSERT is never reached in this test — auth fails first.
+  function makeZendeskDb() {
+    const statement = (): { bind: () => unknown; run: () => Promise<{ success: boolean }>; first: () => Promise<null> } => ({
+      bind: () => statement(),
+      run: async () => ({ success: true }),
+      first: async () => null,
+    });
+    return { prepare: statement };
+  }
+
+  // Proves the Zendesk pre-auth route stays same-host-only even with the mobile
+  // allowlist configured (Global Constraint 4: Zendesk is out of #173's scope).
+  it('rejects a public-host-signed request even when the mobile allowlist is configured (scope boundary)', async () => {
+    const sk = generateSecretKey();
+    const evt = finalizeEvent(
+      {
+        kind: 27235,
+        content: '',
+        tags: [['u', PUBLIC_HOST_PREAUTH_URL], ['method', 'POST']],
+        created_at: Math.floor(Date.now() / 1000),
+      },
+      sk,
+    );
+    const res = await worker.fetch(
+      new Request(OWN_HOST_PREAUTH_URL, {
+        method: 'POST',
+        headers: { Authorization: 'Nostr ' + btoa(JSON.stringify(evt)) },
+      }),
+      {
+        ZENDESK_PREAUTH_SECRET: 'test-secret',
+        DB: makeZendeskDb(),
+        NIP98_PUBLIC_HOST_ALLOWLIST: 'api.divine.video',
+      } as never,
+      ctx,
+    );
+    expect(res.status).toBe(401);
   });
 });

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -919,9 +919,16 @@ describe('mobile NIP-98 endpoint host allowlist (#173)', () => {
     return 'Nostr ' + btoa(JSON.stringify(evt));
   }
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   // No DB in env → handleGetModerationStatus fails open to 200 (age-review.ts:581-584),
-  // so a 200 here proves the auth gate passed, with no D1 harness needed.
+  // so a 200 here proves the auth gate passed, with no D1 harness needed. The
+  // fail-open path logs an expected `[age-review] DB not available` warning;
+  // silence it so the suite output stays clean.
   it('accepts a public-host-signed request when the host is allowlisted (the fix, end-to-end)', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
     const res = await worker.fetch(
       new Request(OWN_HOST_URL, { method: 'GET', headers: { Authorization: nip98Header(PUBLIC_HOST_URL) } }),
       { NIP98_PUBLIC_HOST_ALLOWLIST: 'api.divine.video' } as never,
@@ -931,6 +938,7 @@ describe('mobile NIP-98 endpoint host allowlist (#173)', () => {
   });
 
   it('accepts an own-host-signed request with no allowlist configured (regression)', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
     const res = await worker.fetch(
       new Request(OWN_HOST_URL, { method: 'GET', headers: { Authorization: nip98Header(OWN_HOST_URL) } }),
       {} as never,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -275,11 +275,12 @@ function getAllowedOrigin(requestOrigin: string | null, allowedOriginsEnv: strin
 }
 
 // Parse the NIP-98 public-host allowlist (#173). Same split/trim/filter shape as
-// getAllowedOrigin. Bare hostnames, no wildcards. Empty/unset ⇒ [] ⇒ strict.
+// getAllowedOrigin, plus lowercasing since it's matched against URL.hostname
+// (always lowercase). Bare hostnames, no wildcards. Empty/unset ⇒ [] ⇒ strict.
 function getNip98AllowedHosts(env: Env): string[] {
   return (env.NIP98_PUBLIC_HOST_ALLOWLIST ?? '')
     .split(',')
-    .map((host) => host.trim())
+    .map((host) => host.trim().toLowerCase())
     .filter(Boolean);
 }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1862,10 +1862,12 @@ interface Nip98Result {
   error?: string;
 }
 
-// Returns true iff `signedUrl` differs from `expectedUrl` only in host, that host
-// is in `allowedHosts` (bare hostnames), and scheme + path + query still match
-// exactly. Used only by the two mobile endpoints (#173); strict callers pass an
-// empty allowlist, so this can never return true for them. Malformed URLs → false.
+// Returns true iff `signedUrl` matches `expectedUrl` in scheme + path + query,
+// and its hostname is in `allowedHosts` (bare hostnames). Port and fragment are
+// intentionally not compared — this is a bare-hostname allowlist by design;
+// tightening to port would mean comparing `.host` instead of `.hostname`. Used
+// only by the two mobile endpoints (#173); strict callers pass an empty
+// allowlist, so this can never return true for them. Malformed URLs → false.
 function hostAllowlistedUrlMatch(signedUrl: string, expectedUrl: string, allowedHosts: string[]): boolean {
   if (allowedHosts.length === 0) return false;
   try {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -48,6 +48,10 @@ interface Env extends KeycastEnv {
   NOSTR_NSEC: string | SecretStoreSecret;
   RELAY_URL: string;
   ALLOWED_ORIGINS: string;
+  // Comma-separated public hostnames whose NIP-98 `u`-tag host is accepted in
+  // addition to the worker's own request host, for the two mobile endpoints only
+  // (divine-relay-manager#173). Non-secret. Empty/unset ⇒ strict same-host.
+  NIP98_PUBLIC_HOST_ALLOWLIST?: string;
   ANTHROPIC_API_KEY?: string;
   // Cloudflare Access Service Token for moderation.admin.divine.video
   CF_ACCESS_CLIENT_ID?: string | SecretStoreSecret;
@@ -270,6 +274,15 @@ function getAllowedOrigin(requestOrigin: string | null, allowedOriginsEnv: strin
   return null;
 }
 
+// Parse the NIP-98 public-host allowlist (#173). Same split/trim/filter shape as
+// getAllowedOrigin. Bare hostnames, no wildcards. Empty/unset ⇒ [] ⇒ strict.
+function getNip98AllowedHosts(env: Env): string[] {
+  return (env.NIP98_PUBLIC_HOST_ALLOWLIST ?? '')
+    .split(',')
+    .map((host) => host.trim())
+    .filter(Boolean);
+}
+
 function originMatchesRule(requestOrigin: string, allowedRule: string): boolean {
   if (requestOrigin === allowedRule) {
     return true;
@@ -407,14 +420,14 @@ export default {
 
       // Mobile-facing endpoints: NIP-98 user auth, not admin auth
       if (path === '/v1/account/moderation-status' && request.method === 'GET') {
-        const authResult = await verifyNip98Auth(request, request.url);
+        const authResult = await verifyNip98Auth(request, request.url, getNip98AllowedHosts(env));
         if (!authResult.valid || !authResult.pubkey) return jsonResponse({ success: false, error: authResult.error ?? 'Unauthorized' }, 401, corsHeaders);
         if (env.DB) await ensureSchemaOnce(env.DB);
         return handleGetModerationStatus(authResult.pubkey, env, corsHeaders);
       }
 
       if (path.startsWith('/v1/minor-review-cases/') && path.endsWith('/parent-contact') && request.method === 'POST') {
-        const authResult = await verifyNip98Auth(request, request.url);
+        const authResult = await verifyNip98Auth(request, request.url, getNip98AllowedHosts(env));
         if (!authResult.valid || !authResult.pubkey) return jsonResponse({ success: false, error: authResult.error ?? 'Unauthorized' }, 401, corsHeaders);
         if (env.DB) await ensureSchemaOnce(env.DB);
         const caseId = path.replace('/v1/minor-review-cases/', '').replace('/parent-contact', '');
@@ -2471,7 +2484,8 @@ async function handleZendeskPreAuth(
     // Ensure nonce table exists
     await ensureSchemaOnce(env.DB);
 
-    // Verify NIP-98 auth
+    // Verify NIP-98 auth. Intentionally strict: no allowedHosts passed, so this
+    // Zendesk pre-auth path stays same-host only (#173 scope — do not relax).
     const authResult = await verifyNip98Auth(request, request.url);
     if (!authResult.valid) {
       return jsonResponse(

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1862,9 +1862,30 @@ interface Nip98Result {
   error?: string;
 }
 
-async function verifyNip98Auth(
+// Returns true iff `signedUrl` differs from `expectedUrl` only in host, that host
+// is in `allowedHosts` (bare hostnames), and scheme + path + query still match
+// exactly. Used only by the two mobile endpoints (#173); strict callers pass an
+// empty allowlist, so this can never return true for them. Malformed URLs → false.
+function hostAllowlistedUrlMatch(signedUrl: string, expectedUrl: string, allowedHosts: string[]): boolean {
+  if (allowedHosts.length === 0) return false;
+  try {
+    const signed = new URL(signedUrl);
+    const expected = new URL(expectedUrl);
+    return (
+      signed.protocol === expected.protocol && // scheme not dropped (Constraint 2)
+      signed.pathname === expected.pathname &&  // path stays exactly bound
+      signed.search === expected.search &&      // query stays exactly bound
+      allowedHosts.includes(signed.hostname)    // host is the only relaxation
+    );
+  } catch {
+    return false;
+  }
+}
+
+export async function verifyNip98Auth(
   request: Request,
-  expectedUrl: string
+  expectedUrl: string,
+  allowedHosts: string[] = []
 ): Promise<Nip98Result> {
   const authHeader = request.headers.get('Authorization');
   if (!authHeader || !authHeader.startsWith('Nostr ')) {
@@ -1894,9 +1915,19 @@ async function verifyNip98Auth(
       return { valid: false, error: 'Event timestamp too old or in future' };
     }
 
-    // Verify URL tag
+    // Verify URL tag. Exact string match is the unchanged fast path (covers all
+    // same-host callers, including strict callers that pass no allowedHosts).
+    // Only when the strings differ do we relax the HOST — and only the host:
+    // scheme, path, and query must still match the worker's own request exactly,
+    // and the signed host must be a member of the caller-supplied allowlist.
+    // This closes divine-relay-manager#173, where the mobile client signs for the
+    // public host (api.divine.video) but the request is forwarded to the worker's
+    // real host, so request.url (== expectedUrl) never string-matches the signed u.
     const urlTag = event.tags.find((t: string[]) => t[0] === 'u');
-    if (!urlTag || urlTag[1] !== expectedUrl) {
+    if (!urlTag) {
+      return { valid: false, error: `URL mismatch (expected ${expectedUrl})` };
+    }
+    if (urlTag[1] !== expectedUrl && !hostAllowlistedUrlMatch(urlTag[1], expectedUrl, allowedHosts)) {
       return { valid: false, error: `URL mismatch (expected ${expectedUrl})` };
     }
 

--- a/worker/src/nip98-auth.test.ts
+++ b/worker/src/nip98-auth.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { finalizeEvent, generateSecretKey } from 'nostr-tools';
+import { verifyNip98Auth } from './index';
+
+const OWN = 'https://api-relay-prod.divine.video/v1/account/moderation-status';
+const PUBLIC_HOST = 'api.divine.video';
+const PUBLIC = 'https://api.divine.video/v1/account/moderation-status';
+
+type EvtOverrides = { u: string; method: string; createdAt?: number };
+
+// Build a signed kind-27235 event (mirrors nip86.ts:99-112, minus the payload tag).
+function signEvent(o: EvtOverrides) {
+  const sk = generateSecretKey();
+  return finalizeEvent(
+    {
+      kind: 27235,
+      content: '',
+      tags: [['u', o.u], ['method', o.method]],
+      created_at: o.createdAt ?? Math.floor(Date.now() / 1000),
+    },
+    sk,
+  );
+}
+
+function toHeader(evt: unknown): string {
+  return 'Nostr ' + btoa(JSON.stringify(evt));
+}
+
+// A request that arrives at the worker's OWN host (the forwarded-request scenario).
+function reqAtOwnHost(authHeader: string, method = 'GET'): Request {
+  return new Request(OWN, { method, headers: { Authorization: authHeader } });
+}
+
+describe('verifyNip98Auth host allowlist', () => {
+  it('accepts own host arriving at own host (regression: new builds keep working)', async () => {
+    const evt = signEvent({ u: OWN, method: 'GET' });
+    const res = await verifyNip98Auth(reqAtOwnHost(toHeader(evt)), OWN, [PUBLIC_HOST]);
+    expect(res.valid).toBe(true);
+    expect(res.pubkey).toBe(evt.pubkey);
+  });
+
+  it('accepts a public host that is in the allowlist (the fix)', async () => {
+    const evt = signEvent({ u: PUBLIC, method: 'GET' });
+    const res = await verifyNip98Auth(reqAtOwnHost(toHeader(evt)), OWN, [PUBLIC_HOST]);
+    expect(res.valid).toBe(true);
+    expect(res.pubkey).toBe(evt.pubkey);
+  });
+
+  it('rejects a host that is NOT in the allowlist', async () => {
+    const evt = signEvent({ u: 'https://evil.example/v1/account/moderation-status', method: 'GET' });
+    const res = await verifyNip98Auth(reqAtOwnHost(toHeader(evt)), OWN, [PUBLIC_HOST]);
+    expect(res.valid).toBe(false);
+  });
+
+  it('rejects an allowlisted host with the WRONG path (path stays bound)', async () => {
+    const evt = signEvent({ u: 'https://api.divine.video/v1/account/OTHER', method: 'GET' });
+    const res = await verifyNip98Auth(reqAtOwnHost(toHeader(evt)), OWN, [PUBLIC_HOST]);
+    expect(res.valid).toBe(false);
+  });
+
+  it('rejects an allowlisted host with the WRONG method (method stays bound)', async () => {
+    const evt = signEvent({ u: PUBLIC, method: 'POST' });
+    const res = await verifyNip98Auth(reqAtOwnHost(toHeader(evt), 'GET'), OWN, [PUBLIC_HOST]);
+    expect(res.valid).toBe(false);
+  });
+
+  it('rejects an allowlisted host with the WRONG scheme (http vs https — scheme not dropped)', async () => {
+    const evt = signEvent({ u: 'http://api.divine.video/v1/account/moderation-status', method: 'GET' });
+    const res = await verifyNip98Auth(reqAtOwnHost(toHeader(evt)), OWN, [PUBLIC_HOST]);
+    expect(res.valid).toBe(false);
+  });
+
+  it('rejects an expired event (freshness unchanged)', async () => {
+    const evt = signEvent({ u: PUBLIC, method: 'GET', createdAt: Math.floor(Date.now() / 1000) - 120 });
+    const res = await verifyNip98Auth(reqAtOwnHost(toHeader(evt)), OWN, [PUBLIC_HOST]);
+    expect(res.valid).toBe(false);
+  });
+
+  it('rejects an invalid signature (signature check unchanged)', async () => {
+    const evt = signEvent({ u: PUBLIC, method: 'GET' });
+    const tampered = { ...evt, sig: '0'.repeat(128) };
+    const res = await verifyNip98Auth(reqAtOwnHost(toHeader(tampered)), OWN, [PUBLIC_HOST]);
+    expect(res.valid).toBe(false);
+  });
+
+  it('SCOPE BOUNDARY: a Zendesk-style call (no allowedHosts) rejects the public host', async () => {
+    // Mirrors the Zendesk pre-auth call site (index.ts:2442), which passes NO third arg.
+    const evt = signEvent({ u: PUBLIC, method: 'GET' });
+    const res = await verifyNip98Auth(reqAtOwnHost(toHeader(evt)), OWN);
+    expect(res.valid).toBe(false);
+    // Mutation check: temporarily pass [PUBLIC_HOST] as the 3rd arg here and this
+    // assertion flips to valid — proving the test detects the scope boundary.
+  });
+
+  it('empty/unset allowlist ⇒ own host still valid, public host rejected', async () => {
+    const ownEvt = signEvent({ u: OWN, method: 'GET' });
+    const ownRes = await verifyNip98Auth(reqAtOwnHost(toHeader(ownEvt)), OWN, []);
+    expect(ownRes.valid).toBe(true);
+
+    const pubEvt = signEvent({ u: PUBLIC, method: 'GET' });
+    const pubRes = await verifyNip98Auth(reqAtOwnHost(toHeader(pubEvt)), OWN, []);
+    expect(pubRes.valid).toBe(false);
+  });
+});

--- a/worker/src/nip98-auth.test.ts
+++ b/worker/src/nip98-auth.test.ts
@@ -101,4 +101,16 @@ describe('verifyNip98Auth host allowlist', () => {
     const pubRes = await verifyNip98Auth(reqAtOwnHost(toHeader(pubEvt)), OWN, []);
     expect(pubRes.valid).toBe(false);
   });
+
+  it('rejects a userinfo/credential-prefixed host that resolves to a foreign hostname (no .host bypass)', async () => {
+    // `URL.hostname` of this is `evil.com` — the `api-relay-prod.divine.video@` part
+    // is userinfo, not host. A refactor to `.host` or a naive string split/includes
+    // check could be fooled into treating this as the allowlisted own host.
+    const evt = signEvent({
+      u: 'https://api-relay-prod.divine.video@evil.com/v1/account/moderation-status',
+      method: 'GET',
+    });
+    const res = await verifyNip98Auth(reqAtOwnHost(toHeader(evt)), OWN, [PUBLIC_HOST]);
+    expect(res.valid).toBe(false);
+  });
 });

--- a/worker/wrangler.local.toml
+++ b/worker/wrangler.local.toml
@@ -27,6 +27,8 @@ MODERATION_ADMIN_URL = "https://moderation-api.divine.video"
 REALNESS_API_URL = "https://realness.admin.divine.video"
 # Allow admin UI plus the managed web app and its preview deployments
 ALLOWED_ORIGINS = "https://relay.admin.divine.video,https://app.divine.video,https://*.openvine-app.pages.dev,*.divine-relay-manager.pages.dev,*.divine-relay-admin.pages.dev"
+# NIP-98 public-host allowlist (#173). Empty for local dev (strict same-host).
+NIP98_PUBLIC_HOST_ALLOWLIST = ""
 # Zendesk custom field IDs for auto-solve required fields
 ZENDESK_FIELD_CATEGORY = "14559549220879"
 ZENDESK_FIELD_ISSUE = "14560383908879"

--- a/worker/wrangler.prod.toml
+++ b/worker/wrangler.prod.toml
@@ -91,6 +91,10 @@ MODERATION_SERVICE_URL = "https://moderation-api.divine.video"
 MODERATION_ADMIN_URL = "https://moderation-api.divine.video"
 # Allow admin UI plus the managed web app and its preview deployments
 ALLOWED_ORIGINS = "https://relay.admin.divine.video,https://app.divine.video,https://*.openvine-app.pages.dev,*.divine-relay-manager.pages.dev,*.divine-relay-admin.pages.dev"
+# Public hostname(s) whose NIP-98 u-tag host is accepted in addition to this
+# worker's own host, for the two mobile endpoints only (divine-relay-manager#173).
+# Comma-separated bare hostnames, no wildcards. Empty/unset = strict same-host.
+NIP98_PUBLIC_HOST_ALLOWLIST = "api.divine.video"
 # CDN domain for media proxy (Blossom admin bypass for blocked content preview)
 CDN_DOMAIN = "media.divine.video"
 # Slack webhook for age review deadline alerts (add via: wrangler secret put SLACK_WEBHOOK_URL --config wrangler.prod.toml)

--- a/worker/wrangler.staging.toml
+++ b/worker/wrangler.staging.toml
@@ -90,6 +90,11 @@ MODERATION_SERVICE_URL = "https://moderation-api.divine.video"
 MODERATION_ADMIN_URL = "https://moderation-api.divine.video"
 # Allow admin UI plus the managed web app and its preview deployments
 ALLOWED_ORIGINS = "https://relay.admin.divine.video,https://app.divine.video,https://*.openvine-app.pages.dev,*.divine-relay-manager.pages.dev,*.divine-relay-admin.pages.dev"
+# Public hostname(s) whose NIP-98 u-tag host is accepted in addition to this
+# worker's own host, for the two mobile endpoints only (divine-relay-manager#173).
+# TO CONFIRM before deploy: the staging public-host equivalent of api.divine.video
+# is not yet known — do NOT guess. Leave empty until the Half-1 proxy owner confirms it.
+NIP98_PUBLIC_HOST_ALLOWLIST = ""
 # CDN domain for media proxy (Blossom admin bypass for blocked content preview)
 CDN_DOMAIN = "media.divine.video"
 # Slack webhook for age review deadline alerts (add via: wrangler secret put SLACK_WEBHOOK_URL --config wrangler.staging.toml)


### PR DESCRIPTION
## What this does

Part of #173 (the worker half). The two mobile minor-review endpoints authenticate with NIP-98, which binds each signed request to an exact URL. Requests that older app installs sign for the public host `api.divine.video` reach the worker on its own host (`api-relay-prod.divine.video`), so the exact-URL check rejects them and the minor-review gate does not take effect on those devices. This change lets the worker accept a NIP-98 signature made for a configured public host in addition to its own host, so the gate reaches the existing install base once the routing half is in place.

## Approach

`verifyNip98Auth` keeps its exact-string URL match as an unchanged fast path. Only when the strings differ does it fall back to an additive check that relaxes the host and nothing else: scheme, path, and query must still match the worker's own request exactly, and the signed host must be a member of a per-environment allowlist. An empty or unset allowlist preserves the original strict same-host behaviour, so this does not loosen anything by default.

The allowlist is threaded into only the two mobile endpoints (`GET /v1/account/moderation-status` and `POST /v1/minor-review-cases/*/parent-contact`). The Zendesk pre-auth endpoint keeps strict same-host checking and is left unchanged.

## Config

New non-secret var `NIP98_PUBLIC_HOST_ALLOWLIST` (comma-separated hostnames):
- prod: `api.divine.video`
- staging: empty, pending confirmation of the staging public host
- local: empty

## Scope and dependencies

- The routing half of #173 (directing `api.divine.video/v1/*` to this worker) is infra work in another repo and is not in this PR. This worker change stays inert until that route exists.
- Staging stays inert until its public host is set.

## Testing

New unit tests cover the host allowlist, the scheme/path/method binding, freshness, signature, a userinfo-host rejection, mixed-case config, and the empty-allowlist default. Router tests exercise the wiring end to end, and a route-level test confirms the Zendesk endpoint still rejects an allowlisted public host. Full worker suite green (unit and D1), typecheck and lint clean.

## Follow-ups (tracked separately)

This PR closes the specific fail-open gap for existing installs. Three related hardening items are filed and complete the picture:

- #195 — a single-use nonce for NIP-98 replay protection (the 60s freshness window is the only replay guard today, and relaxing the host slightly widens it).
- #196 — bind the POST parent-contact body with a NIP-98 payload hash (identity, URL, and method are bound today; the body is not).
- #197 — make the moderation-status DB-unavailable fail-open observable and alerted (done, separate PR).

#195 and #196 modify the same `verifyNip98Auth` function as this PR and are sequenced after it to avoid stacking.
