### PR TITLE
fix(db): self-heal zendesk_preauth_nonces in ensureSchema (fresh-D1 footgun)

### DIFF
--- a/worker/src/db.ts
+++ b/worker/src/db.ts
@@ -1,5 +1,6 @@
 // ABOUTME: Shared D1 schema initialization for worker and Durable Objects
-// ABOUTME: Single source of truth for moderation_decisions and moderation_targets DDL
+// ABOUTME: Creates moderation_decisions, moderation_targets, age_review_cases,
+// ABOUTME: age_review_config, and zendesk_preauth_nonces DDL on a fresh D1
 
 /**
  * Ensure all moderation tables and indexes exist.
@@ -130,9 +131,11 @@ export async function ensureSchema(db: D1Database): Promise<void> {
     )
   `).run();
 
-  // Zendesk tables — previously existed only in migrations/0001 and 0003,
-  // which are legacy/manual and not run against fresh D1 instances (this
-  // repo's schema path is ensureSchema, not `wrangler d1 migrations apply`).
+  // zendesk_preauth_nonces previously existed only in migrations/0003, which
+  // is legacy/manual and not run against fresh D1 instances (this repo's
+  // schema path is ensureSchema, not `wrangler d1 migrations apply`).
+  // (zendesk_tickets is self-healed separately by ensureZendeskTable() in
+  // zendesk-sync.ts — not duplicated here.)
   await db.prepare(`
     CREATE TABLE IF NOT EXISTS zendesk_preauth_nonces (
       nonce TEXT PRIMARY KEY,
@@ -146,28 +149,5 @@ export async function ensureSchema(db: D1Database): Promise<void> {
     await db.prepare(`CREATE INDEX IF NOT EXISTS idx_nonces_expires ON zendesk_preauth_nonces(expires_at)`).run();
   } catch {
     // Index already exists
-  }
-
-  await db.prepare(`
-    CREATE TABLE IF NOT EXISTS zendesk_tickets (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      ticket_id INTEGER NOT NULL UNIQUE,
-      event_id TEXT,
-      author_pubkey TEXT,
-      violation_type TEXT,
-      status TEXT DEFAULT 'open',
-      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-      resolved_at TEXT,
-      resolution_action TEXT,
-      resolution_moderator TEXT
-    )
-  `).run();
-
-  try {
-    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_zendesk_event ON zendesk_tickets(event_id)`).run();
-    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_zendesk_author ON zendesk_tickets(author_pubkey)`).run();
-    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_zendesk_status ON zendesk_tickets(status)`).run();
-  } catch {
-    // Indexes already exist
   }
 }

--- a/worker/src/db.ts
+++ b/worker/src/db.ts
@@ -129,4 +129,45 @@ export async function ensureSchema(db: D1Database): Promise<void> {
       value TEXT NOT NULL
     )
   `).run();
+
+  // Zendesk tables — previously existed only in migrations/0001 and 0003,
+  // which are legacy/manual and not run against fresh D1 instances (this
+  // repo's schema path is ensureSchema, not `wrangler d1 migrations apply`).
+  await db.prepare(`
+    CREATE TABLE IF NOT EXISTS zendesk_preauth_nonces (
+      nonce TEXT PRIMARY KEY,
+      pubkey TEXT NOT NULL,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      expires_at INTEGER NOT NULL
+    )
+  `).run();
+
+  try {
+    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_nonces_expires ON zendesk_preauth_nonces(expires_at)`).run();
+  } catch {
+    // Index already exists
+  }
+
+  await db.prepare(`
+    CREATE TABLE IF NOT EXISTS zendesk_tickets (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      ticket_id INTEGER NOT NULL UNIQUE,
+      event_id TEXT,
+      author_pubkey TEXT,
+      violation_type TEXT,
+      status TEXT DEFAULT 'open',
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      resolved_at TEXT,
+      resolution_action TEXT,
+      resolution_moderator TEXT
+    )
+  `).run();
+
+  try {
+    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_zendesk_event ON zendesk_tickets(event_id)`).run();
+    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_zendesk_author ON zendesk_tickets(author_pubkey)`).run();
+    await db.prepare(`CREATE INDEX IF NOT EXISTS idx_zendesk_status ON zendesk_tickets(status)`).run();
+  } catch {
+    // Indexes already exist
+  }
 }

--- a/worker/test/ensureschema-zendesk.d1.test.ts
+++ b/worker/test/ensureschema-zendesk.d1.test.ts
@@ -1,11 +1,9 @@
-// Real-D1 (Miniflare SQLite) validation that ensureSchema self-heals the two
-// Zendesk tables that previously existed ONLY in migrations/*.sql:
-//   zendesk_preauth_nonces (migration 0003)
-//   zendesk_tickets        (migration 0001)
+// Real-D1 (Miniflare SQLite) validation that ensureSchema self-heals
+// zendesk_preauth_nonces, which previously existed ONLY in migrations/0003.sql.
 // This repo builds schema via runtime ensureSchema, NOT
 // `wrangler d1 migrations apply` (see db.ts header comment) — so a
 // freshly-provisioned D1 that never had migrations manually applied was
-// missing both tables, breaking Zendesk pre-auth and ticket dedup.
+// missing the table, breaking Zendesk pre-auth.
 import { Miniflare } from 'miniflare';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { ensureSchema } from '../src/db';
@@ -28,15 +26,15 @@ afterAll(async () => {
   await mf?.dispose();
 });
 
-describe('ensureSchema self-heals Zendesk tables on a fresh D1', () => {
-  it('creates zendesk_preauth_nonces and zendesk_tickets', async () => {
+describe('ensureSchema self-heals zendesk_preauth_nonces on a fresh D1', () => {
+  it('creates zendesk_preauth_nonces', async () => {
     await ensureSchema(DB);
 
     const rows = await DB.prepare(
-      `SELECT name FROM sqlite_master WHERE type='table' AND name IN ('zendesk_preauth_nonces','zendesk_tickets')`
+      `SELECT name FROM sqlite_master WHERE type='table' AND name = 'zendesk_preauth_nonces'`
     ).all<{ name: string }>();
-    const names = rows.results.map((r) => r.name).sort();
-    expect(names).toEqual(['zendesk_preauth_nonces', 'zendesk_tickets']);
+    const names = rows.results.map((r) => r.name);
+    expect(names).toEqual(['zendesk_preauth_nonces']);
   });
 
   it('zendesk_preauth_nonces is usable with the columns the app writes', async () => {
@@ -53,37 +51,14 @@ describe('ensureSchema self-heals Zendesk tables on a fresh D1', () => {
     expect(row).toEqual({ nonce: 'nonce-1', pubkey: 'pk_abc', expires_at: 9999999999 });
   });
 
-  it('zendesk_tickets is usable with the columns the app writes', async () => {
-    await ensureSchema(DB);
-
-    await DB.prepare(`
-      INSERT INTO zendesk_tickets (ticket_id, event_id, author_pubkey, violation_type, status)
-      VALUES (?, ?, ?, ?, 'open')
-    `).bind(4242, 'evt_abc', 'pk_abc', 'spam').run();
-
-    const row = await DB.prepare(
-      'SELECT ticket_id, event_id, author_pubkey, violation_type, status FROM zendesk_tickets WHERE ticket_id = ?'
-    ).bind(4242).first<{ ticket_id: number; event_id: string; author_pubkey: string; violation_type: string; status: string }>();
-
-    expect(row).toEqual({
-      ticket_id: 4242,
-      event_id: 'evt_abc',
-      author_pubkey: 'pk_abc',
-      violation_type: 'spam',
-      status: 'open',
-    });
-  });
-
-  it('creates the expected indexes on both tables', async () => {
+  it('creates the expected index', async () => {
     await ensureSchema(DB);
 
     const rows = await DB.prepare(
-      `SELECT name FROM sqlite_master WHERE type='index' AND name IN (
-        'idx_nonces_expires', 'idx_zendesk_event', 'idx_zendesk_author', 'idx_zendesk_status'
-      )`
+      `SELECT name FROM sqlite_master WHERE type='index' AND name = 'idx_nonces_expires'`
     ).all<{ name: string }>();
-    const names = rows.results.map((r) => r.name).sort();
-    expect(names).toEqual(['idx_nonces_expires', 'idx_zendesk_author', 'idx_zendesk_event', 'idx_zendesk_status']);
+    const names = rows.results.map((r) => r.name);
+    expect(names).toEqual(['idx_nonces_expires']);
   });
 
   it('is idempotent: calling ensureSchema twice does not error', async () => {

--- a/worker/test/ensureschema-zendesk.d1.test.ts
+++ b/worker/test/ensureschema-zendesk.d1.test.ts
@@ -1,0 +1,93 @@
+// Real-D1 (Miniflare SQLite) validation that ensureSchema self-heals the two
+// Zendesk tables that previously existed ONLY in migrations/*.sql:
+//   zendesk_preauth_nonces (migration 0003)
+//   zendesk_tickets        (migration 0001)
+// This repo builds schema via runtime ensureSchema, NOT
+// `wrangler d1 migrations apply` (see db.ts header comment) — so a
+// freshly-provisioned D1 that never had migrations manually applied was
+// missing both tables, breaking Zendesk pre-auth and ticket dedup.
+import { Miniflare } from 'miniflare';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ensureSchema } from '../src/db';
+
+let mf: Miniflare;
+let DB: D1Database;
+
+beforeAll(async () => {
+  mf = new Miniflare({
+    modules: true,
+    script: 'export default { fetch() { return new Response("ok"); } };',
+    compatibilityDate: '2024-12-01',
+    compatibilityFlags: ['nodejs_compat'],
+    d1Databases: ['DB'],
+  });
+  DB = (await mf.getD1Database('DB')) as unknown as D1Database;
+});
+
+afterAll(async () => {
+  await mf?.dispose();
+});
+
+describe('ensureSchema self-heals Zendesk tables on a fresh D1', () => {
+  it('creates zendesk_preauth_nonces and zendesk_tickets', async () => {
+    await ensureSchema(DB);
+
+    const rows = await DB.prepare(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name IN ('zendesk_preauth_nonces','zendesk_tickets')`
+    ).all<{ name: string }>();
+    const names = rows.results.map((r) => r.name).sort();
+    expect(names).toEqual(['zendesk_preauth_nonces', 'zendesk_tickets']);
+  });
+
+  it('zendesk_preauth_nonces is usable with the columns the app writes', async () => {
+    await ensureSchema(DB);
+
+    await DB.prepare(
+      'INSERT INTO zendesk_preauth_nonces (nonce, pubkey, expires_at) VALUES (?, ?, ?)'
+    ).bind('nonce-1', 'pk_abc', 9999999999).run();
+
+    const row = await DB.prepare(
+      'SELECT nonce, pubkey, expires_at FROM zendesk_preauth_nonces WHERE nonce = ?'
+    ).bind('nonce-1').first<{ nonce: string; pubkey: string; expires_at: number }>();
+
+    expect(row).toEqual({ nonce: 'nonce-1', pubkey: 'pk_abc', expires_at: 9999999999 });
+  });
+
+  it('zendesk_tickets is usable with the columns the app writes', async () => {
+    await ensureSchema(DB);
+
+    await DB.prepare(`
+      INSERT INTO zendesk_tickets (ticket_id, event_id, author_pubkey, violation_type, status)
+      VALUES (?, ?, ?, ?, 'open')
+    `).bind(4242, 'evt_abc', 'pk_abc', 'spam').run();
+
+    const row = await DB.prepare(
+      'SELECT ticket_id, event_id, author_pubkey, violation_type, status FROM zendesk_tickets WHERE ticket_id = ?'
+    ).bind(4242).first<{ ticket_id: number; event_id: string; author_pubkey: string; violation_type: string; status: string }>();
+
+    expect(row).toEqual({
+      ticket_id: 4242,
+      event_id: 'evt_abc',
+      author_pubkey: 'pk_abc',
+      violation_type: 'spam',
+      status: 'open',
+    });
+  });
+
+  it('creates the expected indexes on both tables', async () => {
+    await ensureSchema(DB);
+
+    const rows = await DB.prepare(
+      `SELECT name FROM sqlite_master WHERE type='index' AND name IN (
+        'idx_nonces_expires', 'idx_zendesk_event', 'idx_zendesk_author', 'idx_zendesk_status'
+      )`
+    ).all<{ name: string }>();
+    const names = rows.results.map((r) => r.name).sort();
+    expect(names).toEqual(['idx_nonces_expires', 'idx_zendesk_author', 'idx_zendesk_event', 'idx_zendesk_status']);
+  });
+
+  it('is idempotent: calling ensureSchema twice does not error', async () => {
+    await ensureSchema(DB);
+    await expect(ensureSchema(DB)).resolves.not.toThrow();
+  });
+});

--- a/worker/test/ensureschema-zendesk.d1.test.ts
+++ b/worker/test/ensureschema-zendesk.d1.test.ts
@@ -51,6 +51,22 @@ describe('ensureSchema self-heals zendesk_preauth_nonces on a fresh D1', () => {
     expect(row).toEqual({ nonce: 'nonce-1', pubkey: 'pk_abc', expires_at: 9999999999 });
   });
 
+  it('defaults created_at to unixepoch() when not specified', async () => {
+    await ensureSchema(DB);
+
+    // Deliberately omit created_at to exercise the column's NOT NULL DEFAULT.
+    await DB.prepare(
+      'INSERT INTO zendesk_preauth_nonces (nonce, pubkey, expires_at) VALUES (?, ?, ?)'
+    ).bind('nonce-2', 'pk_def', 9999999999).run();
+
+    const row = await DB.prepare(
+      'SELECT created_at FROM zendesk_preauth_nonces WHERE nonce = ?'
+    ).bind('nonce-2').first<{ created_at: number }>();
+
+    expect(typeof row?.created_at).toBe('number');
+    expect(row?.created_at).toBeGreaterThan(0);
+  });
+
   it('creates the expected index', async () => {
     await ensureSchema(DB);
 


### PR DESCRIPTION
## What this does

This worker builds its D1 schema at runtime via `ensureSchema`; the `migrations/*.sql` files are legacy and are not applied to fresh databases. `zendesk_preauth_nonces` was defined only in a migration, so it was never created on a freshly-provisioned D1. The Zendesk pre-auth flow calls `ensureSchema` expecting that table and then inserts into it, so on a fresh D1 the insert throws "no such table" and Zendesk support-auth token issuance fails outright.

This adds `zendesk_preauth_nonces` and its index to `ensureSchema` so a fresh environment works. The DDL matches migration 0003 exactly, and `CREATE TABLE IF NOT EXISTS` makes it a no-op on existing (migrated) databases.

## Scope

Only `zendesk_preauth_nonces`. `zendesk_tickets` is also migration-only, but it is already self-healed by `ensureZendeskTable()` at its usage sites, so it is intentionally not duplicated here (recorded in a code comment).

## Testing

A real-D1 test runs `ensureSchema` on a fresh Miniflare D1 and asserts the table exists, is usable (insert and read back), and has its index, and is mutation-checked (removing the CREATE turns the test red). Full worker suite green, typecheck clean.

## Impact

Latent today (prod and staging were built via migrations), but it strikes any new environment, a D1 recreation, or local-dev-from-scratch.
