### PR TITLE
feat(age-review): alert on the moderation-status DB-unavailable fail-open (#197)

### DIFF
--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -9,6 +9,7 @@ import {
   handleAgeReviewReplyWebhook,
   handleCreateMinorAccount,
   checkAgeReviewDeadlines,
+  sendDbUnavailableAlert,
   syncAgeReviewTicketResolution,
   getAgeReviewConfig,
   updateAgeReviewConfig,
@@ -1026,12 +1027,62 @@ describe('handleGetModerationStatus', () => {
     expect(body.restriction.status).toBe('active');
   });
 
-  it('returns active (fail-open) when DB unavailable', async () => {
+  it('returns active (fail-open) when DB unavailable, logging a greppable alert marker', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
     const res = await handleGetModerationStatus('a'.repeat(64), makeEnv(), corsHeaders);
     const body = await res.json() as { restriction: { status: string } };
 
     expect(res.status).toBe(200);
     expect(body.restriction.status).toBe('active');
+    // Distinct marker so this fail-open path is alertable via log monitoring,
+    // separate from the general Slack-based cron alert (#197).
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('MODERATION_STATUS_DB_UNAVAILABLE'),
+      'a'.repeat(64),
+    );
+
+    errorSpy.mockRestore();
+  });
+});
+
+// -- sendDbUnavailableAlert ---------------------------------------------------
+
+describe('sendDbUnavailableAlert', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts the fixed DB-unavailable message to the webhook and returns true on success', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await sendDbUnavailableAlert('https://hooks.slack.com/test');
+
+    expect(result).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0][0]).toBe('https://hooks.slack.com/test');
+    const options = mockFetch.mock.calls[0][1] as { method: string; headers: Record<string, string>; body: string };
+    expect(options.method).toBe('POST');
+    const payload = JSON.parse(options.body) as { text: string };
+    expect(payload.text).toContain('D1 unavailable');
+    expect(payload.text).toContain('failing open');
+  });
+
+  it('returns false when Slack responds non-ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+
+    const result = await sendDbUnavailableAlert('https://hooks.slack.com/test');
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+
+    const result = await sendDbUnavailableAlert('https://hooks.slack.com/test');
+
+    expect(result).toBe(false);
   });
 });
 

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -1054,11 +1054,11 @@ describe('sendDbUnavailableAlert', () => {
     vi.restoreAllMocks();
   });
 
-  it('posts the fixed DB-unavailable message to the webhook and returns true on success', async () => {
+  it('posts the DB-unavailable message with the environment to the webhook and returns true on success', async () => {
     const mockFetch = vi.fn().mockResolvedValue({ ok: true });
     vi.stubGlobal('fetch', mockFetch);
 
-    const result = await sendDbUnavailableAlert('https://hooks.slack.com/test');
+    const result = await sendDbUnavailableAlert('https://hooks.slack.com/test', 'staging');
 
     expect(result).toBe(true);
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -1068,13 +1068,14 @@ describe('sendDbUnavailableAlert', () => {
     const payload = JSON.parse(options.body) as { text: string };
     expect(payload.text).toContain('D1 unavailable');
     expect(payload.text).toContain('failing open');
+    expect(payload.text).toContain('[staging]');
   });
 
   it('returns false when Slack responds non-ok', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
 
-    const result = await sendDbUnavailableAlert('https://hooks.slack.com/test');
+    const result = await sendDbUnavailableAlert('https://hooks.slack.com/test', 'production');
 
     expect(result).toBe(false);
   });
@@ -1083,7 +1084,7 @@ describe('sendDbUnavailableAlert', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
 
-    const result = await sendDbUnavailableAlert('https://hooks.slack.com/test');
+    const result = await sendDbUnavailableAlert('https://hooks.slack.com/test', 'production');
 
     expect(result).toBe(false);
   });

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -1051,6 +1051,7 @@ describe('handleGetModerationStatus', () => {
 describe('sendDbUnavailableAlert', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it('posts the fixed DB-unavailable message to the webhook and returns true on success', async () => {
@@ -1070,6 +1071,7 @@ describe('sendDbUnavailableAlert', () => {
   });
 
   it('returns false when Slack responds non-ok', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
 
     const result = await sendDbUnavailableAlert('https://hooks.slack.com/test');
@@ -1078,6 +1080,7 @@ describe('sendDbUnavailableAlert', () => {
   });
 
   it('returns false when fetch throws', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
 
     const result = await sendDbUnavailableAlert('https://hooks.slack.com/test');

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -583,6 +583,10 @@ export async function handleGetModerationStatus(
     // monitoring (#197) -- the minor-review gate failing open during a DB
     // outage should never be silent, even though we deliberately keep it
     // fail-open here (see the proactive cron alert in index.ts scheduled()).
+    // MODERATION_STATUS_DB_UNAVAILABLE is intentionally a separate marker from
+    // index.ts's "D1 UNAVAILABLE" -- this one fires per live request that just
+    // failed open; that one fires from the cron proactively detecting the DB
+    // binding is absent. Not a typo -- two distinct signals.
     console.error('[age-review] MODERATION_STATUS_DB_UNAVAILABLE — DB binding absent, returning fail-open active status for', userPubkey);
     return json({ restriction: { status: 'active' } }, 200, corsHeaders);
   }

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -579,7 +579,11 @@ export async function handleGetModerationStatus(
   corsHeaders: Record<string, string>,
 ): Promise<Response> {
   if (!env.DB) {
-    console.warn('[age-review] DB not available — returning fail-open active status for', userPubkey);
+    // Distinct, greppable marker so this fail-open path is alertable via log
+    // monitoring (#197) -- the minor-review gate failing open during a DB
+    // outage should never be silent, even though we deliberately keep it
+    // fail-open here (see the proactive cron alert in index.ts scheduled()).
+    console.error('[age-review] MODERATION_STATUS_DB_UNAVAILABLE — DB binding absent, returning fail-open active status for', userPubkey);
     return json({ restriction: { status: 'active' } }, 200, corsHeaders);
   }
 
@@ -1260,6 +1264,29 @@ async function sendSlackAlert(
     return true;
   } catch (error) {
     console.error('[age-review] Failed to send Slack alert:', error);
+    return false;
+  }
+}
+
+// Proactive alert for the moderation-status DB-unavailable fail-open (#197).
+// Called from index.ts scheduled() once per cron tick when env.DB is absent,
+// so the outage isn't silent even though the request path keeps failing open.
+export async function sendDbUnavailableAlert(webhookUrl: string): Promise<boolean> {
+  try {
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        text: ':rotating_light: D1 unavailable — age-review moderation-status is failing open (returning unrestricted `active`). Investigate the moderation-decisions D1 binding.',
+      }),
+    });
+    if (!res.ok) {
+      console.error(`[age-review] DB-unavailable Slack alert returned ${res.status}`);
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.error('[age-review] Failed to send DB-unavailable Slack alert:', error);
     return false;
   }
 }

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -1275,13 +1275,13 @@ async function sendSlackAlert(
 // Proactive alert for the moderation-status DB-unavailable fail-open (#197).
 // Called from index.ts scheduled() once per cron tick when env.DB is absent,
 // so the outage isn't silent even though the request path keeps failing open.
-export async function sendDbUnavailableAlert(webhookUrl: string): Promise<boolean> {
+export async function sendDbUnavailableAlert(webhookUrl: string, environment: string): Promise<boolean> {
   try {
     const res = await fetch(webhookUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        text: ':rotating_light: D1 unavailable — age-review moderation-status is failing open (returning unrestricted `active`). Investigate the moderation-decisions D1 binding.',
+        text: `:rotating_light: [${environment}] D1 unavailable — age-review moderation-status is failing open (returning unrestricted \`active\`). Investigate the moderation-decisions D1 binding.`,
       }),
     });
     if (!res.ok) {

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -946,7 +946,7 @@ describe('scheduled cron — DB-unavailable alert', () => {
     vi.restoreAllMocks();
   });
 
-  it('sends the DB-unavailable Slack alert when the DB binding is absent', async () => {
+  it('sends the DB-unavailable Slack alert (with environment) when the DB binding is absent', async () => {
     const mockFetch = vi.fn().mockResolvedValue({ ok: true });
     vi.stubGlobal('fetch', mockFetch);
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -956,6 +956,7 @@ describe('scheduled cron — DB-unavailable alert', () => {
       RELAY_URL: 'wss://relay.divine.video',
       REPORT_WATCHER: makeReportWatcher(),
       SLACK_WEBHOOK_URL: 'https://hooks.slack.com/test',
+      ENVIRONMENT: 'staging',
       // DB intentionally absent
     } as never;
 
@@ -963,7 +964,48 @@ describe('scheduled cron — DB-unavailable alert', () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockFetch.mock.calls[0][0]).toBe('https://hooks.slack.com/test');
+    const options = mockFetch.mock.calls[0][1] as { body: string };
+    const payload = JSON.parse(options.body) as { text: string };
+    expect(payload.text).toContain('[staging]');
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('D1 UNAVAILABLE'));
+  });
+
+  it('defaults the environment to "unknown" when ENVIRONMENT is not configured', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const cronEnv = {
+      ALLOWED_ORIGINS: 'https://app.divine.video',
+      RELAY_URL: 'wss://relay.divine.video',
+      REPORT_WATCHER: makeReportWatcher(),
+      SLACK_WEBHOOK_URL: 'https://hooks.slack.com/test',
+      // ENVIRONMENT and DB both intentionally absent
+    } as never;
+
+    await worker.scheduled(scheduledEvent, cronEnv, ctx);
+
+    const options = mockFetch.mock.calls[0][1] as { body: string };
+    const payload = JSON.parse(options.body) as { text: string };
+    expect(payload.text).toContain('[unknown]');
+  });
+
+  it('sends the DB-unavailable alert even when REPORT_WATCHER is not configured', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const cronEnv = {
+      ALLOWED_ORIGINS: 'https://app.divine.video',
+      RELAY_URL: 'wss://relay.divine.video',
+      SLACK_WEBHOOK_URL: 'https://hooks.slack.com/test',
+      // REPORT_WATCHER and DB both intentionally absent
+    } as never;
+
+    await worker.scheduled(scheduledEvent, cronEnv, ctx);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0][0]).toBe('https://hooks.slack.com/test');
   });
 
   it('does not send the DB-unavailable alert when the DB binding is present', async () => {

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import worker from './index';
 
 const env = {
@@ -934,6 +934,12 @@ describe('scheduled cron — DB-unavailable alert', () => {
     });
     return { prepare: statement };
   }
+
+  beforeEach(() => {
+    // scheduled() unconditionally logs a ReportWatcher status line; keep it
+    // out of test stdout.
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
 
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -904,3 +904,92 @@ describe('summarize-user cache validation', () => {
     expect(kv.put).toHaveBeenCalled();
   });
 });
+
+// -- scheduled() DB-unavailable alert (#197) ----------------------------------
+
+describe('scheduled cron — DB-unavailable alert', () => {
+  const scheduledEvent = {} as ScheduledEvent;
+
+  // The REPORT_WATCHER keep-alive check runs before the DB block and returns
+  // early if the binding is absent, so it must be present to exercise the DB
+  // branch below.
+  function makeReportWatcher() {
+    return {
+      idFromName: vi.fn().mockReturnValue('singleton-id'),
+      get: vi.fn().mockReturnValue({
+        fetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({ status: { running: true } }), { status: 200 })),
+      }),
+    };
+  }
+
+  // Tolerates ensureSchema's DDL and checkAgeReviewDeadlines' queries without
+  // producing any rows, so the DB-present case exercises the real code path
+  // without also triggering the deadline-alert Slack call.
+  function makeTolerantDb() {
+    const statement = (sql: string): unknown => ({
+      bind: () => statement(sql),
+      run: async () => ({ success: true, meta: { changes: 0 } }),
+      first: async () => null,
+      all: async () => ({ results: [] }),
+    });
+    return { prepare: statement };
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('sends the DB-unavailable Slack alert when the DB binding is absent', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const cronEnv = {
+      ALLOWED_ORIGINS: 'https://app.divine.video',
+      RELAY_URL: 'wss://relay.divine.video',
+      REPORT_WATCHER: makeReportWatcher(),
+      SLACK_WEBHOOK_URL: 'https://hooks.slack.com/test',
+      // DB intentionally absent
+    } as never;
+
+    await worker.scheduled(scheduledEvent, cronEnv, ctx);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0][0]).toBe('https://hooks.slack.com/test');
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('D1 UNAVAILABLE'));
+  });
+
+  it('does not send the DB-unavailable alert when the DB binding is present', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const cronEnv = {
+      ALLOWED_ORIGINS: 'https://app.divine.video',
+      RELAY_URL: 'wss://relay.divine.video',
+      REPORT_WATCHER: makeReportWatcher(),
+      SLACK_WEBHOOK_URL: 'https://hooks.slack.com/test',
+      DB: makeTolerantDb(),
+    } as never;
+
+    await worker.scheduled(scheduledEvent, cronEnv, ctx);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not send the DB-unavailable alert when no webhook is configured', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const cronEnv = {
+      ALLOWED_ORIGINS: 'https://app.divine.video',
+      RELAY_URL: 'wss://relay.divine.video',
+      REPORT_WATCHER: makeReportWatcher(),
+      // SLACK_WEBHOOK_URL intentionally absent, DB absent too
+    } as never;
+
+    await worker.scheduled(scheduledEvent, cronEnv, ctx);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -620,19 +620,18 @@ export default {
   // Cron keep-alive: wake the ReportWatcher DO every 5 minutes so the alarm
   // chain can't break permanently after a Cloudflare-initiated eviction.
   async scheduled(_event: ScheduledEvent, env: Env, _ctx: ExecutionContext): Promise<void> {
-    if (!env.REPORT_WATCHER) {
-      console.log('[scheduled] REPORT_WATCHER binding not configured, skipping');
-      return;
-    }
-
-    try {
-      const id = env.REPORT_WATCHER.idFromName('singleton');
-      const stub = env.REPORT_WATCHER.get(id);
-      const response = await stub.fetch(new Request('https://do/status'));
-      const status = await response.json() as { status?: { running: boolean } };
-      console.log(`[scheduled] ReportWatcher status: running=${status?.status?.running}`);
-    } catch (error) {
-      console.error('[scheduled] Failed to check ReportWatcher:', error);
+    if (env.REPORT_WATCHER) {
+      try {
+        const id = env.REPORT_WATCHER.idFromName('singleton');
+        const stub = env.REPORT_WATCHER.get(id);
+        const response = await stub.fetch(new Request('https://do/status'));
+        const status = await response.json() as { status?: { running: boolean } };
+        console.log(`[scheduled] ReportWatcher status: running=${status?.status?.running}`);
+      } catch (error) {
+        console.error('[scheduled] Failed to check ReportWatcher:', error);
+      }
+    } else {
+      console.log('[scheduled] REPORT_WATCHER binding not configured, skipping keep-alive');
     }
 
     // Clean up expired pre-auth nonces
@@ -668,7 +667,7 @@ export default {
       // targets. Repeated ~5-min reminders during a sustained outage are
       // acceptable (and preferable to a throttle silently failing open too).
       try {
-        await sendDbUnavailableAlert(env.SLACK_WEBHOOK_URL);
+        await sendDbUnavailableAlert(env.SLACK_WEBHOOK_URL, env.ENVIRONMENT ?? 'unknown');
       } catch (error) {
         console.error('[scheduled] Failed to send DB-unavailable Slack alert:', error);
       }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -658,7 +658,15 @@ export default {
     } else if (env.SLACK_WEBHOOK_URL) {
       // #197: D1 binding unavailable — moderation-status is failing open (returning
       // unrestricted). Alert once per cron tick so the outage isn't silent.
+      // "D1 UNAVAILABLE" is intentionally a separate marker from age-review.ts's
+      // MODERATION_STATUS_DB_UNAVAILABLE -- this one is the cron proactively
+      // detecting the DB binding is absent; that one fires per live request
+      // that just failed open. Not a typo -- two distinct signals.
       console.error('[scheduled] D1 UNAVAILABLE — moderation-status failing open; investigate the moderation-decisions DB binding');
+      // No throttle/dedup here: D1 is the resource that's down, so a D1-backed
+      // last_alerted_at-style throttle would fail during the very outage this
+      // targets. Repeated ~5-min reminders during a sustained outage are
+      // acceptable (and preferable to a throttle silently failing open too).
       try {
         await sendDbUnavailableAlert(env.SLACK_WEBHOOK_URL);
       } catch (error) {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -25,6 +25,7 @@ import {
   handleParentContact,
   handleAgeReviewReplyWebhook,
   checkAgeReviewDeadlines,
+  sendDbUnavailableAlert,
   getAgeReviewConfig,
   updateAgeReviewConfig,
 } from './age-review';
@@ -653,6 +654,15 @@ export default {
         await checkAgeReviewDeadlines(env);
       } catch (error) {
         console.error('[scheduled] Age review deadline check failed:', error);
+      }
+    } else if (env.SLACK_WEBHOOK_URL) {
+      // #197: D1 binding unavailable — moderation-status is failing open (returning
+      // unrestricted). Alert once per cron tick so the outage isn't silent.
+      console.error('[scheduled] D1 UNAVAILABLE — moderation-status failing open; investigate the moderation-decisions DB binding');
+      try {
+        await sendDbUnavailableAlert(env.SLACK_WEBHOOK_URL);
+      } catch (error) {
+        console.error('[scheduled] Failed to send DB-unavailable Slack alert:', error);
       }
     }
   },


### PR DESCRIPTION
## What this does

Closes #197. When the worker's D1 binding is unavailable, `handleGetModerationStatus` deliberately fails open (returns an unrestricted `active` status) so a database problem does not lock out normal users. Until now that happened silently, so the minor-review gate could be failing open with no signal. This keeps the fail-open behaviour but makes it observable.

## Approach

- The request-path fail-open branch now logs a distinct, greppable error marker (`MODERATION_STATUS_DB_UNAVAILABLE`) instead of a quiet warning, so log-based monitoring can alert on it. The returned status and body are unchanged.
- The scheduled cron now sends a Slack alert (reusing the existing age-review alert path) when the DB binding is absent. It fires from the cron rather than per request, so it cannot storm, and a Slack failure cannot disrupt the rest of the scheduled work.

Keeping fail-open rather than switching to fail-closed was a deliberate decision: the client already fails open when the server is unreachable, so failing closed here would add little protection at the cost of locking users out during any outage. Observability was the real gap.

## Scope

Covers the binding-absent (`!env.DB`) case, which is the condition that produces the fail-open. A transient D1 query failure already surfaces as a 500 and is out of scope here.

## Relation to #173

Part of the minor-safety hardening surfaced alongside #173 (the public-host allowlist fix). Sibling follow-ups #195 (replay nonce) and #196 (payload-hash binding) remain open.

## Testing

New tests cover the request-path marker, the Slack alert helper, and the cron branch (fires only when the DB binding is absent and a webhook is configured, never when the DB is present). Full worker suite green, typecheck and lint clean.
