### PR TITLE
feat(age-review): account-type indicator for moderation cases

### DIFF
--- a/src/components/AccountTypeIndicator.test.tsx
+++ b/src/components/AccountTypeIndicator.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { AccountTypeIndicator } from './AccountTypeIndicator';
+
+describe('AccountTypeIndicator', () => {
+  it('renders self-custody as informational with the no-effective-enforcement verdict', () => {
+    render(<AccountTypeIndicator accountStatus={{ success: false, not_found: true }} accountStatusError={false} postCount={0} ticketLinked={true} />);
+    expect(screen.getByText('Self-custody (not in keycast)')).toBeInTheDocument(); // the badge
+    expect(screen.getByText(/no effective enforcement available/i)).toBeInTheDocument(); // the verdict
+    // Not styled/labelled as an error.
+    expect(screen.queryByText(/failed/i)).not.toBeInTheDocument();
+  });
+  it('renders unknown when the keycast lookup is unavailable', () => {
+    render(<AccountTypeIndicator accountStatus={{ success: false, error: '500' }} accountStatusError={false} postCount={0} ticketLinked={false} />);
+    expect(screen.getByText('Account status unavailable')).toBeInTheDocument(); // the badge
+  });
+  it('renders a Divine account with a compliance checklist', () => {
+    render(<AccountTypeIndicator accountStatus={{ success: true, status: 'active' }} accountStatusError={false} postCount={4} ticketLinked={false} />);
+    expect(screen.getByText(/divine account/i)).toBeInTheDocument();
+    expect(screen.getByText(/Sign-in \(keycast\) suspend/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/AccountTypeIndicator.test.tsx
+++ b/src/components/AccountTypeIndicator.test.tsx
@@ -4,19 +4,29 @@ import { AccountTypeIndicator } from './AccountTypeIndicator';
 
 describe('AccountTypeIndicator', () => {
   it('renders self-custody as informational with the no-effective-enforcement verdict', () => {
-    render(<AccountTypeIndicator accountStatus={{ success: false, not_found: true }} accountStatusError={false} postCount={0} ticketLinked={true} />);
+    render(<AccountTypeIndicator accountStatus={{ success: false, not_found: true }} accountStatusError={false} accountStatusLoading={false} contentPresenceKnown={true} postCount={0} ticketLinked={true} />);
     expect(screen.getByText('Self-custody (not in keycast)')).toBeInTheDocument(); // the badge
     expect(screen.getByText(/no effective enforcement available/i)).toBeInTheDocument(); // the verdict
     // Not styled/labelled as an error.
     expect(screen.queryByText(/failed/i)).not.toBeInTheDocument();
   });
   it('renders unknown when the keycast lookup is unavailable', () => {
-    render(<AccountTypeIndicator accountStatus={{ success: false, error: '500' }} accountStatusError={false} postCount={0} ticketLinked={false} />);
+    render(<AccountTypeIndicator accountStatus={{ success: false, error: '500' }} accountStatusError={false} accountStatusLoading={false} contentPresenceKnown={true} postCount={0} ticketLinked={false} />);
     expect(screen.getByText('Account status unavailable')).toBeInTheDocument(); // the badge
   });
   it('renders a Divine account with a compliance checklist', () => {
-    render(<AccountTypeIndicator accountStatus={{ success: true, status: 'active' }} accountStatusError={false} postCount={4} ticketLinked={false} />);
+    render(<AccountTypeIndicator accountStatus={{ success: true, status: 'active' }} accountStatusError={false} accountStatusLoading={false} contentPresenceKnown={true} postCount={4} ticketLinked={false} />);
     expect(screen.getByText(/divine account/i)).toBeInTheDocument();
     expect(screen.getByText(/Sign-in \(keycast\) suspend/i)).toBeInTheDocument();
+  });
+  it('shows a checking state while account status loads (no unavailable flash)', () => {
+    render(<AccountTypeIndicator accountStatus={undefined} accountStatusError={false} accountStatusLoading={true} contentPresenceKnown={false} postCount={undefined} ticketLinked={false} />);
+    expect(screen.getByText(/checking account status/i)).toBeInTheDocument();
+    expect(screen.queryByText(/unavailable/i)).not.toBeInTheDocument();
+  });
+  it('does not conclude unactionable when the content read is unresolved', () => {
+    render(<AccountTypeIndicator accountStatus={{ success: false, not_found: true }} accountStatusError={false} accountStatusLoading={false} contentPresenceKnown={false} postCount={undefined} ticketLinked={true} />);
+    expect(screen.getByText(/verify content directly/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no effective enforcement/i)).not.toBeInTheDocument();
   });
 });

--- a/src/components/AccountTypeIndicator.test.tsx
+++ b/src/components/AccountTypeIndicator.test.tsx
@@ -19,6 +19,11 @@ describe('AccountTypeIndicator', () => {
     expect(screen.getByText(/divine account/i)).toBeInTheDocument();
     expect(screen.getByText(/Sign-in \(keycast\) suspend/i)).toBeInTheDocument();
   });
+  it('does not assert active sign-in when keycast omits status', () => {
+    render(<AccountTypeIndicator accountStatus={{ success: true }} accountStatusError={false} accountStatusLoading={false} contentPresenceKnown={true} postCount={4} ticketLinked={false} />);
+    expect(screen.getAllByText(/sign-in status unavailable/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/sign-in active/i)).not.toBeInTheDocument();
+  });
   it('shows a checking state while account status loads (no unavailable flash)', () => {
     render(<AccountTypeIndicator accountStatus={undefined} accountStatusError={false} accountStatusLoading={true} contentPresenceKnown={false} postCount={undefined} ticketLinked={false} />);
     expect(screen.getByText(/checking account status/i)).toBeInTheDocument();

--- a/src/components/AccountTypeIndicator.tsx
+++ b/src/components/AccountTypeIndicator.tsx
@@ -65,7 +65,9 @@ export function AccountTypeIndicator({
         <Badge className={TYPE_CLASS[v.accountType]}>{TYPE_LABEL[v.accountType]}</Badge>
         {v.accountType === 'divine' ? (
           <span className="text-xs text-muted-foreground">
-            {v.suspended ? 'sign-in suspended' : 'sign-in active'}
+            {accountStatus?.status === 'suspended' ? 'sign-in suspended'
+              : accountStatus?.status === 'banned' ? 'sign-in banned'
+              : 'sign-in active'}
           </span>
         ) : null}
       </div>

--- a/src/components/AccountTypeIndicator.tsx
+++ b/src/components/AccountTypeIndicator.tsx
@@ -7,7 +7,9 @@ import { deriveAccountVerdict, type LegState } from '@/lib/accountVerdict';
 interface Props {
   accountStatus: AccountStatusResponse | undefined;
   accountStatusError: boolean;
+  accountStatusLoading: boolean;
   postCount: number | undefined;
+  contentPresenceKnown: boolean;
   ticketLinked: boolean;
 }
 
@@ -37,8 +39,25 @@ const LEG_CLASS: Record<LegState, string> = {
   not_tracked: 'text-muted-foreground italic',
 };
 
-export function AccountTypeIndicator({ accountStatus, accountStatusError, postCount, ticketLinked }: Props) {
-  const v = deriveAccountVerdict({ accountStatus, accountStatusError, postCount, ticketLinked });
+export function AccountTypeIndicator({
+  accountStatus,
+  accountStatusError,
+  accountStatusLoading,
+  postCount,
+  contentPresenceKnown,
+  ticketLinked,
+}: Props) {
+  // Cold open: the account-status query is in flight with nothing cached yet.
+  // Show a neutral "checking" state rather than flashing "unavailable — retry".
+  if (accountStatusLoading && !accountStatus && !accountStatusError) {
+    return (
+      <div className="rounded-md border p-3 text-sm text-muted-foreground">
+        Checking account status…
+      </div>
+    );
+  }
+
+  const v = deriveAccountVerdict({ accountStatus, accountStatusError, postCount, contentPresenceKnown, ticketLinked });
 
   return (
     <div className="space-y-2 rounded-md border p-3">

--- a/src/components/AccountTypeIndicator.tsx
+++ b/src/components/AccountTypeIndicator.tsx
@@ -1,0 +1,72 @@
+// ABOUTME: Moderator-facing indicator of a target's account type and what
+// ABOUTME: enforcement is actually effective, plus a partial compliance checklist.
+import { Badge } from '@/components/ui/badge';
+import type { AccountStatusResponse } from '@/lib/adminApi';
+import { deriveAccountVerdict, type LegState } from '@/lib/accountVerdict';
+
+interface Props {
+  accountStatus: AccountStatusResponse | undefined;
+  accountStatusError: boolean;
+  postCount: number | undefined;
+  ticketLinked: boolean;
+}
+
+const TYPE_LABEL = {
+  divine: 'Divine account',
+  self_custody: 'Self-custody (not in keycast)',
+  unknown: 'Account status unavailable',
+} as const;
+
+const TYPE_CLASS = {
+  divine: 'bg-sky-600 text-white hover:bg-sky-600',
+  self_custody: 'bg-muted text-foreground', // informational, not destructive
+  unknown: 'bg-muted text-muted-foreground',
+} as const;
+
+const LEG_LABEL: Record<LegState, string> = {
+  done: 'done',
+  missing: 'missing',
+  na: 'n/a',
+  not_tracked: 'not tracked yet',
+};
+
+const LEG_CLASS: Record<LegState, string> = {
+  done: 'text-emerald-600',
+  missing: 'text-amber-600 font-medium',
+  na: 'text-muted-foreground',
+  not_tracked: 'text-muted-foreground italic',
+};
+
+export function AccountTypeIndicator({ accountStatus, accountStatusError, postCount, ticketLinked }: Props) {
+  const v = deriveAccountVerdict({ accountStatus, accountStatusError, postCount, ticketLinked });
+
+  return (
+    <div className="space-y-2 rounded-md border p-3">
+      <div className="flex items-center gap-2 flex-wrap">
+        <Badge className={TYPE_CLASS[v.accountType]}>{TYPE_LABEL[v.accountType]}</Badge>
+        {v.accountType === 'divine' ? (
+          <span className="text-xs text-muted-foreground">
+            {v.suspended ? 'sign-in suspended' : 'sign-in active'}
+          </span>
+        ) : null}
+      </div>
+
+      {v.contentPresence === 'hidden_suspended' ? (
+        <p className="text-xs text-muted-foreground">
+          No visible content, but the account is suspended — content may be hidden by our enforcement (viewer coming).
+        </p>
+      ) : null}
+
+      <ul className="text-xs space-y-0.5">
+        {v.legs.map((leg) => (
+          <li key={leg.key} className="flex justify-between gap-2">
+            <span className="text-muted-foreground">{leg.label}</span>
+            <span className={LEG_CLASS[leg.state]}>{LEG_LABEL[leg.state]}</span>
+          </li>
+        ))}
+      </ul>
+
+      <p className="text-sm font-medium">{v.verdict}</p>
+    </div>
+  );
+}

--- a/src/components/AccountTypeIndicator.tsx
+++ b/src/components/AccountTypeIndicator.tsx
@@ -39,6 +39,13 @@ const LEG_CLASS: Record<LegState, string> = {
   not_tracked: 'text-muted-foreground italic',
 };
 
+const SIGN_IN_LABEL = {
+  active: 'sign-in active',
+  blocked: 'sign-in blocked',
+  unknown: 'sign-in status unavailable',
+  not_applicable: '',
+} as const;
+
 export function AccountTypeIndicator({
   accountStatus,
   accountStatusError,
@@ -65,9 +72,7 @@ export function AccountTypeIndicator({
         <Badge className={TYPE_CLASS[v.accountType]}>{TYPE_LABEL[v.accountType]}</Badge>
         {v.accountType === 'divine' ? (
           <span className="text-xs text-muted-foreground">
-            {accountStatus?.status === 'suspended' ? 'sign-in suspended'
-              : accountStatus?.status === 'banned' ? 'sign-in banned'
-              : 'sign-in active'}
+            {SIGN_IN_LABEL[v.signInStatus]}
           </span>
         ) : null}
       </div>

--- a/src/components/AgeReview.handoff-mutation.test.tsx
+++ b/src/components/AgeReview.handoff-mutation.test.tsx
@@ -15,6 +15,10 @@ const updateAgeReviewCase = vi.fn();
 const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
+vi.mock('@/hooks/useUserStats', () => ({
+  useUserStats: () => ({ data: undefined }),
+}));
+
 vi.mock('@/hooks/useAdminApi', () => ({
   useApiUrl: () => 'https://api.test.divine.video',
   useAdminApi: () => ({

--- a/src/components/AgeReview.handoff-mutation.test.tsx
+++ b/src/components/AgeReview.handoff-mutation.test.tsx
@@ -16,7 +16,10 @@ const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
 vi.mock('@/hooks/useUserStats', () => ({
-  useUserStats: () => ({ data: undefined }),
+  useUserStats: () => ({
+    data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [] },
+    isError: false,
+  }),
 }));
 
 vi.mock('@/hooks/useAdminApi', () => ({

--- a/src/components/AgeReview.list-shadow.test.tsx
+++ b/src/components/AgeReview.list-shadow.test.tsx
@@ -15,6 +15,10 @@ const updateAgeReviewCase = vi.fn();
 const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
+vi.mock('@/hooks/useUserStats', () => ({
+  useUserStats: () => ({ data: undefined }),
+}));
+
 vi.mock('@/hooks/useAdminApi', () => ({
   useApiUrl: () => 'https://api.test.divine.video',
   useAdminApi: () => ({

--- a/src/components/AgeReview.list-shadow.test.tsx
+++ b/src/components/AgeReview.list-shadow.test.tsx
@@ -16,7 +16,10 @@ const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
 vi.mock('@/hooks/useUserStats', () => ({
-  useUserStats: () => ({ data: undefined }),
+  useUserStats: () => ({
+    data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [] },
+    isError: false,
+  }),
 }));
 
 vi.mock('@/hooks/useAdminApi', () => ({

--- a/src/components/AgeReview.midflight-switch.test.tsx
+++ b/src/components/AgeReview.midflight-switch.test.tsx
@@ -15,6 +15,10 @@ const updateAgeReviewCase = vi.fn();
 const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
+vi.mock('@/hooks/useUserStats', () => ({
+  useUserStats: () => ({ data: undefined }),
+}));
+
 vi.mock('@/hooks/useAdminApi', () => ({
   useApiUrl: () => 'https://api.test.divine.video',
   useAdminApi: () => ({

--- a/src/components/AgeReview.midflight-switch.test.tsx
+++ b/src/components/AgeReview.midflight-switch.test.tsx
@@ -16,7 +16,10 @@ const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
 vi.mock('@/hooks/useUserStats', () => ({
-  useUserStats: () => ({ data: undefined }),
+  useUserStats: () => ({
+    data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [] },
+    isError: false,
+  }),
 }));
 
 vi.mock('@/hooks/useAdminApi', () => ({

--- a/src/components/AgeReview.reentry.test.tsx
+++ b/src/components/AgeReview.reentry.test.tsx
@@ -15,6 +15,10 @@ const updateAgeReviewCase = vi.fn();
 const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
+vi.mock('@/hooks/useUserStats', () => ({
+  useUserStats: () => ({ data: undefined }),
+}));
+
 vi.mock('@/hooks/useAdminApi', () => ({
   useApiUrl: () => 'https://api.test.divine.video',
   useAdminApi: () => ({

--- a/src/components/AgeReview.reentry.test.tsx
+++ b/src/components/AgeReview.reentry.test.tsx
@@ -16,7 +16,10 @@ const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
 vi.mock('@/hooks/useUserStats', () => ({
-  useUserStats: () => ({ data: undefined }),
+  useUserStats: () => ({
+    data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [] },
+    isError: false,
+  }),
 }));
 
 vi.mock('@/hooks/useAdminApi', () => ({

--- a/src/components/AgeReview.uninvalidate.test.tsx
+++ b/src/components/AgeReview.uninvalidate.test.tsx
@@ -15,6 +15,10 @@ const updateAgeReviewCase = vi.fn();
 const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
+vi.mock('@/hooks/useUserStats', () => ({
+  useUserStats: () => ({ data: undefined }),
+}));
+
 vi.mock('@/hooks/useAdminApi', () => ({
   useApiUrl: () => 'https://api.test.divine.video',
   useAdminApi: () => ({

--- a/src/components/AgeReview.uninvalidate.test.tsx
+++ b/src/components/AgeReview.uninvalidate.test.tsx
@@ -16,7 +16,10 @@ const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
 vi.mock('@/hooks/useUserStats', () => ({
-  useUserStats: () => ({ data: undefined }),
+  useUserStats: () => ({
+    data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [] },
+    isError: false,
+  }),
 }));
 
 vi.mock('@/hooks/useAdminApi', () => ({

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -439,6 +439,17 @@ describe('AgeReviewDetail', () => {
     expect(await screen.findByText('Self-custody (not in keycast)')).toBeInTheDocument();
   });
 
+  it('does not show "protected-minor status unavailable" for a self-custody (not_found) account (review)', async () => {
+    getAccountStatus.mockResolvedValue({ success: false, not_found: true });
+
+    const { queryClient } = renderDetail(makeCase({ suspected_age_band: 'age_13_15' }));
+
+    await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+    // not_found is definitive (self-custody), not a keycast error — the "unavailable"
+    // protected-minor label is reserved for genuine errors.
+    expect(screen.queryByText(/protected-minor status unavailable/i)).not.toBeInTheDocument();
+  });
+
   it('shows status-unavailable when the account-status query rejects', async () => {
     getAccountStatus.mockRejectedValue(new Error('network'));
 

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -21,7 +21,7 @@ const updateAgeReviewCase = vi.fn().mockResolvedValue({ success: true });
 const getAgeReviewConfig = vi.fn().mockResolvedValue({ auto_delete_on_deny: false });
 const getAccountStatus = vi
   .fn()
-  .mockResolvedValue({ success: true, verified_minor: false });
+  .mockResolvedValue({ success: true, status: 'active', verified_minor: false });
 const writeText = vi.fn().mockResolvedValue(undefined);
 const toast = vi.fn();
 
@@ -95,7 +95,7 @@ describe('AgeReviewDetail', () => {
     getAgeReviewConfig.mockClear();
     getAgeReviewConfig.mockResolvedValue({ auto_delete_on_deny: false });
     getAccountStatus.mockClear();
-    getAccountStatus.mockResolvedValue({ success: true, verified_minor: false });
+    getAccountStatus.mockResolvedValue({ success: true, status: 'active', verified_minor: false });
     toast.mockClear();
     writeText.mockClear();
     Object.assign(navigator, {
@@ -321,7 +321,7 @@ describe('AgeReviewDetail', () => {
   });
 
   it('does not show the protected-minor badge when verified_minor is false', async () => {
-    getAccountStatus.mockResolvedValue({ success: true, verified_minor: false });
+    getAccountStatus.mockResolvedValue({ success: true, status: 'active', verified_minor: false });
 
     const { queryClient } = renderDetail(makeCase());
 
@@ -370,7 +370,7 @@ describe('AgeReviewDetail', () => {
   });
 
   it('shows the DM restriction in a separate rolling-out section, not as an applied protection', async () => {
-    getAccountStatus.mockResolvedValue({ success: true, verified_minor: true });
+    getAccountStatus.mockResolvedValue({ success: true, status: 'active', verified_minor: true });
 
     renderDetail(makeCase());
 
@@ -387,7 +387,7 @@ describe('AgeReviewDetail', () => {
   });
 
   it('frames the protections as policy-derived, not per-device confirmed', async () => {
-    getAccountStatus.mockResolvedValue({ success: true, verified_minor: true });
+    getAccountStatus.mockResolvedValue({ success: true, status: 'active', verified_minor: true });
 
     renderDetail(makeCase());
 
@@ -402,7 +402,7 @@ describe('AgeReviewDetail', () => {
   });
 
   it('does not show the protections block when verified_minor is false', async () => {
-    getAccountStatus.mockResolvedValue({ success: true, verified_minor: false });
+    getAccountStatus.mockResolvedValue({ success: true, status: 'active', verified_minor: false });
 
     const { queryClient } = renderDetail(makeCase());
 

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -4,6 +4,12 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import { AgeReviewDetail } from './AgeReviewDetail';
 import { ApiError } from '@/lib/adminApi';
+
+// AgeReviewDetail reads relay content-presence via useUserStats (which needs a
+// NostrProvider). This unit test isolates the case-action logic, so stub it.
+vi.mock('@/hooks/useUserStats', () => ({
+  useUserStats: () => ({ data: undefined }),
+}));
 import type { AgeReviewCase, AgeBand, AgeReviewState } from '../../shared/age-review';
 
 const updateAgeReviewCase = vi.fn().mockResolvedValue({ success: true });
@@ -418,6 +424,14 @@ describe('AgeReviewDetail', () => {
       screen.queryByText(/protections that apply to this account/i)
     ).not.toBeInTheDocument();
     expect(screen.queryByText(/rolling out \(not yet enforced/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the account-type indicator (self-custody) for a not_found account', async () => {
+    getAccountStatus.mockResolvedValue({ success: false, not_found: true });
+
+    renderDetail(makeCase({ suspected_age_band: 'age_13_15' }));
+
+    expect(await screen.findByText('Self-custody (not in keycast)')).toBeInTheDocument();
   });
 
   it('shows status-unavailable when the account-status query rejects', async () => {

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -6,9 +6,14 @@ import { AgeReviewDetail } from './AgeReviewDetail';
 import { ApiError } from '@/lib/adminApi';
 
 // AgeReviewDetail reads relay content-presence via useUserStats (which needs a
-// NostrProvider). This unit test isolates the case-action logic, so stub it.
+// NostrProvider). This unit test isolates the case-action logic, so stub it with
+// a resolved, empty read (not in-flight) so the indicator's content-presence
+// note doesn't bleed into unrelated assertions.
 vi.mock('@/hooks/useUserStats', () => ({
-  useUserStats: () => ({ data: undefined }),
+  useUserStats: () => ({
+    data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [] },
+    isError: false,
+  }),
 }));
 import type { AgeReviewCase, AgeBand, AgeReviewState } from '../../shared/age-review';
 

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -1,6 +1,9 @@
 import { useState, useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAdminApi, useApiUrl } from "@/hooks/useAdminApi";
+import { useAccountStatus } from "@/hooks/useAccountStatus";
+import { useUserStats } from "@/hooks/useUserStats";
+import { AccountTypeIndicator } from "@/components/AccountTypeIndicator";
 import { ApiError } from "@/lib/adminApi";
 import { reconcileCaseIntoList, type AgeReviewListParams } from "@/lib/ageReviewCache";
 import { useToast } from "@/hooks/useToast";
@@ -213,12 +216,8 @@ export function AgeReviewDetail({ caseData: c }: Props) {
 
   // Keycast-backed protected-minor status (verified_minor). Best-effort: a
   // keycast blip resolves to success:false, so we show status unavailable.
-  const { data: accountStatus, isError: accountStatusFailed } = useQuery({
-    queryKey: ['account-status', apiUrl, c.pubkey],
-    queryFn: () => api.getAccountStatus(c.pubkey),
-    enabled: !!apiUrl && !!c.pubkey,
-    staleTime: 60_000, // verified_minor is durable; avoid refetching per case reopen
-  });
+  const { data: accountStatus, isError: accountStatusFailed } = useAccountStatus(c.pubkey);
+  const { data: userStats } = useUserStats(c.pubkey);
   const verifiedMinorAtDate = accountStatus?.verified_minor_at
     ? new Date(accountStatus.verified_minor_at)
     : null;
@@ -261,6 +260,13 @@ export function AgeReviewDetail({ caseData: c }: Props) {
               </span>
             ) : null}
           </div>
+
+          <AccountTypeIndicator
+            accountStatus={accountStatus}
+            accountStatusError={accountStatusFailed}
+            postCount={userStats?.postCount}
+            ticketLinked={!!c.zendesk_ticket_id}
+          />
 
           {/* Protections that apply to an approved protected minor (#143).
               POLICY-DERIVED from verified_minor: these are client-enforced

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -6,6 +6,7 @@ import { useUserStats } from "@/hooks/useUserStats";
 import { AccountTypeIndicator } from "@/components/AccountTypeIndicator";
 import { ApiError } from "@/lib/adminApi";
 import { reconcileCaseIntoList, type AgeReviewListParams } from "@/lib/ageReviewCache";
+import { deriveAccountVerdict } from "@/lib/accountVerdict";
 import { useToast } from "@/hooks/useToast";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { UserActions } from "@/components/UserActions";
@@ -221,6 +222,15 @@ export function AgeReviewDetail({ caseData: c }: Props) {
   // error; a failed/in-flight read must not read as "no content" (would
   // under-state available enforcement).
   const contentPresenceKnown = userStats !== undefined && !userStatsFailed;
+  const accountVerdict = deriveAccountVerdict({
+    accountStatus,
+    accountStatusError: accountStatusFailed,
+    postCount: userStats?.postCount,
+    contentPresenceKnown,
+    ticketLinked: !!c.zendesk_ticket_id,
+  });
+  const protectedMinorStatusUnavailable =
+    !accountStatusLoading && accountVerdict.accountType === 'unknown';
   const verifiedMinorAtDate = accountStatus?.verified_minor_at
     ? new Date(accountStatus.verified_minor_at)
     : null;
@@ -255,7 +265,7 @@ export function AgeReviewDetail({ caseData: c }: Props) {
                   </span>
                 ) : null}
               </>
-            ) : accountStatusFailed || (accountStatus?.success === false && !accountStatus?.not_found) ? (
+            ) : protectedMinorStatusUnavailable ? (
               // Couldn't determine (keycast down/misconfig) — don't let a blip
               // read the same as a confirmed non-minor; keep the safety signal.
               // not_found (self-custody) is definitive, not an error, so it is

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -255,9 +255,11 @@ export function AgeReviewDetail({ caseData: c }: Props) {
                   </span>
                 ) : null}
               </>
-            ) : accountStatusFailed || accountStatus?.success === false ? (
+            ) : accountStatusFailed || (accountStatus?.success === false && !accountStatus?.not_found) ? (
               // Couldn't determine (keycast down/misconfig) — don't let a blip
               // read the same as a confirmed non-minor; keep the safety signal.
+              // not_found (self-custody) is definitive, not an error, so it is
+              // excluded here — the account-type indicator states it directly.
               <span className="text-xs text-muted-foreground">
                 protected-minor status unavailable
               </span>

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAdminApi, useApiUrl } from "@/hooks/useAdminApi";
+import { useAdminApi } from "@/hooks/useAdminApi";
 import { useAccountStatus } from "@/hooks/useAccountStatus";
 import { useUserStats } from "@/hooks/useUserStats";
 import { AccountTypeIndicator } from "@/components/AccountTypeIndicator";
@@ -101,7 +101,6 @@ const ENFORCEMENT_STATES: AgeReviewState[] = [
 
 export function AgeReviewDetail({ caseData: c }: Props) {
   const api = useAdminApi();
-  const apiUrl = useApiUrl();
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [resolutionNote, setResolutionNote] = useState(c.resolution_note ?? "");
@@ -216,8 +215,12 @@ export function AgeReviewDetail({ caseData: c }: Props) {
 
   // Keycast-backed protected-minor status (verified_minor). Best-effort: a
   // keycast blip resolves to success:false, so we show status unavailable.
-  const { data: accountStatus, isError: accountStatusFailed } = useAccountStatus(c.pubkey);
-  const { data: userStats } = useUserStats(c.pubkey);
+  const { data: accountStatus, isError: accountStatusFailed, isLoading: accountStatusLoading } = useAccountStatus(c.pubkey);
+  const { data: userStats, isError: userStatsFailed } = useUserStats(c.pubkey);
+  // Content presence is trustworthy only once the relay read resolves without
+  // error; a failed/in-flight read must not read as "no content" (would
+  // under-state available enforcement).
+  const contentPresenceKnown = userStats !== undefined && !userStatsFailed;
   const verifiedMinorAtDate = accountStatus?.verified_minor_at
     ? new Date(accountStatus.verified_minor_at)
     : null;
@@ -264,7 +267,9 @@ export function AgeReviewDetail({ caseData: c }: Props) {
           <AccountTypeIndicator
             accountStatus={accountStatus}
             accountStatusError={accountStatusFailed}
+            accountStatusLoading={accountStatusLoading}
             postCount={userStats?.postCount}
+            contentPresenceKnown={contentPresenceKnown}
             ticketLinked={!!c.zendesk_ticket_id}
           />
 

--- a/src/hooks/useAccountStatus.ts
+++ b/src/hooks/useAccountStatus.ts
@@ -1,5 +1,6 @@
 // ABOUTME: Shared query for a pubkey's keycast account status (membership,
-// ABOUTME: suspension, verified_minor). Reused by age-review and the reports pane.
+// ABOUTME: suspension, verified_minor). Consumed by the age-review view; the
+// ABOUTME: reports-pane reuse is a planned follow-up (part C).
 import { useQuery } from '@tanstack/react-query';
 import { useAdminApi, useApiUrl } from './useAdminApi';
 

--- a/src/hooks/useAccountStatus.ts
+++ b/src/hooks/useAccountStatus.ts
@@ -1,0 +1,15 @@
+// ABOUTME: Shared query for a pubkey's keycast account status (membership,
+// ABOUTME: suspension, verified_minor). Reused by age-review and the reports pane.
+import { useQuery } from '@tanstack/react-query';
+import { useAdminApi, useApiUrl } from './useAdminApi';
+
+export function useAccountStatus(pubkey: string | undefined) {
+  const api = useAdminApi();
+  const apiUrl = useApiUrl();
+  return useQuery({
+    queryKey: ['account-status', apiUrl, pubkey],
+    queryFn: () => api.getAccountStatus(pubkey!),
+    enabled: !!apiUrl && !!pubkey,
+    staleTime: 60_000, // verified_minor is durable; avoid refetch per case reopen
+  });
+}

--- a/src/lib/accountVerdict.test.ts
+++ b/src/lib/accountVerdict.test.ts
@@ -4,6 +4,7 @@ import type { AccountStatusResponse } from './adminApi';
 
 const divineActive: AccountStatusResponse = { success: true, status: 'active' };
 const divineSuspended: AccountStatusResponse = { success: true, status: 'suspended' };
+const divineBanned: AccountStatusResponse = { success: true, status: 'banned' };
 const selfCustody: AccountStatusResponse = { success: false, not_found: true };
 const unavailable: AccountStatusResponse = { success: false, error: '500: boom' };
 
@@ -63,6 +64,20 @@ describe('deriveAccountVerdict — content presence + verdict', () => {
     expect(v.contentPresence).toBe('unknown');
     // Applicable-but-unconfirmed, NOT n/a — never under-state the content lever.
     expect(legState(v, 'content_restrict')).toBe('not_tracked');
+  });
+
+  it('treats banned as sign-in blocked (done), never offers "suspend sign-in" (review)', () => {
+    const v = deriveAccountVerdict({ accountStatus: divineBanned, accountStatusError: false, contentPresenceKnown: true, postCount: 2, ticketLinked: true });
+    expect(legState(v, 'signin')).toBe('done');
+    expect(v.verdict.toLowerCase()).not.toContain('suspend sign-in');
+  });
+
+  it('keycast-unavailable still surfaces content/ticket actions, not just "retry" (review)', () => {
+    const v = deriveAccountVerdict({ accountStatus: unavailable, accountStatusError: false, contentPresenceKnown: true, postCount: 5, ticketLinked: false });
+    expect(v.accountType).toBe('unknown');
+    expect(v.verdict.toLowerCase()).toContain('unavailable'); // sign-in note preserved
+    expect(v.verdict.toLowerCase()).toContain('age-restrict'); // content action still shown
+    expect(v.verdict.toLowerCase()).toContain('open ticket'); // ticket action still shown
   });
 
   it('an unresolved read never concludes "no effective enforcement" (Finding #1 regression)', () => {

--- a/src/lib/accountVerdict.test.ts
+++ b/src/lib/accountVerdict.test.ts
@@ -24,6 +24,9 @@ describe('deriveAccountVerdict — account type', () => {
   it('unknown when the query itself errored', () => {
     expect(deriveAccountVerdict({ accountStatus: undefined, accountStatusError: true, contentPresenceKnown: true, postCount: 0, ticketLinked: false }).accountType).toBe('unknown');
   });
+  it('keeps cached successful data authoritative after a background refetch error', () => {
+    expect(deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: true, contentPresenceKnown: true, postCount: 0, ticketLinked: false }).accountType).toBe('divine');
+  });
 });
 
 describe('deriveAccountVerdict — legs', () => {
@@ -32,6 +35,15 @@ describe('deriveAccountVerdict — legs', () => {
   });
   it('sign-in missing when divine + active', () => {
     expect(legState(deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, contentPresenceKnown: true, postCount: 2, ticketLinked: false }), 'signin')).toBe('missing');
+  });
+  it('sign-in not_tracked when keycast omits status', () => {
+    const v = deriveAccountVerdict({ accountStatus: { success: true }, accountStatusError: false, contentPresenceKnown: true, postCount: 0, ticketLinked: true });
+    expect(v.accountType).toBe('divine');
+    expect(v.signInStatus).toBe('unknown');
+    expect(legState(v, 'signin')).toBe('not_tracked');
+    expect(v.verdict.toLowerCase()).not.toContain('suspend sign-in');
+    expect(v.verdict.toLowerCase()).not.toContain('fully enforced');
+    expect(v.verdict.toLowerCase()).toContain('sign-in status unavailable');
   });
   it('sign-in na when self-custody', () => {
     expect(legState(deriveAccountVerdict({ accountStatus: selfCustody, accountStatusError: false, contentPresenceKnown: true, postCount: 2, ticketLinked: false }), 'signin')).toBe('na');

--- a/src/lib/accountVerdict.test.ts
+++ b/src/lib/accountVerdict.test.ts
@@ -12,49 +12,64 @@ const legState = (v: ReturnType<typeof deriveAccountVerdict>, key: string) =>
 
 describe('deriveAccountVerdict — account type', () => {
   it('divine when keycast lookup succeeds', () => {
-    expect(deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, postCount: 3, ticketLinked: false }).accountType).toBe('divine');
+    expect(deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, contentPresenceKnown: true, postCount: 3, ticketLinked: false }).accountType).toBe('divine');
   });
   it('self_custody on keycast not_found', () => {
-    expect(deriveAccountVerdict({ accountStatus: selfCustody, accountStatusError: false, postCount: 0, ticketLinked: false }).accountType).toBe('self_custody');
+    expect(deriveAccountVerdict({ accountStatus: selfCustody, accountStatusError: false, contentPresenceKnown: true, postCount: 0, ticketLinked: false }).accountType).toBe('self_custody');
   });
   it('unknown on keycast error', () => {
-    expect(deriveAccountVerdict({ accountStatus: unavailable, accountStatusError: false, postCount: 0, ticketLinked: false }).accountType).toBe('unknown');
+    expect(deriveAccountVerdict({ accountStatus: unavailable, accountStatusError: false, contentPresenceKnown: true, postCount: 0, ticketLinked: false }).accountType).toBe('unknown');
   });
   it('unknown when the query itself errored', () => {
-    expect(deriveAccountVerdict({ accountStatus: undefined, accountStatusError: true, postCount: 0, ticketLinked: false }).accountType).toBe('unknown');
+    expect(deriveAccountVerdict({ accountStatus: undefined, accountStatusError: true, contentPresenceKnown: true, postCount: 0, ticketLinked: false }).accountType).toBe('unknown');
   });
 });
 
 describe('deriveAccountVerdict — legs', () => {
   it('sign-in done when divine + suspended', () => {
-    expect(legState(deriveAccountVerdict({ accountStatus: divineSuspended, accountStatusError: false, postCount: 2, ticketLinked: true }), 'signin')).toBe('done');
+    expect(legState(deriveAccountVerdict({ accountStatus: divineSuspended, accountStatusError: false, contentPresenceKnown: true, postCount: 2, ticketLinked: true }), 'signin')).toBe('done');
   });
   it('sign-in missing when divine + active', () => {
-    expect(legState(deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, postCount: 2, ticketLinked: false }), 'signin')).toBe('missing');
+    expect(legState(deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, contentPresenceKnown: true, postCount: 2, ticketLinked: false }), 'signin')).toBe('missing');
   });
   it('sign-in na when self-custody', () => {
-    expect(legState(deriveAccountVerdict({ accountStatus: selfCustody, accountStatusError: false, postCount: 2, ticketLinked: false }), 'signin')).toBe('na');
+    expect(legState(deriveAccountVerdict({ accountStatus: selfCustody, accountStatusError: false, contentPresenceKnown: true, postCount: 2, ticketLinked: false }), 'signin')).toBe('na');
   });
   it('ticket done when linked, missing otherwise', () => {
-    expect(legState(deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, postCount: 2, ticketLinked: true }), 'ticket')).toBe('done');
-    expect(legState(deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, postCount: 2, ticketLinked: false }), 'ticket')).toBe('missing');
+    expect(legState(deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, contentPresenceKnown: true, postCount: 2, ticketLinked: true }), 'ticket')).toBe('done');
+    expect(legState(deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, contentPresenceKnown: true, postCount: 2, ticketLinked: false }), 'ticket')).toBe('missing');
   });
   it('content legs not_tracked when content present (deps #123), na when no content', () => {
-    const withContent = deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, postCount: 5, ticketLinked: false });
+    const withContent = deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, contentPresenceKnown: true, postCount: 5, ticketLinked: false });
     expect(legState(withContent, 'content_restrict')).toBe('not_tracked');
-    const noContent = deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, postCount: 0, ticketLinked: false });
+    const noContent = deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, contentPresenceKnown: true, postCount: 0, ticketLinked: false });
     expect(legState(noContent, 'content_restrict')).toBe('na');
   });
 });
 
 describe('deriveAccountVerdict — content presence + verdict', () => {
   it('hidden_suspended when no visible content but suspended', () => {
-    expect(deriveAccountVerdict({ accountStatus: divineSuspended, accountStatusError: false, postCount: 0, ticketLinked: false }).contentPresence).toBe('hidden_suspended');
+    expect(deriveAccountVerdict({ accountStatus: divineSuspended, accountStatusError: false, contentPresenceKnown: true, postCount: 0, ticketLinked: false }).contentPresence).toBe('hidden_suspended');
   });
   it('verdict flags N/A for self-custody', () => {
-    expect(deriveAccountVerdict({ accountStatus: selfCustody, accountStatusError: false, postCount: 0, ticketLinked: false }).verdict.toLowerCase()).toContain('n/a');
+    expect(deriveAccountVerdict({ accountStatus: selfCustody, accountStatusError: false, contentPresenceKnown: true, postCount: 0, ticketLinked: false }).verdict.toLowerCase()).toContain('n/a');
   });
   it('verdict says unavailable for unknown', () => {
-    expect(deriveAccountVerdict({ accountStatus: unavailable, accountStatusError: false, postCount: 0, ticketLinked: false }).verdict.toLowerCase()).toContain('unavailable');
+    expect(deriveAccountVerdict({ accountStatus: unavailable, accountStatusError: false, contentPresenceKnown: true, postCount: 0, ticketLinked: false }).verdict.toLowerCase()).toContain('unavailable');
+  });
+
+  it('contentPresence is unknown (not none) when a non-suspended read has not resolved', () => {
+    const v = deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, contentPresenceKnown: false, postCount: undefined, ticketLinked: false });
+    expect(v.contentPresence).toBe('unknown');
+    // Applicable-but-unconfirmed, NOT n/a — never under-state the content lever.
+    expect(legState(v, 'content_restrict')).toBe('not_tracked');
+  });
+
+  it('an unresolved read never concludes "no effective enforcement" (Finding #1 regression)', () => {
+    // self-custody + relay read failed/loading + ticket already linked: previously
+    // this collapsed to "no relay content — record/ticket only".
+    const v = deriveAccountVerdict({ accountStatus: selfCustody, accountStatusError: false, contentPresenceKnown: false, postCount: undefined, ticketLinked: true });
+    expect(v.verdict.toLowerCase()).not.toContain('no effective enforcement');
+    expect(v.verdict.toLowerCase()).toContain('verify content directly');
   });
 });

--- a/src/lib/accountVerdict.test.ts
+++ b/src/lib/accountVerdict.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { deriveAccountVerdict } from './accountVerdict';
+import type { AccountStatusResponse } from './adminApi';
+
+const divineActive: AccountStatusResponse = { success: true, status: 'active' };
+const divineSuspended: AccountStatusResponse = { success: true, status: 'suspended' };
+const selfCustody: AccountStatusResponse = { success: false, not_found: true };
+const unavailable: AccountStatusResponse = { success: false, error: '500: boom' };
+
+const legState = (v: ReturnType<typeof deriveAccountVerdict>, key: string) =>
+  v.legs.find((l) => l.key === key)!.state;
+
+describe('deriveAccountVerdict — account type', () => {
+  it('divine when keycast lookup succeeds', () => {
+    expect(deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, postCount: 3, ticketLinked: false }).accountType).toBe('divine');
+  });
+  it('self_custody on keycast not_found', () => {
+    expect(deriveAccountVerdict({ accountStatus: selfCustody, accountStatusError: false, postCount: 0, ticketLinked: false }).accountType).toBe('self_custody');
+  });
+  it('unknown on keycast error', () => {
+    expect(deriveAccountVerdict({ accountStatus: unavailable, accountStatusError: false, postCount: 0, ticketLinked: false }).accountType).toBe('unknown');
+  });
+  it('unknown when the query itself errored', () => {
+    expect(deriveAccountVerdict({ accountStatus: undefined, accountStatusError: true, postCount: 0, ticketLinked: false }).accountType).toBe('unknown');
+  });
+});
+
+describe('deriveAccountVerdict — legs', () => {
+  it('sign-in done when divine + suspended', () => {
+    expect(legState(deriveAccountVerdict({ accountStatus: divineSuspended, accountStatusError: false, postCount: 2, ticketLinked: true }), 'signin')).toBe('done');
+  });
+  it('sign-in missing when divine + active', () => {
+    expect(legState(deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, postCount: 2, ticketLinked: false }), 'signin')).toBe('missing');
+  });
+  it('sign-in na when self-custody', () => {
+    expect(legState(deriveAccountVerdict({ accountStatus: selfCustody, accountStatusError: false, postCount: 2, ticketLinked: false }), 'signin')).toBe('na');
+  });
+  it('ticket done when linked, missing otherwise', () => {
+    expect(legState(deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, postCount: 2, ticketLinked: true }), 'ticket')).toBe('done');
+    expect(legState(deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, postCount: 2, ticketLinked: false }), 'ticket')).toBe('missing');
+  });
+  it('content legs not_tracked when content present (deps #123), na when no content', () => {
+    const withContent = deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, postCount: 5, ticketLinked: false });
+    expect(legState(withContent, 'content_restrict')).toBe('not_tracked');
+    const noContent = deriveAccountVerdict({ accountStatus: divineActive, accountStatusError: false, postCount: 0, ticketLinked: false });
+    expect(legState(noContent, 'content_restrict')).toBe('na');
+  });
+});
+
+describe('deriveAccountVerdict — content presence + verdict', () => {
+  it('hidden_suspended when no visible content but suspended', () => {
+    expect(deriveAccountVerdict({ accountStatus: divineSuspended, accountStatusError: false, postCount: 0, ticketLinked: false }).contentPresence).toBe('hidden_suspended');
+  });
+  it('verdict flags N/A for self-custody', () => {
+    expect(deriveAccountVerdict({ accountStatus: selfCustody, accountStatusError: false, postCount: 0, ticketLinked: false }).verdict.toLowerCase()).toContain('n/a');
+  });
+  it('verdict says unavailable for unknown', () => {
+    expect(deriveAccountVerdict({ accountStatus: unavailable, accountStatusError: false, postCount: 0, ticketLinked: false }).verdict.toLowerCase()).toContain('unavailable');
+  });
+});

--- a/src/lib/accountVerdict.ts
+++ b/src/lib/accountVerdict.ts
@@ -14,7 +14,7 @@ export interface ComplianceLeg {
 export interface AccountVerdict {
   accountType: AccountType;
   suspended: boolean;
-  contentPresence: 'visible' | 'hidden_suspended' | 'none';
+  contentPresence: 'visible' | 'hidden_suspended' | 'none' | 'unknown';
   legs: ComplianceLeg[];
   verdict: string;
 }
@@ -23,11 +23,15 @@ export interface DeriveInput {
   accountStatus: AccountStatusResponse | undefined;
   accountStatusError: boolean;
   postCount: number | undefined;
+  // Whether the relay content read has resolved. A failed/in-flight read leaves
+  // postCount undefined, which must NOT be read as "no content" — that would
+  // under-state available enforcement (the content lever silently dropped).
+  contentPresenceKnown: boolean;
   ticketLinked: boolean;
 }
 
 export function deriveAccountVerdict(input: DeriveInput): AccountVerdict {
-  const { accountStatus, accountStatusError, postCount, ticketLinked } = input;
+  const { accountStatus, accountStatusError, postCount, contentPresenceKnown, ticketLinked } = input;
 
   // Account type: a query error, OR success:false without not_found, is "unknown"
   // (keycast unavailable). not_found is self-custody; success is a Divine account.
@@ -44,11 +48,18 @@ export function deriveAccountVerdict(input: DeriveInput): AccountVerdict {
 
   const suspended = accountStatus?.status === 'suspended';
   const hasContent = (postCount ?? 0) > 0;
+  // Suspension hides content, so 'hidden_suspended' is the honest read there
+  // regardless of the relay result. Otherwise, an unresolved read is 'unknown'
+  // (not 'none') so we never assert an empty account we haven't confirmed.
   const contentPresence: AccountVerdict['contentPresence'] =
-    hasContent ? 'visible' : suspended ? 'hidden_suspended' : 'none';
+    hasContent ? 'visible'
+    : suspended ? 'hidden_suspended'
+    : contentPresenceKnown ? 'none'
+    : 'unknown';
 
-  // Content legs are applicable when content is present OR possibly hidden by
-  // suspension; their done-state is not durably recorded yet (deps #123).
+  // Content legs are applicable when content is present, possibly hidden by
+  // suspension, or not-yet-confirmed; their done-state is not durably recorded
+  // yet (deps #123). Only a confirmed-empty account marks them n/a.
   const contentApplicable = contentPresence !== 'none';
   const contentLegState: LegState = contentApplicable ? 'not_tracked' : 'na';
 
@@ -83,16 +94,35 @@ function buildVerdict(
   if (accountType === 'unknown') {
     return 'Sign-in lever unconfirmed (account status unavailable) — retry before relying on it.';
   }
+  const contentUnknownNote =
+    'Relay content status unavailable — verify content directly before ruling out a content action.';
+
   const available: string[] = [];
   if (signinState === 'missing') available.push('suspend sign-in');
-  if (contentPresence !== 'none') available.push('age-restrict/remove content');
+  // Only offer a content action when content is present or likely-hidden. When
+  // the read is 'unknown' we do NOT auto-list it (we can't confirm content) and
+  // do NOT conclude "no content" — the note below tells the moderator to verify.
+  if (contentPresence === 'visible' || contentPresence === 'hidden_suspended') {
+    available.push('age-restrict/remove content');
+  }
   if (!ticketLinked) available.push('open ticket');
 
   const prefix = accountType === 'self_custody' ? 'Sign-in suspend N/A (self-custody). ' : '';
-  if (available.length === 0) {
-    return accountType === 'self_custody' && contentPresence === 'none'
-      ? 'No effective enforcement available (self-custody, no relay content) — record/ticket only.'
-      : `${prefix}Fully enforced — no further action needed.`;
+
+  if (available.length > 0) {
+    const tail = contentPresence === 'unknown' ? ` ${contentUnknownNote}` : '';
+    return `${prefix}Available: ${available.join(', ')}.${tail}`;
   }
-  return `${prefix}Available: ${available.join(', ')}.`;
+  // available is empty
+  if (contentPresence === 'unknown') {
+    // Never conclude unactionable on an unconfirmed content read (Story B).
+    return `${prefix}${contentUnknownNote}`;
+  }
+  if (accountType === 'self_custody' && contentPresence === 'none') {
+    return 'No effective enforcement available (self-custody, no relay content) — record/ticket only.';
+  }
+  // Only reachable once content-leg done-tracking lands (#123): all applicable
+  // legs done. Until then content legs are 'not_tracked', so this never fires
+  // and the verdict can never wrongly claim full enforcement.
+  return `${prefix}Fully enforced — no further action needed.`;
 }

--- a/src/lib/accountVerdict.ts
+++ b/src/lib/accountVerdict.ts
@@ -11,8 +11,11 @@ export interface ComplianceLeg {
   state: LegState;
 }
 
+export type SignInStatus = 'active' | 'blocked' | 'unknown' | 'not_applicable';
+
 export interface AccountVerdict {
   accountType: AccountType;
+  signInStatus: SignInStatus;
   contentPresence: 'visible' | 'hidden_suspended' | 'none' | 'unknown';
   legs: ComplianceLeg[];
   verdict: string;
@@ -32,15 +35,15 @@ export interface DeriveInput {
 export function deriveAccountVerdict(input: DeriveInput): AccountVerdict {
   const { accountStatus, accountStatusError, postCount, contentPresenceKnown, ticketLinked } = input;
 
-  // Account type: a query error, OR success:false without not_found, is "unknown"
-  // (keycast unavailable). not_found is self-custody; success is a Divine account.
+  // Account type is data-first: if TanStack keeps cached success data after a
+  // failed background refetch, the UI should not contradict that cached status.
   let accountType: AccountType;
-  if (accountStatusError || (accountStatus?.success === false && !accountStatus.not_found)) {
-    accountType = 'unknown';
-  } else if (accountStatus?.not_found) {
+  if (accountStatus?.not_found) {
     accountType = 'self_custody';
   } else if (accountStatus?.success) {
     accountType = 'divine';
+  } else if (accountStatusError || accountStatus?.success === false) {
+    accountType = 'unknown';
   } else {
     accountType = 'unknown';
   }
@@ -65,10 +68,17 @@ export function deriveAccountVerdict(input: DeriveInput): AccountVerdict {
   const contentApplicable = contentPresence !== 'none';
   const contentLegState: LegState = contentApplicable ? 'not_tracked' : 'na';
 
+  const signInStatus: SignInStatus =
+    accountType === 'self_custody' ? 'not_applicable'
+    : accountType === 'unknown' ? 'unknown'
+    : signInBlocked ? 'blocked'
+    : accountStatus?.status === 'active' ? 'active'
+    : 'unknown';
+
   const signinState: LegState =
-    accountType === 'self_custody' ? 'na'
-    : accountType === 'unknown' ? 'not_tracked'
-    : signInBlocked ? 'done'
+    signInStatus === 'not_applicable' ? 'na'
+    : signInStatus === 'unknown' ? 'not_tracked'
+    : signInStatus === 'blocked' ? 'done'
     : 'missing';
 
   const legs: ComplianceLeg[] = [
@@ -80,6 +90,7 @@ export function deriveAccountVerdict(input: DeriveInput): AccountVerdict {
 
   return {
     accountType,
+    signInStatus,
     contentPresence,
     legs,
     verdict: buildVerdict(accountType, contentPresence, signinState, ticketLinked),
@@ -114,6 +125,14 @@ function buildVerdict(
     const tail = contentPresence === 'unknown' ? ` ${contentUnknownNote}` : '';
     return available.length > 0
       ? `${note} Content/ticket actions still apply: ${available.join(', ')}.${tail}`
+      : `${note}${tail}`;
+  }
+
+  if (signinState === 'not_tracked') {
+    const note = 'Sign-in status unavailable — retry before relying on it.';
+    const tail = contentPresence === 'unknown' ? ` ${contentUnknownNote}` : '';
+    return available.length > 0
+      ? `${note} Available: ${available.join(', ')}.${tail}`
       : `${note}${tail}`;
   }
 

--- a/src/lib/accountVerdict.ts
+++ b/src/lib/accountVerdict.ts
@@ -13,7 +13,6 @@ export interface ComplianceLeg {
 
 export interface AccountVerdict {
   accountType: AccountType;
-  suspended: boolean;
   contentPresence: 'visible' | 'hidden_suspended' | 'none' | 'unknown';
   legs: ComplianceLeg[];
   verdict: string;
@@ -81,7 +80,6 @@ export function deriveAccountVerdict(input: DeriveInput): AccountVerdict {
 
   return {
     accountType,
-    suspended,
     contentPresence,
     legs,
     verdict: buildVerdict(accountType, contentPresence, signinState, ticketLinked),

--- a/src/lib/accountVerdict.ts
+++ b/src/lib/accountVerdict.ts
@@ -47,6 +47,9 @@ export function deriveAccountVerdict(input: DeriveInput): AccountVerdict {
   }
 
   const suspended = accountStatus?.status === 'suspended';
+  // Both suspended and banned block sign-in. Kept separate from `suspended`
+  // because only *suspend* hides content reversibly — ban purges it.
+  const signInBlocked = suspended || accountStatus?.status === 'banned';
   const hasContent = (postCount ?? 0) > 0;
   // Suspension hides content, so 'hidden_suspended' is the honest read there
   // regardless of the relay result. Otherwise, an unresolved read is 'unknown'
@@ -66,7 +69,7 @@ export function deriveAccountVerdict(input: DeriveInput): AccountVerdict {
   const signinState: LegState =
     accountType === 'self_custody' ? 'na'
     : accountType === 'unknown' ? 'not_tracked'
-    : suspended ? 'done'
+    : signInBlocked ? 'done'
     : 'missing';
 
   const legs: ComplianceLeg[] = [
@@ -91,9 +94,6 @@ function buildVerdict(
   signinState: LegState,
   ticketLinked: boolean,
 ): string {
-  if (accountType === 'unknown') {
-    return 'Sign-in lever unconfirmed (account status unavailable) — retry before relying on it.';
-  }
   const contentUnknownNote =
     'Relay content status unavailable — verify content directly before ruling out a content action.';
 
@@ -106,6 +106,18 @@ function buildVerdict(
     available.push('age-restrict/remove content');
   }
   if (!ticketLinked) available.push('open ticket');
+
+  // Keycast unavailable: only the SIGN-IN leg is unconfirmed. Content-presence
+  // and ticket don't depend on keycast, so still surface those actions instead
+  // of collapsing the whole verdict to "retry". (signinState is 'not_tracked'
+  // here, so 'suspend sign-in' is never in `available`.)
+  if (accountType === 'unknown') {
+    const note = 'Sign-in lever unconfirmed (account status unavailable) — retry before relying on it.';
+    const tail = contentPresence === 'unknown' ? ` ${contentUnknownNote}` : '';
+    return available.length > 0
+      ? `${note} Content/ticket actions still apply: ${available.join(', ')}.${tail}`
+      : `${note}${tail}`;
+  }
 
   const prefix = accountType === 'self_custody' ? 'Sign-in suspend N/A (self-custody). ' : '';
 

--- a/src/lib/accountVerdict.ts
+++ b/src/lib/accountVerdict.ts
@@ -1,0 +1,98 @@
+// ABOUTME: Pure synthesis of an age-review target's account type, enforcement
+// ABOUTME: compliance legs, and a one-line "what's effective" verdict. No I/O.
+import type { AccountStatusResponse } from './adminApi';
+
+export type AccountType = 'divine' | 'self_custody' | 'unknown';
+export type LegState = 'done' | 'missing' | 'na' | 'not_tracked';
+
+export interface ComplianceLeg {
+  key: 'signin' | 'ticket' | 'content_restrict' | 'relay_suspend';
+  label: string;
+  state: LegState;
+}
+
+export interface AccountVerdict {
+  accountType: AccountType;
+  suspended: boolean;
+  contentPresence: 'visible' | 'hidden_suspended' | 'none';
+  legs: ComplianceLeg[];
+  verdict: string;
+}
+
+export interface DeriveInput {
+  accountStatus: AccountStatusResponse | undefined;
+  accountStatusError: boolean;
+  postCount: number | undefined;
+  ticketLinked: boolean;
+}
+
+export function deriveAccountVerdict(input: DeriveInput): AccountVerdict {
+  const { accountStatus, accountStatusError, postCount, ticketLinked } = input;
+
+  // Account type: a query error, OR success:false without not_found, is "unknown"
+  // (keycast unavailable). not_found is self-custody; success is a Divine account.
+  let accountType: AccountType;
+  if (accountStatusError || (accountStatus?.success === false && !accountStatus.not_found)) {
+    accountType = 'unknown';
+  } else if (accountStatus?.not_found) {
+    accountType = 'self_custody';
+  } else if (accountStatus?.success) {
+    accountType = 'divine';
+  } else {
+    accountType = 'unknown';
+  }
+
+  const suspended = accountStatus?.status === 'suspended';
+  const hasContent = (postCount ?? 0) > 0;
+  const contentPresence: AccountVerdict['contentPresence'] =
+    hasContent ? 'visible' : suspended ? 'hidden_suspended' : 'none';
+
+  // Content legs are applicable when content is present OR possibly hidden by
+  // suspension; their done-state is not durably recorded yet (deps #123).
+  const contentApplicable = contentPresence !== 'none';
+  const contentLegState: LegState = contentApplicable ? 'not_tracked' : 'na';
+
+  const signinState: LegState =
+    accountType === 'self_custody' ? 'na'
+    : accountType === 'unknown' ? 'not_tracked'
+    : suspended ? 'done'
+    : 'missing';
+
+  const legs: ComplianceLeg[] = [
+    { key: 'signin', label: 'Sign-in (keycast) suspend', state: signinState },
+    { key: 'content_restrict', label: 'Content age-restrict', state: contentLegState },
+    { key: 'relay_suspend', label: 'Relay content suspend', state: contentLegState },
+    { key: 'ticket', label: 'Age-review ticket', state: ticketLinked ? 'done' : 'missing' },
+  ];
+
+  return {
+    accountType,
+    suspended,
+    contentPresence,
+    legs,
+    verdict: buildVerdict(accountType, contentPresence, signinState, ticketLinked),
+  };
+}
+
+function buildVerdict(
+  accountType: AccountType,
+  contentPresence: AccountVerdict['contentPresence'],
+  signinState: LegState,
+  ticketLinked: boolean,
+): string {
+  if (accountType === 'unknown') {
+    return 'Sign-in lever unconfirmed (account status unavailable) — retry before relying on it.';
+  }
+  const available: string[] = [];
+  if (signinState === 'missing') available.push('suspend sign-in');
+  if (contentPresence !== 'none') available.push('age-restrict/remove content');
+  if (!ticketLinked) available.push('open ticket');
+
+  const prefix = accountType === 'self_custody' ? 'Sign-in suspend N/A (self-custody). ' : '';
+  if (available.length === 0) {
+    return accountType === 'self_custody' && contentPresence === 'none'
+      ? 'No effective enforcement available (self-custody, no relay content) — record/ticket only.'
+      : `${prefix}Fully enforced — no further action needed.`;
+  }
+  return `${prefix}Available: ${available.join(', ')}.`;
+}

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -1088,6 +1088,7 @@ export interface AccountStatusResponse {
   suspended_at?: string;
   verified_minor?: boolean;
   verified_minor_at?: string;
+  not_found?: boolean;
   error?: string;
 }
 

--- a/worker/src/account-status.test.ts
+++ b/worker/src/account-status.test.ts
@@ -82,7 +82,27 @@ describe('handleAccountStatus', () => {
     const res = await handleAccountStatus(VALID_PUBKEY, makeEnv(), CORS);
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { success: boolean };
+    const body = (await res.json()) as { success: boolean; not_found?: boolean };
     expect(body.success).toBe(false);
+    // A server error is unavailable, NOT self-custody.
+    expect(body.not_found).toBeFalsy();
+  });
+
+  it('surfaces not_found (self-custody) for a keycast 404, distinct from unavailable', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve('User not found'),
+      }),
+    );
+
+    const res = await handleAccountStatus(VALID_PUBKEY, makeEnv(), CORS);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean; not_found?: boolean };
+    expect(body.success).toBe(false);
+    expect(body.not_found).toBe(true);
   });
 });

--- a/worker/src/account-status.ts
+++ b/worker/src/account-status.ts
@@ -38,7 +38,15 @@ export async function handleAccountStatus(
 
   const result = await getUserStatus(pubkey, env);
   if (!result.success) {
-    return json({ success: false, error: result.error ?? 'unavailable' }, 200, corsHeaders);
+    // not_found (keycast 404) is self-custody — informational, distinct from an
+    // unavailable/errored lookup, so the UI can style it non-destructively (#191).
+    return json(
+      result.notFound
+        ? { success: false, not_found: true }
+        : { success: false, error: result.error ?? 'unavailable' },
+      200,
+      corsHeaders,
+    );
   }
 
   return json(

--- a/worker/src/keycast-client.test.ts
+++ b/worker/src/keycast-client.test.ts
@@ -308,6 +308,22 @@ describe('keycast-client', () => {
       expect(result.success).toBe(false);
       expect(result.notFound).toBe(true);
     });
+
+    it('does not return notFound for an unrecognized 404 body', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      fetchMock.mockResolvedValue({ ok: false, status: 404, text: () => Promise.resolve('<h1>Not Found</h1>') });
+
+      const result = await getUserStatus(VALID_PUBKEY, makeEnv());
+
+      expect(result.success).toBe(false);
+      expect(result.notFound).toBeFalsy();
+      expect(result.error).toContain('404');
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Keycast status endpoint returned an unrecognized 404 body',
+        { body: '<h1>Not Found</h1>' },
+      );
+      warnSpy.mockRestore();
+    });
   });
 
   describe('createMinorAccount', () => {

--- a/worker/src/keycast-client.test.ts
+++ b/worker/src/keycast-client.test.ts
@@ -298,6 +298,15 @@ describe('keycast-client', () => {
       const result = await getUserStatus(VALID_PUBKEY, makeEnv());
       expect(result.success).toBe(false);
       expect(result.error).toContain('500');
+      // A generic failure is NOT not-found.
+      expect(result.notFound).toBeFalsy();
+    });
+
+    it('returns notFound on a keycast 404 (self-custody), not a generic error', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 404, text: () => Promise.resolve('User not found') });
+      const result = await getUserStatus(VALID_PUBKEY, makeEnv());
+      expect(result.success).toBe(false);
+      expect(result.notFound).toBe(true);
     });
   });
 

--- a/worker/src/keycast-client.ts
+++ b/worker/src/keycast-client.ts
@@ -174,6 +174,7 @@ export interface UserStatusResult {
   suspended_at?: string;
   verified_minor?: boolean;
   verified_minor_at?: string;
+  notFound?: boolean;
   error?: string;
 }
 
@@ -194,6 +195,11 @@ export async function getUserStatus(pubkey: string, env: KeycastEnv): Promise<Us
     });
     if (!res.ok) {
       const text = await res.text();
+      // A 404 is "not a keycast user" (self-custody) — an expected, informational
+      // state, not a failure. Distinguish it so the UI never shows it as an error.
+      if (res.status === 404) {
+        return { success: false, notFound: true };
+      }
       return { success: false, error: `${res.status}: ${text}` };
     }
     const data = await res.json() as Record<string, unknown>;

--- a/worker/src/keycast-client.ts
+++ b/worker/src/keycast-client.ts
@@ -178,6 +178,20 @@ export interface UserStatusResult {
   error?: string;
 }
 
+function isKeycastUserNotFound(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+
+  try {
+    const data = JSON.parse(trimmed) as Record<string, unknown>;
+    const code = typeof data.code === 'string' ? data.code.toLowerCase() : '';
+    const error = typeof data.error === 'string' ? data.error.toLowerCase() : '';
+    return code === 'user_not_found' || error === 'user_not_found' || error === 'user not found';
+  } catch {
+    return trimmed.toLowerCase() === 'user not found';
+  }
+}
+
 export async function getUserStatus(pubkey: string, env: KeycastEnv): Promise<UserStatusResult> {
   if (!env.KEYCAST_URL || !env.KEYCAST_SERVICE_TOKEN) {
     return { success: false, error: 'not configured' };
@@ -195,10 +209,16 @@ export async function getUserStatus(pubkey: string, env: KeycastEnv): Promise<Us
     });
     if (!res.ok) {
       const text = await res.text();
-      // A 404 is "not a keycast user" (self-custody) — an expected, informational
-      // state, not a failure. Distinguish it so the UI never shows it as an error.
-      if (res.status === 404) {
+      // Keycast's user-not-found response is "not a keycast user"
+      // (self-custody). Other 404s can be route/config errors and must stay
+      // unavailable so the UI keeps the safety label.
+      if (res.status === 404 && isKeycastUserNotFound(text)) {
         return { success: false, notFound: true };
+      }
+      if (res.status === 404) {
+        console.warn('Keycast status endpoint returned an unrecognized 404 body', {
+          body: text.slice(0, 200),
+        });
       }
       return { success: false, error: `${res.status}: ${text}` };
     }


### PR DESCRIPTION
## Summary

Adds an **account-type indicator** to the age-review case view: it tells the moderator whether a reported target is a Divine keycast account, a self-custody pubkey we hold no login lever over, or unknown (keycast unavailable) — and states plainly what enforcement is actually effective, so the tool never implies an action that can't land.

## Motivation

From the 2026-07-21 legacy-reset investigation and moderator feedback:
- Much of the reported-under-16 backlog is self-custody pubkeys with no Divine login — "suspend sign-in" does nothing there, but the tool implied it was available.
- Our own suspension hides content, so an already-enforced account can read as "nothing here."
- Partial/incidental prior enforcement (e.g. a single event-ban) looks the same as a fully-compliant age-review outcome.

Design spec + plan: `support-trust-safety/docs/superpowers/specs/2026-07-22-age-review-account-type-indicator-design.md` and the matching plan.

Closes #191.

## What it does

- Backend: `getUserStatus` / `/api/account-status` gain a structured `not_found` (self-custody) state, distinct from `error` (unavailable). The 404 path now requires a Keycast user-not-found body so route/config 404s remain unavailable.
- Pure `deriveAccountVerdict` helper: maps account-status + relay content-presence + ticket into an account type, a compliance-leg checklist, and a one-line "what's effective" verdict — never advertising an action that can't land, never under-stating a real one.
- `AccountTypeIndicator` component + `useAccountStatus` hook, wired into `AgeReviewDetail` (content-presence via `useUserStats`).

## Scope

- Account-type badge + effectiveness verdict + content-presence note + a partial compliance checklist (sign-in and ticket legs truthfully sourced; content legs show applicability + "not tracked yet").
- Addresses self-custody as a not-applicable/informational leg, not a Keycast outage.
- Deferred to #123: content-leg *done*-tracking needs durable per-leg enforcement persistence.

## Manual validation

Rendered all seven states live on the local stack: divine active/suspended, self-custody with/without content, unknown, cold-load "checking", and an unresolved-read case. Confirmed self-custody reads as informational (not an error), the checklist reflects done/missing/n-a/not-tracked, and an indeterminate content read says "verify content directly" rather than falsely concluding "no effective enforcement."

## Testing

- `npx vitest run src/lib/accountVerdict.test.ts src/components/AccountTypeIndicator.test.tsx src/components/AgeReviewDetail.test.tsx`
- `cd worker && npx vitest run src/keycast-client.test.ts src/account-status.test.ts`
- `npx tsc -p tsconfig.app.json --noEmit`
- `npm run test`

Note: `cd worker && npx vitest run` currently fails in existing unrelated `age-review.test.ts` funnel mocks and `bulk-moderate.test.ts` delete-all expectations; the touched worker account-status/keycast tests pass.
