### PR TITLE
feat(age-review): view reported and account content in the case pane (#200)

### DIFF
--- a/src/components/AgeReview.handoff-mutation.test.tsx
+++ b/src/components/AgeReview.handoff-mutation.test.tsx
@@ -15,10 +15,10 @@ const updateAgeReviewCase = vi.fn();
 const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
-vi.mock('@/hooks/useReportedEvent', () => ({ useReportedEvent: () => ({ data: null, isLoading: false }) }));
+vi.mock('@/hooks/useReportedEvent', () => ({ useReportedEvent: () => ({ data: undefined, isFetching: false, isError: false, refetch: () => Promise.resolve() }) }));
 vi.mock('@/hooks/useUserStats', () => ({
   useUserStats: () => ({
-    data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [] },
+    data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [], relayIncomplete: false },
     isError: false,
   }),
 }));

--- a/src/components/AgeReview.handoff-mutation.test.tsx
+++ b/src/components/AgeReview.handoff-mutation.test.tsx
@@ -15,6 +15,7 @@ const updateAgeReviewCase = vi.fn();
 const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
+vi.mock('@/hooks/useReportedEvent', () => ({ useReportedEvent: () => ({ data: null, isLoading: false }) }));
 vi.mock('@/hooks/useUserStats', () => ({
   useUserStats: () => ({
     data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [] },

--- a/src/components/AgeReview.list-shadow.test.tsx
+++ b/src/components/AgeReview.list-shadow.test.tsx
@@ -15,10 +15,10 @@ const updateAgeReviewCase = vi.fn();
 const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
-vi.mock('@/hooks/useReportedEvent', () => ({ useReportedEvent: () => ({ data: null, isLoading: false }) }));
+vi.mock('@/hooks/useReportedEvent', () => ({ useReportedEvent: () => ({ data: undefined, isFetching: false, isError: false, refetch: () => Promise.resolve() }) }));
 vi.mock('@/hooks/useUserStats', () => ({
   useUserStats: () => ({
-    data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [] },
+    data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [], relayIncomplete: false },
     isError: false,
   }),
 }));

--- a/src/components/AgeReview.list-shadow.test.tsx
+++ b/src/components/AgeReview.list-shadow.test.tsx
@@ -15,6 +15,7 @@ const updateAgeReviewCase = vi.fn();
 const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
+vi.mock('@/hooks/useReportedEvent', () => ({ useReportedEvent: () => ({ data: null, isLoading: false }) }));
 vi.mock('@/hooks/useUserStats', () => ({
   useUserStats: () => ({
     data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [] },

--- a/src/components/AgeReview.midflight-switch.test.tsx
+++ b/src/components/AgeReview.midflight-switch.test.tsx
@@ -15,10 +15,10 @@ const updateAgeReviewCase = vi.fn();
 const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
-vi.mock('@/hooks/useReportedEvent', () => ({ useReportedEvent: () => ({ data: null, isLoading: false }) }));
+vi.mock('@/hooks/useReportedEvent', () => ({ useReportedEvent: () => ({ data: undefined, isFetching: false, isError: false, refetch: () => Promise.resolve() }) }));
 vi.mock('@/hooks/useUserStats', () => ({
   useUserStats: () => ({
-    data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [] },
+    data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [], relayIncomplete: false },
     isError: false,
   }),
 }));

--- a/src/components/AgeReview.midflight-switch.test.tsx
+++ b/src/components/AgeReview.midflight-switch.test.tsx
@@ -15,6 +15,7 @@ const updateAgeReviewCase = vi.fn();
 const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
+vi.mock('@/hooks/useReportedEvent', () => ({ useReportedEvent: () => ({ data: null, isLoading: false }) }));
 vi.mock('@/hooks/useUserStats', () => ({
   useUserStats: () => ({
     data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [] },

--- a/src/components/AgeReview.reentry.test.tsx
+++ b/src/components/AgeReview.reentry.test.tsx
@@ -15,10 +15,10 @@ const updateAgeReviewCase = vi.fn();
 const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
-vi.mock('@/hooks/useReportedEvent', () => ({ useReportedEvent: () => ({ data: null, isLoading: false }) }));
+vi.mock('@/hooks/useReportedEvent', () => ({ useReportedEvent: () => ({ data: undefined, isFetching: false, isError: false, refetch: () => Promise.resolve() }) }));
 vi.mock('@/hooks/useUserStats', () => ({
   useUserStats: () => ({
-    data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [] },
+    data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [], relayIncomplete: false },
     isError: false,
   }),
 }));

--- a/src/components/AgeReview.reentry.test.tsx
+++ b/src/components/AgeReview.reentry.test.tsx
@@ -15,6 +15,7 @@ const updateAgeReviewCase = vi.fn();
 const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
+vi.mock('@/hooks/useReportedEvent', () => ({ useReportedEvent: () => ({ data: null, isLoading: false }) }));
 vi.mock('@/hooks/useUserStats', () => ({
   useUserStats: () => ({
     data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [] },

--- a/src/components/AgeReview.uninvalidate.test.tsx
+++ b/src/components/AgeReview.uninvalidate.test.tsx
@@ -15,10 +15,10 @@ const updateAgeReviewCase = vi.fn();
 const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
-vi.mock('@/hooks/useReportedEvent', () => ({ useReportedEvent: () => ({ data: null, isLoading: false }) }));
+vi.mock('@/hooks/useReportedEvent', () => ({ useReportedEvent: () => ({ data: undefined, isFetching: false, isError: false, refetch: () => Promise.resolve() }) }));
 vi.mock('@/hooks/useUserStats', () => ({
   useUserStats: () => ({
-    data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [] },
+    data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [], relayIncomplete: false },
     isError: false,
   }),
 }));

--- a/src/components/AgeReview.uninvalidate.test.tsx
+++ b/src/components/AgeReview.uninvalidate.test.tsx
@@ -15,6 +15,7 @@ const updateAgeReviewCase = vi.fn();
 const getAgeReviewConfig = vi.fn();
 const getAccountStatus = vi.fn();
 
+vi.mock('@/hooks/useReportedEvent', () => ({ useReportedEvent: () => ({ data: null, isLoading: false }) }));
 vi.mock('@/hooks/useUserStats', () => ({
   useUserStats: () => ({
     data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [] },

--- a/src/components/AgeReviewContent.reveal.test.tsx
+++ b/src/components/AgeReviewContent.reveal.test.tsx
@@ -36,7 +36,6 @@ const base = {
   contentLoading: false,
   contentError: false,
   accountStatus: active,
-  accountStatusLoading: false,
   accountStatusFailed: false,
   recentPosts: [] as never[],
   hasReportId: true,

--- a/src/components/AgeReviewContent.reveal.test.tsx
+++ b/src/components/AgeReviewContent.reveal.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { AgeReviewContent } from "./AgeReviewContent";
+import type { AccountStatusResponse } from "@/lib/adminApi";
+import type { ReportedEventResult } from "@/hooks/useReportedEvent";
+
+// A stateful stand-in for MediaPreview. The real component holds `showMedia` in
+// state and its reset effect only clears `userToggledRef` on an event change, so
+// a revealed clip stays revealed when the same element is reused for another
+// event. This mock reproduces that retention so the guard (a key on the reported
+// card) is actually exercised rather than assumed.
+vi.mock("@/components/MediaPreview", async () => {
+  const { useState } = await import("react");
+  return {
+    MediaPreview: ({ event }: { event: { id: string } }) => {
+      const [shown, setShown] = useState(false);
+      return (
+        <div data-testid="media-preview">
+          <span>{event.id}</span>
+          <button onClick={() => setShown(true)}>{shown ? "revealed" : "reveal"}</button>
+        </div>
+      );
+    },
+  };
+});
+
+const active: AccountStatusResponse = { success: true, status: "active" };
+
+function ev(id: string) {
+  return { id, pubkey: "d4".repeat(32), created_at: 1751000000, kind: 34235, tags: [], content: "", sig: "" } as never;
+}
+const found = (event: ReturnType<typeof ev>): ReportedEventResult => ({ status: "found", event, banned: false });
+
+const base = {
+  postCount: 0,
+  contentLoading: false,
+  contentError: false,
+  accountStatus: active,
+  accountStatusLoading: false,
+  accountStatusFailed: false,
+  recentPosts: [] as never[],
+  hasReportId: true,
+};
+
+describe("AgeReviewContent reveal state", () => {
+  it("does not carry a revealed clip over to the next case", () => {
+    const caseA = ev("a1".repeat(32));
+    const caseB = ev("b2".repeat(32));
+
+    const { rerender } = render(<AgeReviewContent {...base} reportedEvent={found(caseA)} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "reveal" }));
+    expect(screen.getByRole("button", { name: "revealed" })).toBeInTheDocument();
+
+    // Same pane, different case. Media must be gated again: revealing content in
+    // an under-16 review is a deliberate act, not a sticky preference.
+    rerender(<AgeReviewContent {...base} reportedEvent={found(caseB)} />);
+
+    expect(screen.getByText("b2".repeat(32))).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "reveal" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "revealed" })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/AgeReviewContent.reveal.test.tsx
+++ b/src/components/AgeReviewContent.reveal.test.tsx
@@ -30,6 +30,7 @@ function ev(id: string) {
   return { id, pubkey: "d4".repeat(32), created_at: 1751000000, kind: 34235, tags: [], content: "", sig: "" } as never;
 }
 const found = (event: ReturnType<typeof ev>): ReportedEventResult => ({ status: "found", event, banned: false });
+const foreign = (event: ReturnType<typeof ev>): ReportedEventResult => ({ status: "target_foreign", event, banned: false });
 
 const base = {
   postCount: 0,
@@ -56,6 +57,21 @@ describe("AgeReviewContent reveal state", () => {
     rerender(<AgeReviewContent {...base} reportedEvent={found(caseB)} />);
 
     expect(screen.getByText("b2".repeat(32))).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "reveal" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "revealed" })).not.toBeInTheDocument();
+  });
+
+  it("does not carry a revealed clip over on the foreign-author path either", () => {
+    // Mis-targeted content is still gated: it is shown for evidence, not exposed
+    // by default, and the gate must reset per case like the normal path.
+    const caseA = ev("a1".repeat(32));
+    const caseB = ev("b2".repeat(32));
+
+    const { rerender } = render(<AgeReviewContent {...base} reportedEvent={foreign(caseA)} />);
+    fireEvent.click(screen.getByRole("button", { name: "reveal" }));
+    expect(screen.getByRole("button", { name: "revealed" })).toBeInTheDocument();
+
+    rerender(<AgeReviewContent {...base} reportedEvent={foreign(caseB)} />);
     expect(screen.getByRole("button", { name: "reveal" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "revealed" })).not.toBeInTheDocument();
   });

--- a/src/components/AgeReviewContent.test.tsx
+++ b/src/components/AgeReviewContent.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { AgeReviewContent } from "./AgeReviewContent";
+import type { AccountStatusResponse } from "@/lib/adminApi";
+
+// Isolate from MediaPreview's media-fetch/proxy logic.
+vi.mock("@/components/MediaPreview", () => ({
+  MediaPreview: ({ event }: { event: { id: string } }) => (
+    <div data-testid="media-preview">{event.id}</div>
+  ),
+}));
+
+const active: AccountStatusResponse = { success: true, status: "active" };
+const suspended: AccountStatusResponse = { success: true, status: "suspended" };
+const banned: AccountStatusResponse = { success: true, status: "banned" };
+
+function ev(id: string) {
+  return { id, pubkey: "b".repeat(64), created_at: 1751000000, kind: 34235, tags: [], content: "a clip", sig: "" } as never;
+}
+
+const base = { postCount: 0, contentLoading: false, contentError: false, accountStatus: active, recentPosts: [] as never[] };
+const reported = (event: ReturnType<typeof ev>, banned: boolean) => ({ event, banned });
+
+describe("AgeReviewContent", () => {
+  it("renders the target's recent content when present", () => {
+    render(<AgeReviewContent {...base} postCount={2} recentPosts={[ev("1".repeat(64)), ev("2".repeat(64))]} />);
+    expect(screen.getByText(/recent content \(2\)/i)).toBeInTheDocument();
+    expect(screen.getAllByTestId("media-preview")).toHaveLength(2);
+  });
+
+  it("labels suspended content as hidden by suspension (not blank)", () => {
+    render(<AgeReviewContent {...base} accountStatus={suspended} />);
+    expect(screen.getByText(/hidden by suspension/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("media-preview")).not.toBeInTheDocument();
+  });
+
+  it("labels banned content as removed", () => {
+    render(<AgeReviewContent {...base} accountStatus={banned} />);
+    expect(screen.getByText(/removed \(account banned\)/i)).toBeInTheDocument();
+  });
+
+  it("surfaces a load error (with retry) rather than claiming absent", () => {
+    const onRetry = vi.fn();
+    render(<AgeReviewContent {...base} postCount={undefined} contentError={true} onRetry={onRetry} />);
+    expect(screen.getByText(/couldn't load/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no content found/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("states confirmed-absent explicitly, not blamed on suspension", () => {
+    render(<AgeReviewContent {...base} accountStatus={active} />);
+    expect(screen.getByText(/no content found/i)).toBeInTheDocument();
+    expect(screen.getByText(/not attributable to suspension/i)).toBeInTheDocument();
+  });
+
+  it("shows the reported event (relay-visible, no banned badge)", () => {
+    render(<AgeReviewContent {...base} hasReportId reportedEvent={reported(ev("f".repeat(64)), false)} />);
+    expect(screen.getByText(/reported content/i)).toBeInTheDocument();
+    expect(screen.queryByText(/removed \(banned\)/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a banned reported event (via getbannedevent) badged as removed", () => {
+    render(<AgeReviewContent {...base} hasReportId reportedEvent={reported(ev("f".repeat(64)), true)} />);
+    expect(screen.getByText(/reported content/i)).toBeInTheDocument();
+    expect(screen.getByText(/removed \(banned\)/i)).toBeInTheDocument();
+  });
+
+  it("dedupes the reported event from the recent-content list", () => {
+    const shared = ev("f".repeat(64));
+    render(
+      <AgeReviewContent
+        {...base}
+        postCount={2}
+        recentPosts={[shared, ev("1".repeat(64))]}
+        hasReportId
+        reportedEvent={reported(shared, false)}
+      />,
+    );
+    // reported event + one other post = 2 MediaPreviews, not 3
+    expect(screen.getAllByTestId("media-preview")).toHaveLength(2);
+    expect(screen.getByText(/recent content \(1\)/i)).toBeInTheDocument();
+  });
+
+  it("states when the reported event is not found (and there was a report id)", () => {
+    render(<AgeReviewContent {...base} hasReportId reportedEvent={null} reportedEventLoading={false} />);
+    expect(screen.getByText(/not on the relay/i)).toBeInTheDocument();
+  });
+
+  it("labels a reported-event load error (with retry), not as absent", () => {
+    const onRetryReported = vi.fn();
+    render(
+      <AgeReviewContent
+        {...base}
+        hasReportId
+        reportedEvent={undefined}
+        reportedEventLoading={false}
+        reportedEventError
+        onRetryReported={onRetryReported}
+      />,
+    );
+    expect(screen.getByText(/couldn't load the reported event/i)).toBeInTheDocument();
+    expect(screen.queryByText(/not on the relay/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/AgeReviewContent.test.tsx
+++ b/src/components/AgeReviewContent.test.tsx
@@ -30,7 +30,6 @@ const base = {
   contentLoading: false,
   contentError: false,
   accountStatus: active,
-  accountStatusLoading: false,
   accountStatusFailed: false,
   recentPosts: [] as never[],
 };
@@ -80,9 +79,23 @@ describe("AgeReviewContent: account content", () => {
     expect(screen.getByText(/suspension cannot be ruled out/i)).toBeInTheDocument();
   });
 
-  it("does not rule out suspension while account status is still loading", () => {
-    render(<AgeReviewContent {...base} accountStatus={undefined} accountStatusLoading />);
+  it("does not rule out suspension before account status has arrived", () => {
+    render(<AgeReviewContent {...base} accountStatus={undefined} />);
     expect(screen.getByText(/suspension cannot be ruled out/i)).toBeInTheDocument();
+  });
+
+  it("does not trust stale status data after the status read failed", () => {
+    // TanStack keeps the last successful `data` while isError is true, so without
+    // the failed flag a stale "active" would be treated as current truth.
+    render(<AgeReviewContent {...base} accountStatus={active} accountStatusFailed />);
+    expect(screen.getByText(/suspension cannot be ruled out/i)).toBeInTheDocument();
+    expect(screen.queryByText(/not suspended/i)).not.toBeInTheDocument();
+  });
+
+  it("treats a self-custody account as a definitive answer, not unavailable", () => {
+    render(<AgeReviewContent {...base} accountStatus={{ success: false, not_found: true }} />);
+    expect(screen.getByText(/self-custody account/i)).toBeInTheDocument();
+    expect(screen.queryByText(/cannot be ruled out/i)).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/AgeReviewContent.test.tsx
+++ b/src/components/AgeReviewContent.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { AgeReviewContent } from "./AgeReviewContent";
 import type { AccountStatusResponse } from "@/lib/adminApi";
+import type { ReportedEventResult } from "@/hooks/useReportedEvent";
 
 // Isolate from MediaPreview's media-fetch/proxy logic.
 vi.mock("@/components/MediaPreview", () => ({
@@ -13,15 +14,28 @@ vi.mock("@/components/MediaPreview", () => ({
 const active: AccountStatusResponse = { success: true, status: "active" };
 const suspended: AccountStatusResponse = { success: true, status: "suspended" };
 const banned: AccountStatusResponse = { success: true, status: "banned" };
+const statusUnavailable: AccountStatusResponse = { success: false };
 
 function ev(id: string) {
   return { id, pubkey: "b".repeat(64), created_at: 1751000000, kind: 34235, tags: [], content: "a clip", sig: "" } as never;
 }
 
-const base = { postCount: 0, contentLoading: false, contentError: false, accountStatus: active, recentPosts: [] as never[] };
-const reported = (event: ReturnType<typeof ev>, banned: boolean) => ({ event, banned });
+const found = (event: ReturnType<typeof ev>, isBanned = false): ReportedEventResult =>
+  ({ status: "found", event, banned: isBanned });
 
-describe("AgeReviewContent", () => {
+// Account status resolved and says "active" unless a test says otherwise, so
+// the absent/unknown distinction is exercised deliberately rather than by default.
+const base = {
+  postCount: 0,
+  contentLoading: false,
+  contentError: false,
+  accountStatus: active,
+  accountStatusLoading: false,
+  accountStatusFailed: false,
+  recentPosts: [] as never[],
+};
+
+describe("AgeReviewContent: account content", () => {
   it("renders the target's recent content when present", () => {
     render(<AgeReviewContent {...base} postCount={2} recentPosts={[ev("1".repeat(64)), ev("2".repeat(64))]} />);
     expect(screen.getByText(/recent content \(2\)/i)).toBeInTheDocument();
@@ -47,21 +61,40 @@ describe("AgeReviewContent", () => {
     expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
   });
 
-  it("states confirmed-absent explicitly, not blamed on suspension", () => {
-    render(<AgeReviewContent {...base} accountStatus={active} />);
-    expect(screen.getByText(/no content found/i)).toBeInTheDocument();
-    expect(screen.getByText(/not attributable to suspension/i)).toBeInTheDocument();
+  it("treats a truncated relay read as an error, never as absence", () => {
+    // NPool.query resolves with partial results instead of throwing, so a cut-short
+    // read arrives as postCount 0 with no error flag. It must not read as "absent".
+    render(<AgeReviewContent {...base} postCount={0} contentIncomplete={true} />);
+    expect(screen.getByText(/couldn't load/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no content found/i)).not.toBeInTheDocument();
   });
 
-  it("shows the reported event (relay-visible, no banned badge)", () => {
-    render(<AgeReviewContent {...base} hasReportId reportedEvent={reported(ev("f".repeat(64)), false)} />);
+  it("states confirmed-absent only when the account is known not suspended", () => {
+    render(<AgeReviewContent {...base} accountStatus={active} />);
+    expect(screen.getByText(/no content found/i)).toBeInTheDocument();
+    expect(screen.getByText(/not suspended/i)).toBeInTheDocument();
+  });
+
+  it("does not rule out suspension when account status is unavailable", () => {
+    render(<AgeReviewContent {...base} accountStatus={statusUnavailable} accountStatusFailed />);
+    expect(screen.getByText(/suspension cannot be ruled out/i)).toBeInTheDocument();
+  });
+
+  it("does not rule out suspension while account status is still loading", () => {
+    render(<AgeReviewContent {...base} accountStatus={undefined} accountStatusLoading />);
+    expect(screen.getByText(/suspension cannot be ruled out/i)).toBeInTheDocument();
+  });
+});
+
+describe("AgeReviewContent: reported content", () => {
+  it("shows the resolved reported event (no banned badge)", () => {
+    render(<AgeReviewContent {...base} hasReportId reportedEvent={found(ev("f".repeat(64)))} />);
     expect(screen.getByText(/reported content/i)).toBeInTheDocument();
     expect(screen.queryByText(/removed \(banned\)/i)).not.toBeInTheDocument();
   });
 
-  it("shows a banned reported event (via getbannedevent) badged as removed", () => {
-    render(<AgeReviewContent {...base} hasReportId reportedEvent={reported(ev("f".repeat(64)), true)} />);
-    expect(screen.getByText(/reported content/i)).toBeInTheDocument();
+  it("badges a reported event retrieved via getbannedevent as removed", () => {
+    render(<AgeReviewContent {...base} hasReportId reportedEvent={found(ev("f".repeat(64)), true)} />);
     expect(screen.getByText(/removed \(banned\)/i)).toBeInTheDocument();
   });
 
@@ -73,17 +106,60 @@ describe("AgeReviewContent", () => {
         postCount={2}
         recentPosts={[shared, ev("1".repeat(64))]}
         hasReportId
-        reportedEvent={reported(shared, false)}
+        reportedEvent={found(shared)}
       />,
     );
-    // reported event + one other post = 2 MediaPreviews, not 3
     expect(screen.getAllByTestId("media-preview")).toHaveLength(2);
     expect(screen.getByText(/recent content \(1\)/i)).toBeInTheDocument();
   });
 
-  it("states when the reported event is not found (and there was a report id)", () => {
-    render(<AgeReviewContent {...base} hasReportId reportedEvent={null} reportedEventLoading={false} />);
-    expect(screen.getByText(/not on the relay/i)).toBeInTheDocument();
+  it("explains an account-level report instead of implying a missing post", () => {
+    render(<AgeReviewContent {...base} hasReportId reportedEvent={{ status: "account_level" }} />);
+    expect(screen.getByText(/filed against the account/i)).toBeInTheDocument();
+    expect(screen.queryByText(/not retrievable/i)).not.toBeInTheDocument();
+  });
+
+  it("says when the report event itself is gone", () => {
+    render(<AgeReviewContent {...base} hasReportId reportedEvent={{ status: "report_missing" }} />);
+    expect(screen.getByText(/report event is no longer on the relay/i)).toBeInTheDocument();
+  });
+
+  it("says the target is not retrievable when the account is not under enforcement", () => {
+    render(
+      <AgeReviewContent
+        {...base}
+        hasReportId
+        reportedEvent={{ status: "target_missing", targetEventId: "a".repeat(64) }}
+      />,
+    );
+    expect(screen.getByText(/not retrievable/i)).toBeInTheDocument();
+  });
+
+  it("blames suspension, not deletion, when the target is hidden by a suspended account", () => {
+    // Suspension hides the account's events and getbannedevent only knows per-event
+    // bans, so without the account-status ladder this reads as "deleted".
+    render(
+      <AgeReviewContent
+        {...base}
+        accountStatus={suspended}
+        hasReportId
+        reportedEvent={{ status: "target_missing", targetEventId: "a".repeat(64) }}
+      />,
+    );
+    expect(screen.getByText(/hidden by the account's suspension/i)).toBeInTheDocument();
+    expect(screen.queryByText(/deleted, aged out/i)).not.toBeInTheDocument();
+  });
+
+  it("attributes a missing target to the ban when the account is banned", () => {
+    render(
+      <AgeReviewContent
+        {...base}
+        accountStatus={banned}
+        hasReportId
+        reportedEvent={{ status: "target_missing", targetEventId: "a".repeat(64) }}
+      />,
+    );
+    expect(screen.getByText(/removed with the account ban/i)).toBeInTheDocument();
   });
 
   it("labels a reported-event load error (with retry), not as absent", () => {
@@ -93,13 +169,32 @@ describe("AgeReviewContent", () => {
         {...base}
         hasReportId
         reportedEvent={undefined}
-        reportedEventLoading={false}
         reportedEventError
         onRetryReported={onRetryReported}
       />,
     );
-    expect(screen.getByText(/couldn't load the reported event/i)).toBeInTheDocument();
-    expect(screen.queryByText(/not on the relay/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/couldn't load the reported content/i)).toBeInTheDocument();
+    expect(screen.queryByText(/not retrievable/i)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("shows a loading state while the lookup is in flight, never a missing-content claim", () => {
+    render(<AgeReviewContent {...base} hasReportId reportedEvent={undefined} reportedEventLoading />);
+    expect(screen.getByText(/loading reported content/i)).toBeInTheDocument();
+    expect(screen.queryByText(/not retrievable/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/no longer on the relay/i)).not.toBeInTheDocument();
+  });
+
+  it("omits the reported section entirely for a case with no report", () => {
+    render(<AgeReviewContent {...base} hasReportId={false} reportedEvent={undefined} />);
+    expect(screen.queryByText(/reported content/i)).not.toBeInTheDocument();
+  });
+
+  it("does not render a bare heading when there is nothing to say yet", () => {
+    // Idle: a report id exists but the lookup has not resolved, errored, or
+    // started. A lone "Reported content" label over empty space reads as though
+    // something failed to render.
+    render(<AgeReviewContent {...base} hasReportId reportedEvent={undefined} reportedEventLoading={false} />);
+    expect(screen.queryByText(/reported content/i)).not.toBeInTheDocument();
   });
 });

--- a/src/components/AgeReviewContent.test.tsx
+++ b/src/components/AgeReviewContent.test.tsx
@@ -163,6 +163,34 @@ describe("AgeReviewContent: reported content", () => {
     expect(screen.queryByText(/deleted, aged out/i)).not.toBeInTheDocument();
   });
 
+  it("does not blame a suspension it can no longer verify", () => {
+    // Stale suspended status retained after a failed refetch: blaming it here
+    // would contradict the account card below, which says status is unavailable.
+    render(
+      <AgeReviewContent
+        {...base}
+        accountStatus={suspended}
+        accountStatusFailed
+        hasReportId
+        reportedEvent={{ status: "target_missing", targetEventId: "a".repeat(64) }}
+      />,
+    );
+    expect(screen.getByText(/not retrievable/i)).toBeInTheDocument();
+    expect(screen.queryByText(/hidden by the account's suspension/i)).not.toBeInTheDocument();
+  });
+
+  it("says the linked event is not a report, rather than that it is missing", () => {
+    render(<AgeReviewContent {...base} hasReportId reportedEvent={{ status: "not_a_report" }} />);
+    expect(screen.getByText(/not a report/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no longer on the relay/i)).not.toBeInTheDocument();
+  });
+
+  it("does not call an unparseable target an account-level report", () => {
+    render(<AgeReviewContent {...base} hasReportId reportedEvent={{ status: "target_unreadable" }} />);
+    expect(screen.getByText(/target we cannot read/i)).toBeInTheDocument();
+    expect(screen.queryByText(/filed against the account/i)).not.toBeInTheDocument();
+  });
+
   it("attributes a missing target to the ban when the account is banned", () => {
     render(
       <AgeReviewContent

--- a/src/components/AgeReviewContent.test.tsx
+++ b/src/components/AgeReviewContent.test.tsx
@@ -163,7 +163,7 @@ describe("AgeReviewContent: reported content", () => {
     expect(screen.queryByText(/deleted, aged out/i)).not.toBeInTheDocument();
   });
 
-  it("does not blame a suspension it can no longer verify", () => {
+  it("does not blame a suspension it can no longer verify, in either section", () => {
     // Stale suspended status retained after a failed refetch: blaming it here
     // would contradict the account card below, which says status is unavailable.
     render(
@@ -177,6 +177,24 @@ describe("AgeReviewContent: reported content", () => {
     );
     expect(screen.getByText(/not retrievable/i)).toBeInTheDocument();
     expect(screen.queryByText(/hidden by the account's suspension/i)).not.toBeInTheDocument();
+    // ...and the account-content card below must not assert it either, or the
+    // two halves of the pane contradict each other on the same screen.
+    expect(screen.queryByText(/content hidden by suspension/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a foreign-authored post, but labelled and never as this account's", () => {
+    const foreign = ev("c".repeat(64));
+    render(
+      <AgeReviewContent
+        {...base}
+        hasReportId
+        reportedEvent={{ status: "target_foreign", event: foreign, authorPubkey: "e".repeat(64), banned: false }}
+      />,
+    );
+    // Evidence is preserved...
+    expect(screen.getByTestId("media-preview")).toBeInTheDocument();
+    // ...but attribution is explicit, so it cannot be read as this account's post.
+    expect(screen.getByText(/not by this case's subject/i)).toBeInTheDocument();
   });
 
   it("says the linked event is not a report, rather than that it is missing", () => {

--- a/src/components/AgeReviewContent.test.tsx
+++ b/src/components/AgeReviewContent.test.tsx
@@ -30,7 +30,6 @@ const base = {
   contentLoading: false,
   contentError: false,
   accountStatus: active,
-  accountStatusFailed: false,
   recentPosts: [] as never[],
 };
 
@@ -75,7 +74,7 @@ describe("AgeReviewContent: account content", () => {
   });
 
   it("does not rule out suspension when account status is unavailable", () => {
-    render(<AgeReviewContent {...base} accountStatus={statusUnavailable} accountStatusFailed />);
+    render(<AgeReviewContent {...base} accountStatus={statusUnavailable} />);
     expect(screen.getByText(/suspension cannot be ruled out/i)).toBeInTheDocument();
   });
 
@@ -84,13 +83,7 @@ describe("AgeReviewContent: account content", () => {
     expect(screen.getByText(/suspension cannot be ruled out/i)).toBeInTheDocument();
   });
 
-  it("does not trust stale status data after the status read failed", () => {
-    // TanStack keeps the last successful `data` while isError is true, so without
-    // the failed flag a stale "active" would be treated as current truth.
-    render(<AgeReviewContent {...base} accountStatus={active} accountStatusFailed />);
-    expect(screen.getByText(/suspension cannot be ruled out/i)).toBeInTheDocument();
-    expect(screen.queryByText(/not suspended/i)).not.toBeInTheDocument();
-  });
+
 
   it("treats a self-custody account as a definitive answer, not unavailable", () => {
     render(<AgeReviewContent {...base} accountStatus={{ success: false, not_found: true }} />);
@@ -108,6 +101,31 @@ describe("AgeReviewContent: reported content", () => {
 
   it("badges a reported event retrieved via getbannedevent as removed", () => {
     render(<AgeReviewContent {...base} hasReportId reportedEvent={found(ev("f".repeat(64)), true)} />);
+    expect(screen.getByText(/removed \(banned\)/i)).toBeInTheDocument();
+  });
+
+  it("badges a banned foreign post, and never shows the badge without the content", () => {
+    const e = ev("c".repeat(64));
+    const { rerender } = render(
+      <AgeReviewContent {...base} hasReportId reportedEvent={{ status: "target_foreign", event: e, banned: true }} />,
+    );
+    expect(screen.getByText(/removed \(banned\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/not by this case's subject/i)).toBeInTheDocument();
+
+    // A background refetch must not strip the content and the warning while
+    // leaving the badge behind: "removed (banned)" over "Loading…" is a claim
+    // about nothing, and a banned post shown without its attribution warning is
+    // the misattribution this path exists to prevent.
+    rerender(
+      <AgeReviewContent
+        {...base}
+        hasReportId
+        reportedEvent={{ status: "target_foreign", event: e, banned: true }}
+        reportedEventLoading
+      />,
+    );
+    expect(screen.queryByText(/loading reported content/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/not by this case's subject/i)).toBeInTheDocument();
     expect(screen.getByText(/removed \(banned\)/i)).toBeInTheDocument();
   });
 
@@ -163,38 +181,19 @@ describe("AgeReviewContent: reported content", () => {
     expect(screen.queryByText(/deleted, aged out/i)).not.toBeInTheDocument();
   });
 
-  it("does not blame a suspension it can no longer verify, in either section", () => {
-    // Stale suspended status retained after a failed refetch: blaming it here
-    // would contradict the account card below, which says status is unavailable.
+  it("keeps the two sections agreeing about a stale suspended status", () => {
+    // Data-first, matching the account panel above: both attribute to the
+    // suspension rather than one asserting it and the other doubting it.
     render(
       <AgeReviewContent
         {...base}
         accountStatus={suspended}
-        accountStatusFailed
         hasReportId
         reportedEvent={{ status: "target_missing", targetEventId: "a".repeat(64) }}
       />,
     );
-    expect(screen.getByText(/not retrievable/i)).toBeInTheDocument();
-    expect(screen.queryByText(/hidden by the account's suspension/i)).not.toBeInTheDocument();
-    // ...and the account-content card below must not assert it either, or the
-    // two halves of the pane contradict each other on the same screen.
-    expect(screen.queryByText(/content hidden by suspension/i)).not.toBeInTheDocument();
-  });
-
-  it("shows a foreign-authored post, but labelled and never as this account's", () => {
-    const foreign = ev("c".repeat(64));
-    render(
-      <AgeReviewContent
-        {...base}
-        hasReportId
-        reportedEvent={{ status: "target_foreign", event: foreign, authorPubkey: "e".repeat(64), banned: false }}
-      />,
-    );
-    // Evidence is preserved...
-    expect(screen.getByTestId("media-preview")).toBeInTheDocument();
-    // ...but attribution is explicit, so it cannot be read as this account's post.
-    expect(screen.getByText(/not by this case's subject/i)).toBeInTheDocument();
+    expect(screen.getByText(/hidden by the account's suspension/i)).toBeInTheDocument();
+    expect(screen.queryByText(/cannot be ruled out/i)).not.toBeInTheDocument();
   });
 
   it("says the linked event is not a report, rather than that it is missing", () => {

--- a/src/components/AgeReviewContent.test.tsx
+++ b/src/components/AgeReviewContent.test.tsx
@@ -181,19 +181,25 @@ describe("AgeReviewContent: reported content", () => {
     expect(screen.queryByText(/deleted, aged out/i)).not.toBeInTheDocument();
   });
 
-  it("keeps the two sections agreeing about a stale suspended status", () => {
-    // Data-first, matching the account panel above: both attribute to the
-    // suspension rather than one asserting it and the other doubting it.
+  it("marks both sections as stale, and offers a retry, when the status is unrefreshed", () => {
+    // Data-first keeps the two sections agreeing, but neither may present a
+    // claim resting on an unrefreshed status as though it were current, and the
+    // moderator needs a way to re-ask.
+    const onRetry = vi.fn();
     render(
       <AgeReviewContent
         {...base}
         accountStatus={suspended}
+        accountStatusFailed
+        onRetry={onRetry}
         hasReportId
         reportedEvent={{ status: "target_missing", targetEventId: "a".repeat(64) }}
       />,
     );
     expect(screen.getByText(/hidden by the account's suspension/i)).toBeInTheDocument();
-    expect(screen.queryByText(/cannot be ruled out/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/hidden by suspension/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/could not be refreshed/i).length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
   });
 
   it("says the linked event is not a report, rather than that it is missing", () => {

--- a/src/components/AgeReviewContent.tsx
+++ b/src/components/AgeReviewContent.tsx
@@ -69,12 +69,21 @@ function Note({ children }: { children: ReactNode }) {
  * only knows per-event bans, so without this an enforced account reads as
  * "deleted", which is a different and much more final claim.
  */
-function reportedMissingReason(accountStatus: AccountStatusResponse | undefined): string {
-  if (accountStatus?.status === "suspended") {
-    return "The reported post is hidden by the account's suspension, so it cannot be shown here.";
-  }
-  if (accountStatus?.status === "banned") {
-    return "The reported post was removed with the account ban.";
+function reportedMissingReason(
+  accountStatus: AccountStatusResponse | undefined,
+  accountStatusFailed: boolean | undefined,
+): string {
+  // A status we no longer trust cannot explain anything. TanStack keeps the last
+  // successful data while isError is true, so without this the section could
+  // blame a suspension that has since been lifted, while the card directly below
+  // correctly says the status is unavailable.
+  if (!accountStatusFailed) {
+    if (accountStatus?.status === "suspended") {
+      return "The reported post is hidden by the account's suspension, so it cannot be shown here.";
+    }
+    if (accountStatus?.status === "banned") {
+      return "The reported post was removed with the account ban.";
+    }
   }
   return "The reported post is not retrievable from the relay (deleted, aged out, or hidden).";
 }
@@ -129,16 +138,21 @@ export function AgeReviewContent({
     <Note>This report was filed against the account rather than a specific post, so there is no single item to show.</Note>
   ) : reportedEvent?.status === "report_missing" ? (
     <Note>The report event is no longer on the relay, so its target cannot be resolved.</Note>
+  ) : reportedEvent?.status === "not_a_report" ? (
+    <Note>The linked event is not a report, so what it refers to cannot be determined.</Note>
+  ) : reportedEvent?.status === "target_unreadable" ? (
+    <Note>This report names a target we cannot read, so the reported post cannot be resolved.</Note>
   ) : reportedEvent?.status === "target_foreign" ? (
     // Deliberately not rendered: judging this account by another account's post
-    // is how the wrong person gets enforced against.
+    // is how the wrong person gets enforced against. Stated as a fact about the
+    // tag, not an accusation, since a client quirk is likelier than bad faith.
     <div className="rounded-md border border-amber-500/40 p-2.5 text-xs text-amber-700 dark:text-amber-400">
       This report points at an event authored by a different account
       (<span className="font-mono">{reportedEvent.authorPubkey.slice(0, 12)}…</span>),
-      not by this case's subject, so it is not shown here. Treat the report itself as suspect.
+      not by this case's subject, so it is not shown here as this account's content.
     </div>
   ) : reportedEvent?.status === "target_missing" ? (
-    <Note>{reportedMissingReason(accountStatus)}</Note>
+    <Note>{reportedMissingReason(accountStatus, accountStatusFailed)}</Note>
   ) : null;
 
   return (

--- a/src/components/AgeReviewContent.tsx
+++ b/src/components/AgeReviewContent.tsx
@@ -1,0 +1,131 @@
+// ABOUTME: Renders an age-review target's content — the reported event (relay or
+// ABOUTME: getbannedevent fallback) plus recent posts via MediaPreview (which proxies
+// ABOUTME: Blossom-blocked media) — or a verified "why not visible" reason. Never a
+// ABOUTME: blank, never a guess, never an error masked as absent.
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { RefreshCw } from "lucide-react";
+import type { NostrEvent } from "@nostrify/nostrify";
+import type { AccountStatusResponse } from "@/lib/adminApi";
+import type { ReportedEventResult } from "@/hooks/useReportedEvent";
+import { MediaPreview } from "@/components/MediaPreview";
+import { getKindName } from "@/lib/kindNames";
+import { deriveContentVisibility } from "@/lib/contentVisibility";
+
+interface AgeReviewContentProps {
+  postCount: number | undefined;
+  contentLoading: boolean;
+  contentError: boolean;
+  accountStatus: AccountStatusResponse | undefined;
+  recentPosts: NostrEvent[];
+  onRetry?: () => void;
+  // The specific reported event (relay-visible or retrieved via getbannedevent).
+  reportedEvent?: ReportedEventResult | null;
+  reportedEventLoading?: boolean;
+  // The reported-event read errored (relay/timeout) — distinct from a confirmed
+  // not-found, so we never label a transient failure as "deleted or aged out".
+  reportedEventError?: boolean;
+  onRetryReported?: () => void;
+  // Whether the case has a report_id at all (so "not found" only shows when it does).
+  hasReportId?: boolean;
+}
+
+// One content item — click-to-reveal media (MediaPreview default; the media-proxy
+// fallback handles Blossom-blocked blobs), kind + timestamp, and any text.
+function ContentCard({ event }: { event: NostrEvent }) {
+  return (
+    <div className="rounded-md border p-2.5 space-y-1.5">
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <span>{getKindName(event.kind)}</span>
+        <span>·</span>
+        <span>{new Date(event.created_at * 1000).toLocaleString()}</span>
+      </div>
+      <MediaPreview event={event} maxItems={4} />
+      {event.content ? (
+        <p className="text-sm whitespace-pre-wrap break-words">{event.content}</p>
+      ) : null}
+    </div>
+  );
+}
+
+export function AgeReviewContent({
+  postCount,
+  contentLoading,
+  contentError,
+  accountStatus,
+  recentPosts,
+  onRetry,
+  reportedEvent,
+  reportedEventLoading,
+  reportedEventError,
+  onRetryReported,
+  hasReportId,
+}: AgeReviewContentProps) {
+  const vis = deriveContentVisibility({ postCount, contentLoading, contentError, accountStatus });
+  const reportedId = reportedEvent?.event.id;
+  const otherPosts = recentPosts.filter((e) => e.id !== reportedId);
+
+  return (
+    <div className="space-y-3">
+      {/* The specific event that triggered the case. */}
+      {reportedEvent ? (
+        <div className="space-y-1.5">
+          <h4 className="flex items-center gap-2 text-sm font-medium">
+            Reported content
+            {reportedEvent.banned ? (
+              <Badge variant="destructive" className="text-xs">removed (banned)</Badge>
+            ) : null}
+          </h4>
+          <ContentCard event={reportedEvent.event} />
+        </div>
+      ) : reportedEventLoading ? (
+        <p className="text-xs text-muted-foreground">Loading reported content…</p>
+      ) : reportedEventError ? (
+        <div className="flex items-center justify-between gap-2 text-xs text-amber-700 dark:text-amber-400">
+          <span>Couldn't load the reported event (relay error).</span>
+          {onRetryReported ? (
+            <Button variant="outline" size="sm" onClick={onRetryReported}>
+              <RefreshCw className="mr-1 h-3 w-3" /> Retry
+            </Button>
+          ) : null}
+        </div>
+      ) : hasReportId ? (
+        <p className="text-xs text-muted-foreground">
+          The reported event is not on the relay (deleted or aged out).
+        </p>
+      ) : null}
+
+      {/* The account's other recent content, or a verified reason it isn't visible. */}
+      {vis.state === "has_content" ? (
+        otherPosts.length > 0 ? (
+          <div className="space-y-2">
+            <h4 className="text-sm font-medium">Recent content ({otherPosts.length})</h4>
+            <div className="space-y-2">
+              {otherPosts.map((e) => (
+                <ContentCard key={e.id} event={e} />
+              ))}
+            </div>
+          </div>
+        ) : null
+      ) : (
+        <Card>
+          <CardContent
+            className={`p-3 text-sm ${
+              vis.state === "error" ? "text-amber-700 dark:text-amber-400" : "text-muted-foreground"
+            }`}
+          >
+            <div className="flex items-center justify-between gap-2">
+              <span>{vis.message}</span>
+              {vis.state === "error" && onRetry ? (
+                <Button variant="outline" size="sm" onClick={onRetry}>
+                  <RefreshCw className="mr-1 h-3 w-3" /> Retry
+                </Button>
+              ) : null}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/AgeReviewContent.tsx
+++ b/src/components/AgeReviewContent.tsx
@@ -1,7 +1,9 @@
-// ABOUTME: Renders an age-review target's content — the reported event (relay or
-// ABOUTME: getbannedevent fallback) plus recent posts via MediaPreview (which proxies
-// ABOUTME: Blossom-blocked media) — or a verified "why not visible" reason. Never a
-// ABOUTME: blank, never a guess, never an error masked as absent.
+// ABOUTME: Renders an age-review target's content: the reported event (resolved
+// ABOUTME: through the report's target tag, with a getbannedevent fallback) plus
+// ABOUTME: recent posts via MediaPreview (which proxies Blossom-blocked media),
+// ABOUTME: or a verified reason it is not visible. Never a blank, never a guess,
+// ABOUTME: never an error or an in-flight read presented as absence.
+import type { ReactNode } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -17,21 +19,26 @@ interface AgeReviewContentProps {
   postCount: number | undefined;
   contentLoading: boolean;
   contentError: boolean;
+  // The account read resolved but was truncated, so a zero count proves nothing.
+  contentIncomplete?: boolean;
   accountStatus: AccountStatusResponse | undefined;
+  accountStatusLoading?: boolean;
+  accountStatusFailed?: boolean;
   recentPosts: NostrEvent[];
   onRetry?: () => void;
-  // The specific reported event (relay-visible or retrieved via getbannedevent).
+  // Outcome of resolving what the report targets. Undefined while it has not run.
   reportedEvent?: ReportedEventResult | null;
   reportedEventLoading?: boolean;
-  // The reported-event read errored (relay/timeout) — distinct from a confirmed
-  // not-found, so we never label a transient failure as "deleted or aged out".
+  // The lookup failed. Distinct from any "not retrievable" outcome, so a
+  // transient failure is never labelled as a deletion.
   reportedEventError?: boolean;
   onRetryReported?: () => void;
-  // Whether the case has a report_id at all (so "not found" only shows when it does).
+  // Whether the case has a report_id at all (so the reported section only
+  // appears for cases that came from a report).
   hasReportId?: boolean;
 }
 
-// One content item — click-to-reveal media (MediaPreview default; the media-proxy
+// One content item: click-to-reveal media (MediaPreview default; the media-proxy
 // fallback handles Blossom-blocked blobs), kind + timestamp, and any text.
 function ContentCard({ event }: { event: NostrEvent }) {
   return (
@@ -49,11 +56,35 @@ function ContentCard({ event }: { event: NostrEvent }) {
   );
 }
 
+function Note({ children }: { children: ReactNode }) {
+  return <p className="text-xs text-muted-foreground">{children}</p>;
+}
+
+/**
+ * Why the reported event is not on screen. A suspend or ban explains it
+ * definitively, so those are checked before falling back to "not retrievable":
+ * suspension hides the account's events from the relay read and `getbannedevent`
+ * only knows per-event bans, so without this an enforced account reads as
+ * "deleted", which is a different and much more final claim.
+ */
+function reportedMissingReason(accountStatus: AccountStatusResponse | undefined): string {
+  if (accountStatus?.status === "suspended") {
+    return "The reported post is hidden by the account's suspension, so it cannot be shown here.";
+  }
+  if (accountStatus?.status === "banned") {
+    return "The reported post was removed with the account ban.";
+  }
+  return "The reported post is not retrievable from the relay (deleted, aged out, or hidden).";
+}
+
 export function AgeReviewContent({
   postCount,
   contentLoading,
   contentError,
+  contentIncomplete,
   accountStatus,
+  accountStatusLoading,
+  accountStatusFailed,
   recentPosts,
   onRetry,
   reportedEvent,
@@ -62,38 +93,59 @@ export function AgeReviewContent({
   onRetryReported,
   hasReportId,
 }: AgeReviewContentProps) {
-  const vis = deriveContentVisibility({ postCount, contentLoading, contentError, accountStatus });
-  const reportedId = reportedEvent?.event.id;
+  const vis = deriveContentVisibility({
+    postCount,
+    contentLoading,
+    contentError,
+    contentIncomplete,
+    accountStatus,
+    accountStatusLoading,
+    accountStatusFailed,
+  });
+
+  const foundReported = reportedEvent?.status === "found" ? reportedEvent : undefined;
+  const reportedId = foundReported?.event.id;
   const otherPosts = recentPosts.filter((e) => e.id !== reportedId);
+
+  // Built first so the heading is only rendered when something sits under it,
+  // rather than leaving a bare "Reported content" label over empty space.
+  const reportedBody = !hasReportId ? null : foundReported ? (
+    // Keyed so the click-to-reveal state cannot carry over when the pane is
+    // reused for another case (MediaPreview keeps `showMedia` across an event
+    // swap, and revealing media is a deliberate gate here).
+    <ContentCard key={foundReported.event.id} event={foundReported.event} />
+  ) : reportedEventLoading ? (
+    <Note>Loading reported content…</Note>
+  ) : reportedEventError ? (
+    <div className="flex items-center justify-between gap-2 text-xs text-amber-700 dark:text-amber-400">
+      <span>Couldn't load the reported content (relay error).</span>
+      {onRetryReported ? (
+        <Button variant="outline" size="sm" onClick={onRetryReported}>
+          <RefreshCw className="mr-1 h-3 w-3" /> Retry
+        </Button>
+      ) : null}
+    </div>
+  ) : reportedEvent?.status === "account_level" ? (
+    <Note>This report was filed against the account rather than a specific post, so there is no single item to show.</Note>
+  ) : reportedEvent?.status === "report_missing" ? (
+    <Note>The report event is no longer on the relay, so its target cannot be resolved.</Note>
+  ) : reportedEvent?.status === "target_missing" ? (
+    <Note>{reportedMissingReason(accountStatus)}</Note>
+  ) : null;
 
   return (
     <div className="space-y-3">
-      {/* The specific event that triggered the case. */}
-      {reportedEvent ? (
+      {/* The specific content the case was opened about. */}
+      {reportedBody ? (
         <div className="space-y-1.5">
           <h4 className="flex items-center gap-2 text-sm font-medium">
             Reported content
-            {reportedEvent.banned ? (
+            {foundReported?.banned ? (
               <Badge variant="destructive" className="text-xs">removed (banned)</Badge>
             ) : null}
           </h4>
-          <ContentCard event={reportedEvent.event} />
+          {reportedBody}
         </div>
-      ) : reportedEventLoading ? (
-        <p className="text-xs text-muted-foreground">Loading reported content…</p>
-      ) : reportedEventError ? (
-        <div className="flex items-center justify-between gap-2 text-xs text-amber-700 dark:text-amber-400">
-          <span>Couldn't load the reported event (relay error).</span>
-          {onRetryReported ? (
-            <Button variant="outline" size="sm" onClick={onRetryReported}>
-              <RefreshCw className="mr-1 h-3 w-3" /> Retry
-            </Button>
-          ) : null}
-        </div>
-      ) : hasReportId ? (
-        <p className="text-xs text-muted-foreground">
-          The reported event is not on the relay (deleted or aged out).
-        </p>
       ) : null}
 
       {/* The account's other recent content, or a verified reason it isn't visible. */}

--- a/src/components/AgeReviewContent.tsx
+++ b/src/components/AgeReviewContent.tsx
@@ -211,7 +211,7 @@ export function AgeReviewContent({
               {/* Retry for anything the moderator can actually act on: a failed
                   content read, an unknown status, or a claim resting on a status
                   we could not refresh. onRetry refetches both queries. */}
-              {(vis.state === "error" || vis.state === "unknown" || accountStatusFailed) && onRetry ? (
+              {vis.state !== "loading" && (vis.state === "error" || vis.state === "unknown" || accountStatusFailed) && onRetry ? (
                 <Button variant="outline" size="sm" onClick={onRetry}>
                   <RefreshCw className="mr-1 h-3 w-3" /> Retry
                 </Button>

--- a/src/components/AgeReviewContent.tsx
+++ b/src/components/AgeReviewContent.tsx
@@ -22,7 +22,6 @@ interface AgeReviewContentProps {
   // The account read resolved but was truncated, so a zero count proves nothing.
   contentIncomplete?: boolean;
   accountStatus: AccountStatusResponse | undefined;
-  accountStatusFailed?: boolean;
   recentPosts: NostrEvent[];
   onRetry?: () => void;
   // Outcome of resolving what the report targets. Undefined while it has not run.
@@ -69,21 +68,16 @@ function Note({ children }: { children: ReactNode }) {
  * only knows per-event bans, so without this an enforced account reads as
  * "deleted", which is a different and much more final claim.
  */
-function reportedMissingReason(
-  accountStatus: AccountStatusResponse | undefined,
-  accountStatusFailed: boolean | undefined,
-): string {
-  // A status we no longer trust cannot explain anything. TanStack keeps the last
-  // successful data while isError is true, so without this the section could
-  // blame a suspension that has since been lifted. deriveContentVisibility
-  // applies the same gate, so the two halves of the pane agree.
-  if (!accountStatusFailed) {
-    if (accountStatus?.status === "suspended") {
-      return "The reported post is hidden by the account's suspension, so it cannot be shown here.";
-    }
-    if (accountStatus?.status === "banned") {
-      return "The reported post was removed with the account ban.";
-    }
+function reportedMissingReason(accountStatus: AccountStatusResponse | undefined): string {
+  // Data-first, matching deriveContentVisibility and deriveAccountVerdict: all
+  // three read the same status, so all three must reach the same conclusion
+  // about it. A cached success that a later refetch failed to renew is still the
+  // last thing keycast told us.
+  if (accountStatus?.status === "suspended") {
+    return "The reported post is hidden by the account's suspension, so it cannot be shown here.";
+  }
+  if (accountStatus?.status === "banned") {
+    return "The reported post was removed with the account ban.";
   }
   return "The reported post is not retrievable from the relay (deleted, aged out, or hidden).";
 }
@@ -94,7 +88,6 @@ export function AgeReviewContent({
   contentError,
   contentIncomplete,
   accountStatus,
-  accountStatusFailed,
   recentPosts,
   onRetry,
   reportedEvent,
@@ -109,20 +102,42 @@ export function AgeReviewContent({
     contentError,
     contentIncomplete,
     accountStatus,
-    accountStatusFailed,
   });
 
-  const foundReported = reportedEvent?.status === "found" ? reportedEvent : undefined;
-  const reportedId = foundReported?.event.id;
+  // The one resolved event, if any. Both the body and the badge derive from
+  // this, so a "removed (banned)" badge can never appear over a loading or error
+  // message, detached from the attribution warning that belongs with it.
+  // Resolved content also survives a background refetch rather than being
+  // replaced by "Loading…".
+  const shown =
+    reportedEvent?.status === "found" || reportedEvent?.status === "target_foreign"
+      ? reportedEvent
+      : undefined;
+  const reportedId = shown?.status === "found" ? shown.event.id : undefined;
   const otherPosts = recentPosts.filter((e) => e.id !== reportedId);
 
   // Built first so the heading is only rendered when something sits under it,
   // rather than leaving a bare "Reported content" label over empty space.
-  const reportedBody = !hasReportId ? null : foundReported ? (
-    // Keyed so the click-to-reveal state cannot carry over when the pane is
-    // reused for another case (MediaPreview keeps `showMedia` across an event
-    // swap, and revealing media is a deliberate gate here).
-    <ContentCard key={foundReported.event.id} event={foundReported.event} />
+  const reportedBody = !hasReportId ? null : shown ? (
+    shown.status === "target_foreign" ? (
+      // Shown, but never as this account's content. Hiding it would lose evidence
+      // (a report about a repost legitimately names the original), so the warning
+      // carries the attribution instead. Stated as a fact about the tag rather
+      // than an accusation: a client quirk is likelier than bad faith.
+      <div className="space-y-1.5">
+        <div className="rounded-md border border-amber-500/40 p-2.5 text-xs text-amber-700 dark:text-amber-400">
+          This post was authored by{" "}
+          <span className="font-mono">{shown.event.pubkey.slice(0, 12)}…</span>, not by this case's
+          subject. Do not judge this account by it without confirming the connection.
+        </div>
+        <ContentCard key={shown.event.id} event={shown.event} />
+      </div>
+    ) : (
+      // Keyed so the click-to-reveal state cannot carry over when the pane is
+      // reused for another case (MediaPreview keeps `showMedia` across an event
+      // swap, and revealing media is a deliberate gate here).
+      <ContentCard key={shown.event.id} event={shown.event} />
+    )
   ) : reportedEventLoading ? (
     <Note>Loading reported content…</Note>
   ) : reportedEventError ? (
@@ -142,21 +157,8 @@ export function AgeReviewContent({
     <Note>The linked event is not a report, so what it refers to cannot be determined.</Note>
   ) : reportedEvent?.status === "target_unreadable" ? (
     <Note>This report names a target we cannot read, so the reported post cannot be resolved.</Note>
-  ) : reportedEvent?.status === "target_foreign" ? (
-    // Shown, but never as this account's content. Hiding it would lose evidence
-    // (a report about a repost legitimately names the original), so the warning
-    // carries the attribution instead. Stated as a fact about the tag rather
-    // than an accusation: a client quirk is likelier than bad faith.
-    <div className="space-y-1.5">
-      <div className="rounded-md border border-amber-500/40 p-2.5 text-xs text-amber-700 dark:text-amber-400">
-        This post was authored by{" "}
-        <span className="font-mono">{reportedEvent.authorPubkey.slice(0, 12)}…</span>, not by this
-        case's subject. Do not judge this account by it without confirming the connection.
-      </div>
-      <ContentCard key={reportedEvent.event.id} event={reportedEvent.event} />
-    </div>
   ) : reportedEvent?.status === "target_missing" ? (
-    <Note>{reportedMissingReason(accountStatus, accountStatusFailed)}</Note>
+    <Note>{reportedMissingReason(accountStatus)}</Note>
   ) : null;
 
   return (
@@ -166,11 +168,9 @@ export function AgeReviewContent({
         <div className="space-y-1.5">
           <h4 className="flex items-center gap-2 text-sm font-medium">
             Reported content
-            {reportedEvent?.status === "found" || reportedEvent?.status === "target_foreign"
-              ? reportedEvent.banned && (
-                  <Badge variant="destructive" className="text-xs">removed (banned)</Badge>
-                )
-              : null}
+            {shown?.banned ? (
+              <Badge variant="destructive" className="text-xs">removed (banned)</Badge>
+            ) : null}
           </h4>
           {reportedBody}
         </div>

--- a/src/components/AgeReviewContent.tsx
+++ b/src/components/AgeReviewContent.tsx
@@ -75,8 +75,8 @@ function reportedMissingReason(
 ): string {
   // A status we no longer trust cannot explain anything. TanStack keeps the last
   // successful data while isError is true, so without this the section could
-  // blame a suspension that has since been lifted, while the card directly below
-  // correctly says the status is unavailable.
+  // blame a suspension that has since been lifted. deriveContentVisibility
+  // applies the same gate, so the two halves of the pane agree.
   if (!accountStatusFailed) {
     if (accountStatus?.status === "suspended") {
       return "The reported post is hidden by the account's suspension, so it cannot be shown here.";
@@ -143,13 +143,17 @@ export function AgeReviewContent({
   ) : reportedEvent?.status === "target_unreadable" ? (
     <Note>This report names a target we cannot read, so the reported post cannot be resolved.</Note>
   ) : reportedEvent?.status === "target_foreign" ? (
-    // Deliberately not rendered: judging this account by another account's post
-    // is how the wrong person gets enforced against. Stated as a fact about the
-    // tag, not an accusation, since a client quirk is likelier than bad faith.
-    <div className="rounded-md border border-amber-500/40 p-2.5 text-xs text-amber-700 dark:text-amber-400">
-      This report points at an event authored by a different account
-      (<span className="font-mono">{reportedEvent.authorPubkey.slice(0, 12)}…</span>),
-      not by this case's subject, so it is not shown here as this account's content.
+    // Shown, but never as this account's content. Hiding it would lose evidence
+    // (a report about a repost legitimately names the original), so the warning
+    // carries the attribution instead. Stated as a fact about the tag rather
+    // than an accusation: a client quirk is likelier than bad faith.
+    <div className="space-y-1.5">
+      <div className="rounded-md border border-amber-500/40 p-2.5 text-xs text-amber-700 dark:text-amber-400">
+        This post was authored by{" "}
+        <span className="font-mono">{reportedEvent.authorPubkey.slice(0, 12)}…</span>, not by this
+        case's subject. Do not judge this account by it without confirming the connection.
+      </div>
+      <ContentCard key={reportedEvent.event.id} event={reportedEvent.event} />
     </div>
   ) : reportedEvent?.status === "target_missing" ? (
     <Note>{reportedMissingReason(accountStatus, accountStatusFailed)}</Note>
@@ -162,9 +166,11 @@ export function AgeReviewContent({
         <div className="space-y-1.5">
           <h4 className="flex items-center gap-2 text-sm font-medium">
             Reported content
-            {foundReported?.banned ? (
-              <Badge variant="destructive" className="text-xs">removed (banned)</Badge>
-            ) : null}
+            {reportedEvent?.status === "found" || reportedEvent?.status === "target_foreign"
+              ? reportedEvent.banned && (
+                  <Badge variant="destructive" className="text-xs">removed (banned)</Badge>
+                )
+              : null}
           </h4>
           {reportedBody}
         </div>

--- a/src/components/AgeReviewContent.tsx
+++ b/src/components/AgeReviewContent.tsx
@@ -22,7 +22,6 @@ interface AgeReviewContentProps {
   // The account read resolved but was truncated, so a zero count proves nothing.
   contentIncomplete?: boolean;
   accountStatus: AccountStatusResponse | undefined;
-  accountStatusLoading?: boolean;
   accountStatusFailed?: boolean;
   recentPosts: NostrEvent[];
   onRetry?: () => void;
@@ -39,7 +38,7 @@ interface AgeReviewContentProps {
 }
 
 // One content item: click-to-reveal media (MediaPreview default; the media-proxy
-// fallback handles Blossom-blocked blobs), kind + timestamp, and any text.
+// fallback handles Blossom-blocked blobs), kind + timestamp, author, and any text.
 function ContentCard({ event }: { event: NostrEvent }) {
   return (
     <div className="rounded-md border p-2.5 space-y-1.5">
@@ -47,6 +46,9 @@ function ContentCard({ event }: { event: NostrEvent }) {
         <span>{getKindName(event.kind)}</span>
         <span>·</span>
         <span>{new Date(event.created_at * 1000).toLocaleString()}</span>
+        <span>·</span>
+        {/* Author is shown so content can never be attributed by position alone. */}
+        <span className="font-mono">{event.pubkey.slice(0, 12)}…</span>
       </div>
       <MediaPreview event={event} maxItems={4} />
       {event.content ? (
@@ -83,7 +85,6 @@ export function AgeReviewContent({
   contentError,
   contentIncomplete,
   accountStatus,
-  accountStatusLoading,
   accountStatusFailed,
   recentPosts,
   onRetry,
@@ -99,7 +100,6 @@ export function AgeReviewContent({
     contentError,
     contentIncomplete,
     accountStatus,
-    accountStatusLoading,
     accountStatusFailed,
   });
 
@@ -129,6 +129,14 @@ export function AgeReviewContent({
     <Note>This report was filed against the account rather than a specific post, so there is no single item to show.</Note>
   ) : reportedEvent?.status === "report_missing" ? (
     <Note>The report event is no longer on the relay, so its target cannot be resolved.</Note>
+  ) : reportedEvent?.status === "target_foreign" ? (
+    // Deliberately not rendered: judging this account by another account's post
+    // is how the wrong person gets enforced against.
+    <div className="rounded-md border border-amber-500/40 p-2.5 text-xs text-amber-700 dark:text-amber-400">
+      This report points at an event authored by a different account
+      (<span className="font-mono">{reportedEvent.authorPubkey.slice(0, 12)}…</span>),
+      not by this case's subject, so it is not shown here. Treat the report itself as suspect.
+    </div>
   ) : reportedEvent?.status === "target_missing" ? (
     <Note>{reportedMissingReason(accountStatus)}</Note>
   ) : null;
@@ -169,7 +177,9 @@ export function AgeReviewContent({
           >
             <div className="flex items-center justify-between gap-2">
               <span>{vis.message}</span>
-              {vis.state === "error" && onRetry ? (
+              {/* `unknown` gets a retry too: it is reached when the account-status
+                  read failed, and refetching content alone can never clear it. */}
+              {(vis.state === "error" || vis.state === "unknown") && onRetry ? (
                 <Button variant="outline" size="sm" onClick={onRetry}>
                   <RefreshCw className="mr-1 h-3 w-3" /> Retry
                 </Button>

--- a/src/components/AgeReviewContent.tsx
+++ b/src/components/AgeReviewContent.tsx
@@ -22,6 +22,9 @@ interface AgeReviewContentProps {
   // The account read resolved but was truncated, so a zero count proves nothing.
   contentIncomplete?: boolean;
   accountStatus: AccountStatusResponse | undefined;
+  // Status refetch failed with cached data retained: marks the claim as possibly
+  // stale and offers a retry, without changing what the claim is.
+  accountStatusFailed?: boolean;
   recentPosts: NostrEvent[];
   onRetry?: () => void;
   // Outcome of resolving what the report targets. Undefined while it has not run.
@@ -68,16 +71,22 @@ function Note({ children }: { children: ReactNode }) {
  * only knows per-event bans, so without this an enforced account reads as
  * "deleted", which is a different and much more final claim.
  */
-function reportedMissingReason(accountStatus: AccountStatusResponse | undefined): string {
+function reportedMissingReason(
+  accountStatus: AccountStatusResponse | undefined,
+  accountStatusFailed: boolean | undefined,
+): string {
+  const stale = accountStatusFailed
+    ? " Status could not be refreshed just now, so this is the last answer keycast gave."
+    : "";
   // Data-first, matching deriveContentVisibility and deriveAccountVerdict: all
   // three read the same status, so all three must reach the same conclusion
   // about it. A cached success that a later refetch failed to renew is still the
   // last thing keycast told us.
   if (accountStatus?.status === "suspended") {
-    return "The reported post is hidden by the account's suspension, so it cannot be shown here.";
+    return `The reported post is hidden by the account's suspension, so it cannot be shown here.${stale}`;
   }
   if (accountStatus?.status === "banned") {
-    return "The reported post was removed with the account ban.";
+    return `The reported post was removed with the account ban.${stale}`;
   }
   return "The reported post is not retrievable from the relay (deleted, aged out, or hidden).";
 }
@@ -88,6 +97,7 @@ export function AgeReviewContent({
   contentError,
   contentIncomplete,
   accountStatus,
+  accountStatusFailed,
   recentPosts,
   onRetry,
   reportedEvent,
@@ -102,6 +112,7 @@ export function AgeReviewContent({
     contentError,
     contentIncomplete,
     accountStatus,
+    accountStatusFailed,
   });
 
   // The one resolved event, if any. Both the body and the badge derive from
@@ -158,7 +169,7 @@ export function AgeReviewContent({
   ) : reportedEvent?.status === "target_unreadable" ? (
     <Note>This report names a target we cannot read, so the reported post cannot be resolved.</Note>
   ) : reportedEvent?.status === "target_missing" ? (
-    <Note>{reportedMissingReason(accountStatus)}</Note>
+    <Note>{reportedMissingReason(accountStatus, accountStatusFailed)}</Note>
   ) : null;
 
   return (
@@ -197,9 +208,10 @@ export function AgeReviewContent({
           >
             <div className="flex items-center justify-between gap-2">
               <span>{vis.message}</span>
-              {/* `unknown` gets a retry too: it is reached when the account-status
-                  read failed, and refetching content alone can never clear it. */}
-              {(vis.state === "error" || vis.state === "unknown") && onRetry ? (
+              {/* Retry for anything the moderator can actually act on: a failed
+                  content read, an unknown status, or a claim resting on a status
+                  we could not refresh. onRetry refetches both queries. */}
+              {(vis.state === "error" || vis.state === "unknown" || accountStatusFailed) && onRetry ? (
                 <Button variant="outline" size="sm" onClick={onRetry}>
                   <RefreshCw className="mr-1 h-3 w-3" /> Retry
                 </Button>

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -12,11 +12,11 @@ import { ApiError } from '@/lib/adminApi';
 // AgeReviewContent reads the reported event via useReportedEvent (which needs a
 // NostrProvider). This unit test isolates the case-action logic, so stub it.
 vi.mock('@/hooks/useReportedEvent', () => ({
-  useReportedEvent: () => ({ data: null, isLoading: false }),
+  useReportedEvent: () => ({ data: undefined, isFetching: false, isError: false, refetch: () => Promise.resolve() }),
 }));
 vi.mock('@/hooks/useUserStats', () => ({
   useUserStats: () => ({
-    data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [] },
+    data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [], relayIncomplete: false },
     isError: false,
   }),
 }));

--- a/src/components/AgeReviewDetail.test.tsx
+++ b/src/components/AgeReviewDetail.test.tsx
@@ -9,6 +9,11 @@ import { ApiError } from '@/lib/adminApi';
 // NostrProvider). This unit test isolates the case-action logic, so stub it with
 // a resolved, empty read (not in-flight) so the indicator's content-presence
 // note doesn't bleed into unrelated assertions.
+// AgeReviewContent reads the reported event via useReportedEvent (which needs a
+// NostrProvider). This unit test isolates the case-action logic, so stub it.
+vi.mock('@/hooks/useReportedEvent', () => ({
+  useReportedEvent: () => ({ data: null, isLoading: false }),
+}));
 vi.mock('@/hooks/useUserStats', () => ({
   useUserStats: () => ({
     data: { postCount: 0, reportCount: 0, labelCount: 0, recentPosts: [], existingLabels: [], previousReports: [] },

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -305,6 +305,7 @@ export function AgeReviewDetail({ caseData: c }: Props) {
             contentError={userStatsFailed}
             contentIncomplete={userStats?.relayIncomplete}
             accountStatus={accountStatus}
+            accountStatusFailed={accountStatusFailed}
             recentPosts={userStats?.recentPosts ?? []}
             onRetry={() => { void refetchUserStats(); void refetchAccountStatus(); }}
             reportedEvent={reportedEvent}

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -661,7 +661,11 @@ export function AgeReviewDetail({ caseData: c }: Props) {
           <div className="border-t pt-4 mt-4">
             <p className="text-xs text-muted-foreground mb-2">Auto-delete is disabled. You can manually delete content:</p>
             <UserActions
-              pubkey={c.pubkey}
+              // Normalized, like the reads above: the worker forwards this
+              // verbatim to the relay, which keys on lowercase hex, so a
+              // mixed-case `p` tag would enforce against nothing while
+              // reporting success.
+              pubkey={subjectPubkey}
               context="age-review"
               onActionComplete={() => queryClient.invalidateQueries({ queryKey: ['age-review-cases'] })}
             />

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -4,6 +4,8 @@ import { useAdminApi } from "@/hooks/useAdminApi";
 import { useAccountStatus } from "@/hooks/useAccountStatus";
 import { useUserStats } from "@/hooks/useUserStats";
 import { AccountTypeIndicator } from "@/components/AccountTypeIndicator";
+import { AgeReviewContent } from "@/components/AgeReviewContent";
+import { useReportedEvent } from "@/hooks/useReportedEvent";
 import { ApiError } from "@/lib/adminApi";
 import { reconcileCaseIntoList, type AgeReviewListParams } from "@/lib/ageReviewCache";
 import { deriveAccountVerdict } from "@/lib/accountVerdict";
@@ -217,7 +219,8 @@ export function AgeReviewDetail({ caseData: c }: Props) {
   // Keycast-backed protected-minor status (verified_minor). Best-effort: a
   // keycast blip resolves to success:false, so we show status unavailable.
   const { data: accountStatus, isError: accountStatusFailed, isLoading: accountStatusLoading } = useAccountStatus(c.pubkey);
-  const { data: userStats, isError: userStatsFailed } = useUserStats(c.pubkey);
+  const { data: userStats, isError: userStatsFailed, isLoading: userStatsLoading, refetch: refetchUserStats } = useUserStats(c.pubkey);
+  const { data: reportedEvent, isLoading: reportedEventLoading, isError: reportedEventFailed, refetch: refetchReported } = useReportedEvent(c.report_id ?? undefined);
   // Content presence is trustworthy only once the relay read resolves without
   // error; a failed/in-flight read must not read as "no content" (would
   // under-state available enforcement).
@@ -283,6 +286,20 @@ export function AgeReviewDetail({ caseData: c }: Props) {
             postCount={userStats?.postCount}
             contentPresenceKnown={contentPresenceKnown}
             ticketLinked={!!c.zendesk_ticket_id}
+          />
+
+          <AgeReviewContent
+            postCount={userStats?.postCount}
+            contentLoading={userStatsLoading}
+            contentError={userStatsFailed}
+            accountStatus={accountStatus}
+            recentPosts={userStats?.recentPosts ?? []}
+            onRetry={() => { void refetchUserStats(); }}
+            reportedEvent={reportedEvent}
+            reportedEventLoading={reportedEventLoading}
+            reportedEventError={reportedEventFailed}
+            onRetryReported={() => { void refetchReported(); }}
+            hasReportId={!!c.report_id}
           />
 
           {/* Protections that apply to an approved protected minor (#143).

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -219,8 +219,11 @@ export function AgeReviewDetail({ caseData: c }: Props) {
   // Keycast-backed protected-minor status (verified_minor). Best-effort: a
   // keycast blip resolves to success:false, so we show status unavailable.
   const { data: accountStatus, isError: accountStatusFailed, isLoading: accountStatusLoading } = useAccountStatus(c.pubkey);
-  const { data: userStats, isError: userStatsFailed, isLoading: userStatsLoading, refetch: refetchUserStats } = useUserStats(c.pubkey);
-  const { data: reportedEvent, isLoading: reportedEventLoading, isError: reportedEventFailed, refetch: refetchReported } = useReportedEvent(c.report_id ?? undefined);
+  const { data: userStats, isError: userStatsFailed, isFetching: userStatsFetching, refetch: refetchUserStats } = useUserStats(c.pubkey);
+  // isFetching, not isLoading: isLoading stays false while an errored query
+  // refetches, so a Retry click would leave the error copy on screen with no
+  // sign anything happened.
+  const { data: reportedEvent, isFetching: reportedEventFetching, isError: reportedEventFailed, refetch: refetchReported } = useReportedEvent(c.report_id ?? undefined);
   // Content presence is trustworthy only once the relay read resolves without
   // error; a failed/in-flight read must not read as "no content" (would
   // under-state available enforcement).
@@ -290,13 +293,16 @@ export function AgeReviewDetail({ caseData: c }: Props) {
 
           <AgeReviewContent
             postCount={userStats?.postCount}
-            contentLoading={userStatsLoading}
+            contentLoading={userStatsFetching}
             contentError={userStatsFailed}
+            contentIncomplete={userStats?.relayIncomplete}
             accountStatus={accountStatus}
+            accountStatusLoading={accountStatusLoading}
+            accountStatusFailed={accountStatusFailed}
             recentPosts={userStats?.recentPosts ?? []}
             onRetry={() => { void refetchUserStats(); }}
             reportedEvent={reportedEvent}
-            reportedEventLoading={reportedEventLoading}
+            reportedEventLoading={reportedEventFetching}
             reportedEventError={reportedEventFailed}
             onRetryReported={() => { void refetchReported(); }}
             hasReportId={!!c.report_id}

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -235,7 +235,10 @@ export function AgeReviewDetail({ caseData: c }: Props) {
   // A truncated relay read leaves userStats defined with isError false and a
   // zero count, which would read as "this account has no content" and render the
   // content-enforcement legs as n/a, under-stating what a moderator can do.
-  const contentPresenceKnown = userStats !== undefined && !userStatsFailed && !userStats.relayIncomplete;
+  const contentPresenceKnown =
+    userStats !== undefined &&
+    !userStatsFailed &&
+    !userStats.authoredContentIncomplete;
   const accountVerdict = deriveAccountVerdict({
     accountStatus,
     accountStatusError: accountStatusFailed,
@@ -303,7 +306,7 @@ export function AgeReviewDetail({ caseData: c }: Props) {
             postCount={userStats?.postCount}
             contentLoading={userStatsFetching}
             contentError={userStatsFailed}
-            contentIncomplete={userStats?.relayIncomplete}
+            contentIncomplete={userStats?.authoredContentIncomplete}
             accountStatus={accountStatus}
             accountStatusFailed={accountStatusFailed}
             recentPosts={userStats?.recentPosts ?? []}

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -218,12 +218,17 @@ export function AgeReviewDetail({ caseData: c }: Props) {
 
   // Keycast-backed protected-minor status (verified_minor). Best-effort: a
   // keycast blip resolves to success:false, so we show status unavailable.
-  const { data: accountStatus, isError: accountStatusFailed, isLoading: accountStatusLoading, refetch: refetchAccountStatus } = useAccountStatus(c.pubkey);
-  const { data: userStats, isError: userStatsFailed, isFetching: userStatsFetching, refetch: refetchUserStats } = useUserStats(c.pubkey);
+  // Normalized once here: the case pubkey is stored verbatim from the report's
+  // `p` tag, which is untrusted, while relays and the worker both require
+  // lowercase hex. Passing it raw makes a mixed-case tag look like an account
+  // with no content and no available enforcement.
+  const subjectPubkey = c.pubkey.toLowerCase();
+  const { data: accountStatus, isError: accountStatusFailed, isLoading: accountStatusLoading, refetch: refetchAccountStatus } = useAccountStatus(subjectPubkey);
+  const { data: userStats, isError: userStatsFailed, isFetching: userStatsFetching, refetch: refetchUserStats } = useUserStats(subjectPubkey);
   // isFetching, not isLoading: isLoading stays false while an errored query
   // refetches, so a Retry click would leave the error copy on screen with no
   // sign anything happened.
-  const { data: reportedEvent, isFetching: reportedEventFetching, isError: reportedEventFailed, refetch: refetchReported } = useReportedEvent(c.report_id ?? undefined, c.pubkey);
+  const { data: reportedEvent, isFetching: reportedEventFetching, isError: reportedEventFailed, refetch: refetchReported } = useReportedEvent(c.report_id ?? undefined, subjectPubkey);
   // Content presence is trustworthy only once the relay read resolves without
   // error; a failed/in-flight read must not read as "no content" (would
   // under-state available enforcement).
@@ -300,7 +305,6 @@ export function AgeReviewDetail({ caseData: c }: Props) {
             contentError={userStatsFailed}
             contentIncomplete={userStats?.relayIncomplete}
             accountStatus={accountStatus}
-            accountStatusFailed={accountStatusFailed}
             recentPosts={userStats?.recentPosts ?? []}
             onRetry={() => { void refetchUserStats(); void refetchAccountStatus(); }}
             reportedEvent={reportedEvent}

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -218,16 +218,19 @@ export function AgeReviewDetail({ caseData: c }: Props) {
 
   // Keycast-backed protected-minor status (verified_minor). Best-effort: a
   // keycast blip resolves to success:false, so we show status unavailable.
-  const { data: accountStatus, isError: accountStatusFailed, isLoading: accountStatusLoading } = useAccountStatus(c.pubkey);
+  const { data: accountStatus, isError: accountStatusFailed, isLoading: accountStatusLoading, refetch: refetchAccountStatus } = useAccountStatus(c.pubkey);
   const { data: userStats, isError: userStatsFailed, isFetching: userStatsFetching, refetch: refetchUserStats } = useUserStats(c.pubkey);
   // isFetching, not isLoading: isLoading stays false while an errored query
   // refetches, so a Retry click would leave the error copy on screen with no
   // sign anything happened.
-  const { data: reportedEvent, isFetching: reportedEventFetching, isError: reportedEventFailed, refetch: refetchReported } = useReportedEvent(c.report_id ?? undefined);
+  const { data: reportedEvent, isFetching: reportedEventFetching, isError: reportedEventFailed, refetch: refetchReported } = useReportedEvent(c.report_id ?? undefined, c.pubkey);
   // Content presence is trustworthy only once the relay read resolves without
   // error; a failed/in-flight read must not read as "no content" (would
   // under-state available enforcement).
-  const contentPresenceKnown = userStats !== undefined && !userStatsFailed;
+  // A truncated relay read leaves userStats defined with isError false and a
+  // zero count, which would read as "this account has no content" and render the
+  // content-enforcement legs as n/a, under-stating what a moderator can do.
+  const contentPresenceKnown = userStats !== undefined && !userStatsFailed && !userStats.relayIncomplete;
   const accountVerdict = deriveAccountVerdict({
     accountStatus,
     accountStatusError: accountStatusFailed,
@@ -284,8 +287,8 @@ export function AgeReviewDetail({ caseData: c }: Props) {
 
           <AccountTypeIndicator
             accountStatus={accountStatus}
-            accountStatusError={accountStatusFailed}
             accountStatusLoading={accountStatusLoading}
+            accountStatusError={accountStatusFailed}
             postCount={userStats?.postCount}
             contentPresenceKnown={contentPresenceKnown}
             ticketLinked={!!c.zendesk_ticket_id}
@@ -297,10 +300,9 @@ export function AgeReviewDetail({ caseData: c }: Props) {
             contentError={userStatsFailed}
             contentIncomplete={userStats?.relayIncomplete}
             accountStatus={accountStatus}
-            accountStatusLoading={accountStatusLoading}
             accountStatusFailed={accountStatusFailed}
             recentPosts={userStats?.recentPosts ?? []}
-            onRetry={() => { void refetchUserStats(); }}
+            onRetry={() => { void refetchUserStats(); void refetchAccountStatus(); }}
             reportedEvent={reportedEvent}
             reportedEventLoading={reportedEventFetching}
             reportedEventError={reportedEventFailed}

--- a/src/components/AgeReviewDetail.wiring.test.tsx
+++ b/src/components/AgeReviewDetail.wiring.test.tsx
@@ -18,7 +18,7 @@ const reportedEvent = vi.fn();
 
 vi.mock('@/hooks/useUserStats', () => ({ useUserStats: () => userStats() }));
 vi.mock('@/hooks/useAccountStatus', () => ({ useAccountStatus: () => accountStatus() }));
-vi.mock('@/hooks/useReportedEvent', () => ({ useReportedEvent: () => reportedEvent() }));
+vi.mock('@/hooks/useReportedEvent', () => ({ useReportedEvent: (...args: unknown[]) => reportedEvent(...args) }));
 vi.mock('@/components/MediaPreview', () => ({ MediaPreview: () => <div data-testid="media-preview" /> }));
 vi.mock('@/hooks/useAuthor', () => ({ useAuthor: () => ({ data: undefined, isLoading: false }) }));
 vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
@@ -127,6 +127,14 @@ describe('AgeReviewDetail feeds the content derivations', () => {
     reportedEvent.mockReturnValue({ data: undefined, isFetching: true, isError: false, refetch: vi.fn() });
     show();
     await waitFor(() => expect(screen.getByText(/loading reported content/i)).toBeInTheDocument());
+  });
+
+  it('passes the case subject to the lookup, so the author check can run at all', async () => {
+    // The guard is `if (casePubkey && ...)`, so dropping this argument silently
+    // disables author verification with no type error and no visible change.
+    show();
+    await waitFor(() => expect(reportedEvent).toHaveBeenCalled());
+    expect(reportedEvent).toHaveBeenCalledWith('report-1', PUBKEY);
   });
 
   it('surfaces a foreign-authored reported event rather than rendering it', async () => {

--- a/src/components/AgeReviewDetail.wiring.test.tsx
+++ b/src/components/AgeReviewDetail.wiring.test.tsx
@@ -22,6 +22,11 @@ vi.mock('@/hooks/useReportedEvent', () => ({ useReportedEvent: (...args: unknown
 vi.mock('@/components/MediaPreview', () => ({ MediaPreview: () => <div data-testid="media-preview" /> }));
 vi.mock('@/hooks/useAuthor', () => ({ useAuthor: () => ({ data: undefined, isLoading: false }) }));
 vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+// Exposes the pubkey the enforcement path would act on, which is the one value
+// in this component that is written rather than read.
+vi.mock('@/components/UserActions', () => ({
+  UserActions: ({ pubkey }: { pubkey: string }) => <div data-testid="user-actions">{pubkey}</div>,
+}));
 vi.mock('@/hooks/useAdminApi', () => ({
   useApiUrl: () => 'https://api.test',
   useAdminApi: () => ({
@@ -31,12 +36,16 @@ vi.mock('@/hooks/useAdminApi', () => ({
   }),
 }));
 
-const PUBKEY = 'a'.repeat(64);
+// Deliberately mixed case: the case pubkey is stored verbatim from an untrusted
+// `p` tag, and every consumer (relay filters, the worker, the management API)
+// requires lowercase. A lowercase fixture cannot observe the normalization.
+const RAW_PUBKEY = 'AbCd'.repeat(16);
+const PUBKEY = RAW_PUBKEY.toLowerCase();
 
-function makeCase(): AgeReviewCase {
+function makeCase(over: Partial<AgeReviewCase> = {}): AgeReviewCase {
   return {
     id: 'case-1',
-    pubkey: PUBKEY,
+    pubkey: RAW_PUBKEY,
     reporter_pubkey: 'b'.repeat(64),
     report_id: 'report-1',
     suspected_age_band: 'age_13_15',
@@ -52,6 +61,7 @@ function makeCase(): AgeReviewCase {
     last_alerted_at: null,
     zendesk_ticket_id: null,
     created_via: null,
+    ...over,
   } as AgeReviewCase;
 }
 
@@ -145,6 +155,34 @@ describe('AgeReviewDetail feeds the content derivations', () => {
     show();
     await waitFor(() => expect(reportedEvent).toHaveBeenCalled());
     expect(reportedEvent).toHaveBeenCalledWith('report-1', PUBKEY);
+  });
+
+  it('normalizes the case pubkey before handing it to the lookups', async () => {
+    show();
+    await waitFor(() => expect(reportedEvent).toHaveBeenCalled());
+    expect(reportedEvent).toHaveBeenCalledWith('report-1', PUBKEY);
+  });
+
+  it('marks a claim resting on an unrefreshed status, and offers a retry', async () => {
+    // Cached status with a failed refetch. The state stays data-first so this
+    // and the panel above agree, but the moderator must be able to see that the
+    // answer is not current, and to re-ask.
+    accountStatus.mockReturnValue({
+      data: { success: true, status: 'active' }, isError: true, isLoading: false, refetch: vi.fn(),
+    });
+    show();
+    await waitFor(() => expect(screen.getByText(/could not be refreshed/i)).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it('enforces against the normalized pubkey, not the raw one from the report', async () => {
+    // The reads and the writes must target the same account. The worker forwards
+    // this value verbatim to the relay, which keys on lowercase hex, so a raw
+    // mixed-case pubkey would report success while enforcing nothing.
+    render(<AgeReviewDetail caseData={makeCase({ state: 'denied_closed' })} />, { wrapper });
+    await waitFor(() => expect(screen.getByTestId('user-actions')).toBeInTheDocument());
+    expect(screen.getByTestId('user-actions')).toHaveTextContent(PUBKEY);
+    expect(screen.getByTestId('user-actions')).not.toHaveTextContent(RAW_PUBKEY);
   });
 
   it('labels a foreign-authored reported event instead of attributing it', async () => {

--- a/src/components/AgeReviewDetail.wiring.test.tsx
+++ b/src/components/AgeReviewDetail.wiring.test.tsx
@@ -86,12 +86,22 @@ describe('AgeReviewDetail feeds the content derivations', () => {
     expect(screen.queryByText(/no content found/i)).not.toBeInTheDocument();
   });
 
-  it('passes account-status failure through, so suspension is not ruled out unchecked', async () => {
-    // Stale successful data retained alongside isError: only the failed flag can
-    // reveal that this answer is no longer trustworthy.
-    accountStatus.mockReturnValue({ data: { success: true, status: 'active' }, isError: true, isLoading: false, refetch: vi.fn() });
+  it('does not rule out suspension when keycast could not answer', async () => {
+    accountStatus.mockReturnValue({ data: { success: false }, isError: true, isLoading: false, refetch: vi.fn() });
     show();
     await waitFor(() => expect(screen.getByText(/suspension cannot be ruled out/i)).toBeInTheDocument());
+  });
+
+  it('does not let the account panel and the content card contradict each other', async () => {
+    // Both read the same status. A stale suspended value retained after a failed
+    // refetch must not make one assert the suspension while the other says it
+    // cannot be ruled out, 20px apart on the same screen.
+    accountStatus.mockReturnValue({
+      data: { success: true, status: 'suspended' }, isError: true, isLoading: false, refetch: vi.fn(),
+    });
+    const { container } = show();
+    await waitFor(() => expect(screen.getByText(/hidden by suspension/i)).toBeInTheDocument());
+    expect(container.textContent).not.toMatch(/cannot be ruled out/i);
   });
 
   it('does not claim absence before account status has arrived', async () => {
@@ -143,7 +153,7 @@ describe('AgeReviewDetail feeds the content derivations', () => {
       tags: [], content: 'clip', sig: '',
     };
     reportedEvent.mockReturnValue({
-      data: { status: 'target_foreign', event: foreign, authorPubkey: 'e'.repeat(64), banned: false },
+      data: { status: 'target_foreign', event: foreign, banned: false },
       isFetching: false, isError: false, refetch: vi.fn(),
     });
     show();

--- a/src/components/AgeReviewDetail.wiring.test.tsx
+++ b/src/components/AgeReviewDetail.wiring.test.tsx
@@ -137,13 +137,18 @@ describe('AgeReviewDetail feeds the content derivations', () => {
     expect(reportedEvent).toHaveBeenCalledWith('report-1', PUBKEY);
   });
 
-  it('surfaces a foreign-authored reported event rather than rendering it', async () => {
+  it('labels a foreign-authored reported event instead of attributing it', async () => {
+    const foreign = {
+      id: 'c'.repeat(64), pubkey: 'e'.repeat(64), created_at: 1, kind: 34235,
+      tags: [], content: 'clip', sig: '',
+    };
     reportedEvent.mockReturnValue({
-      data: { status: 'target_foreign', targetEventId: 'c'.repeat(64), authorPubkey: 'e'.repeat(64) },
+      data: { status: 'target_foreign', event: foreign, authorPubkey: 'e'.repeat(64), banned: false },
       isFetching: false, isError: false, refetch: vi.fn(),
     });
     show();
-    await waitFor(() => expect(screen.getByText(/authored by a different account/i)).toBeInTheDocument());
-    expect(screen.queryByTestId('media-preview')).not.toBeInTheDocument();
+    // Evidence is shown, but the attribution warning must come with it.
+    await waitFor(() => expect(screen.getByText(/not by this case's subject/i)).toBeInTheDocument());
+    expect(screen.getByTestId('media-preview')).toBeInTheDocument();
   });
 });

--- a/src/components/AgeReviewDetail.wiring.test.tsx
+++ b/src/components/AgeReviewDetail.wiring.test.tsx
@@ -69,7 +69,11 @@ const emptyStats = (over: Record<string, unknown> = {}) => ({
   data: {
     postCount: 0, reportCount: 0, labelCount: 0,
     recentPosts: [], existingLabels: [], previousReports: [],
-    relayIncomplete: false, ...over,
+    relayIncomplete: false,
+    authoredContentIncomplete: false,
+    labelsIncomplete: false,
+    reportsIncomplete: false,
+    ...over,
   },
   isError: false, isFetching: false, refetch: vi.fn(),
 });
@@ -89,11 +93,26 @@ beforeEach(() => {
 const show = () => render(<AgeReviewDetail caseData={makeCase()} />, { wrapper });
 
 describe('AgeReviewDetail feeds the content derivations', () => {
-  it('passes relayIncomplete through, so a truncated read is not shown as absence', async () => {
-    userStats.mockReturnValue(emptyStats({ relayIncomplete: true }));
+  it('passes authoredContentIncomplete through, so a truncated content read is not shown as absence', async () => {
+    userStats.mockReturnValue(emptyStats({
+      relayIncomplete: true,
+      authoredContentIncomplete: true,
+    }));
     show();
     await waitFor(() => expect(screen.getByText(/couldn't load/i)).toBeInTheDocument());
     expect(screen.queryByText(/no content found/i)).not.toBeInTheDocument();
+  });
+
+  it('does not treat an ancillary stats failure as an authored-content failure', async () => {
+    userStats.mockReturnValue(emptyStats({
+      relayIncomplete: true,
+      authoredContentIncomplete: false,
+      labelsIncomplete: true,
+    }));
+    const { container } = show();
+    await waitFor(() => expect(screen.getByText(/no content found/i)).toBeInTheDocument());
+    expect(screen.queryByText(/couldn't load this account's content/i)).not.toBeInTheDocument();
+    expect(container.textContent).toMatch(/n\/a/i);
   });
 
   it('does not rule out suspension when keycast could not answer', async () => {
@@ -123,7 +142,10 @@ describe('AgeReviewDetail feeds the content derivations', () => {
   it('keeps content enforcement available when the relay read was truncated', async () => {
     // A zero count from an unfinished read must not mark the content levers n/a:
     // that tells a moderator an action is unavailable when it may well apply.
-    userStats.mockReturnValue(emptyStats({ relayIncomplete: true }));
+    userStats.mockReturnValue(emptyStats({
+      relayIncomplete: true,
+      authoredContentIncomplete: true,
+    }));
     const { container } = show();
     await waitFor(() => expect(screen.getByText(/couldn't load/i)).toBeInTheDocument());
     expect(container.textContent).not.toMatch(/n\/a/i);

--- a/src/components/AgeReviewDetail.wiring.test.tsx
+++ b/src/components/AgeReviewDetail.wiring.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+
+import { AgeReviewDetail } from './AgeReviewDetail';
+import type { AgeReviewCase } from '../../shared/age-review';
+
+// The pure derivations (contentVisibility, useReportedEvent) are covered by their
+// own tests. What was NOT covered is that AgeReviewDetail actually FEEDS them:
+// every plumbing prop could be hardcoded to a falsy default and the whole suite
+// still passed. These tests assert the wiring through the rendered output, so a
+// dropped prop shows up as a wrong claim on screen rather than as silence.
+
+const userStats = vi.fn();
+const accountStatus = vi.fn();
+const reportedEvent = vi.fn();
+
+vi.mock('@/hooks/useUserStats', () => ({ useUserStats: () => userStats() }));
+vi.mock('@/hooks/useAccountStatus', () => ({ useAccountStatus: () => accountStatus() }));
+vi.mock('@/hooks/useReportedEvent', () => ({ useReportedEvent: () => reportedEvent() }));
+vi.mock('@/components/MediaPreview', () => ({ MediaPreview: () => <div data-testid="media-preview" /> }));
+vi.mock('@/hooks/useAuthor', () => ({ useAuthor: () => ({ data: undefined, isLoading: false }) }));
+vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock('@/hooks/useAdminApi', () => ({
+  useApiUrl: () => 'https://api.test',
+  useAdminApi: () => ({
+    updateAgeReviewCase: vi.fn().mockResolvedValue({ success: true }),
+    getAgeReviewConfig: vi.fn().mockResolvedValue({ auto_delete_on_deny: false }),
+    getAccountStatus: vi.fn().mockResolvedValue({ success: true, status: 'active' }),
+  }),
+}));
+
+const PUBKEY = 'a'.repeat(64);
+
+function makeCase(): AgeReviewCase {
+  return {
+    id: 'case-1',
+    pubkey: PUBKEY,
+    reporter_pubkey: 'b'.repeat(64),
+    report_id: 'report-1',
+    suspected_age_band: 'age_13_15',
+    state: 'under_moderator_review',
+    allowed_resolution: 'parent_video_or_email',
+    parent_contact_email: null,
+    deadline_at: new Date(Date.now() + 7 * 864e5).toISOString(),
+    clock_paused: 0,
+    clock_paused_at: null,
+    remaining_days_when_paused: null,
+    moderator_pubkey: null,
+    resolution_note: null,
+    last_alerted_at: null,
+    zendesk_ticket_id: null,
+    created_via: null,
+  } as AgeReviewCase;
+}
+
+const emptyStats = (over: Record<string, unknown> = {}) => ({
+  data: {
+    postCount: 0, reportCount: 0, labelCount: 0,
+    recentPosts: [], existingLabels: [], previousReports: [],
+    relayIncomplete: false, ...over,
+  },
+  isError: false, isFetching: false, refetch: vi.fn(),
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  userStats.mockReturnValue(emptyStats());
+  accountStatus.mockReturnValue({ data: { success: true, status: 'active' }, isError: false, isLoading: false, refetch: vi.fn() });
+  reportedEvent.mockReturnValue({ data: undefined, isFetching: false, isError: false, refetch: vi.fn() });
+});
+
+const show = () => render(<AgeReviewDetail caseData={makeCase()} />, { wrapper });
+
+describe('AgeReviewDetail feeds the content derivations', () => {
+  it('passes relayIncomplete through, so a truncated read is not shown as absence', async () => {
+    userStats.mockReturnValue(emptyStats({ relayIncomplete: true }));
+    show();
+    await waitFor(() => expect(screen.getByText(/couldn't load/i)).toBeInTheDocument());
+    expect(screen.queryByText(/no content found/i)).not.toBeInTheDocument();
+  });
+
+  it('passes account-status failure through, so suspension is not ruled out unchecked', async () => {
+    // Stale successful data retained alongside isError: only the failed flag can
+    // reveal that this answer is no longer trustworthy.
+    accountStatus.mockReturnValue({ data: { success: true, status: 'active' }, isError: true, isLoading: false, refetch: vi.fn() });
+    show();
+    await waitFor(() => expect(screen.getByText(/suspension cannot be ruled out/i)).toBeInTheDocument());
+  });
+
+  it('does not claim absence before account status has arrived', async () => {
+    accountStatus.mockReturnValue({ data: undefined, isError: false, isLoading: true, refetch: vi.fn() });
+    show();
+    await waitFor(() => expect(screen.getByText(/suspension cannot be ruled out/i)).toBeInTheDocument());
+  });
+
+  it('keeps content enforcement available when the relay read was truncated', async () => {
+    // A zero count from an unfinished read must not mark the content levers n/a:
+    // that tells a moderator an action is unavailable when it may well apply.
+    userStats.mockReturnValue(emptyStats({ relayIncomplete: true }));
+    const { container } = show();
+    await waitFor(() => expect(screen.getByText(/couldn't load/i)).toBeInTheDocument());
+    expect(container.textContent).not.toMatch(/n\/a/i);
+  });
+
+  it('marks content enforcement n/a only on a complete read that found nothing', async () => {
+    // The contrast case: same zero count, but the read actually finished.
+    userStats.mockReturnValue(emptyStats({ relayIncomplete: false }));
+    const { container } = show();
+    await waitFor(() => expect(screen.getByText(/no content found/i)).toBeInTheDocument());
+    expect(container.textContent).toMatch(/n\/a/i);
+  });
+
+  it('passes the reported-event error through, so it is not shown as deleted', async () => {
+    reportedEvent.mockReturnValue({ data: undefined, isFetching: false, isError: true, refetch: vi.fn() });
+    show();
+    await waitFor(() => expect(screen.getByText(/couldn't load the reported content/i)).toBeInTheDocument());
+  });
+
+  it('passes the in-flight reported-event read through as loading', async () => {
+    reportedEvent.mockReturnValue({ data: undefined, isFetching: true, isError: false, refetch: vi.fn() });
+    show();
+    await waitFor(() => expect(screen.getByText(/loading reported content/i)).toBeInTheDocument());
+  });
+
+  it('surfaces a foreign-authored reported event rather than rendering it', async () => {
+    reportedEvent.mockReturnValue({
+      data: { status: 'target_foreign', targetEventId: 'c'.repeat(64), authorPubkey: 'e'.repeat(64) },
+      isFetching: false, isError: false, refetch: vi.fn(),
+    });
+    show();
+    await waitFor(() => expect(screen.getByText(/authored by a different account/i)).toBeInTheDocument());
+    expect(screen.queryByTestId('media-preview')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/UserProfileCard.test.tsx
+++ b/src/components/UserProfileCard.test.tsx
@@ -61,6 +61,7 @@ function stats(recentPosts: NostrEvent[]): UserStats {
     recentPosts,
     existingLabels: [],
     previousReports: [],
+    relayIncomplete: false,
   };
 }
 

--- a/src/components/UserProfileCard.test.tsx
+++ b/src/components/UserProfileCard.test.tsx
@@ -61,6 +61,9 @@ function stats(recentPosts: NostrEvent[]): UserStats {
     recentPosts,
     existingLabels: [],
     previousReports: [],
+    authoredContentIncomplete: false,
+    labelsIncomplete: false,
+    reportsIncomplete: false,
     relayIncomplete: false,
   };
 }

--- a/src/hooks/useReportedEvent.test.tsx
+++ b/src/hooks/useReportedEvent.test.tsx
@@ -120,7 +120,7 @@ describe('useReportedEvent', () => {
 
     const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toEqual({ status: 'target_foreign', event: foreign, authorPubkey: stranger, banned: false });
+    expect(result.current.data).toEqual({ status: 'target_foreign', event: foreign, banned: false });
   });
 
   it('shows a target authored by the case subject', async () => {
@@ -161,7 +161,7 @@ describe('useReportedEvent', () => {
 
     const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toMatchObject({ status: 'target_foreign', authorPubkey: stranger, banned: true });
+    expect(result.current.data).toMatchObject({ status: 'target_foreign', banned: true });
   });
 
   it('still tries the banned lookup when another tagged event was readable', async () => {
@@ -189,7 +189,7 @@ describe('useReportedEvent', () => {
 
     const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toMatchObject({ status: 'target_foreign', authorPubkey: 'ee'.repeat(32) });
+    expect(result.current.data).toMatchObject({ status: 'target_foreign' });
   });
 
   it('ignores a malformed banned response instead of crashing on it', async () => {
@@ -242,6 +242,65 @@ describe('useReportedEvent', () => {
     const { result } = render();
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(result.current.data).toBeUndefined();
+  });
+
+  it('caps how many tagged ids it will chase, so a hostile report cannot fan out', async () => {
+    // Each unresolved id costs a signed management request. The tag list comes
+    // from an untrusted event, so it must be bounded.
+    const many = Array.from({ length: 40 }, (_, i) => ['e', i.toString(16).padStart(2, '0').repeat(32)]);
+    relayReturns([report(many)], []);
+    callRelayRpc.mockRejectedValue(new ApiError('Event not found or not banned', 400, 'Bad Request'));
+
+    const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(callRelayRpc.mock.calls.length).toBeLessThanOrEqual(4);
+  });
+
+  it('does not issue duplicate lookups for a repeated tag', async () => {
+    relayReturns([report([['e', TARGET_ID], ['e', TARGET_ID], ['e', TARGET_ID]])], []);
+    callRelayRpc.mockRejectedValue(new ApiError('Event not found or not banned', 400, 'Bad Request'));
+
+    const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(callRelayRpc).toHaveBeenCalledTimes(1);
+  });
+
+  it('names the earliest tag even when a later one is readable and the earlier is banned', async () => {
+    // Tag order must hold across the readable/banned boundary, or the pane names
+    // a different event than the one the first tag points at.
+    const FIRST = 'cc'.repeat(32);
+    const bannedFirst = { ...content(FIRST), pubkey: 'ee'.repeat(32) };
+    const readableSecond = { ...content(TARGET_ID), pubkey: 'ff'.repeat(32) };
+    relayReturns([report([['e', FIRST], ['e', TARGET_ID]])], [readableSecond]);
+    callRelayRpc.mockResolvedValueOnce(bannedFirst);
+
+    const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ status: 'target_foreign', event: bannedFirst, banned: true });
+  });
+
+  it('keys the query by the case subject, so two cases cannot share a cached answer', async () => {
+    // One shared client, or each render gets its own cache and the key cannot
+    // be observed at all.
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const shared = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+    const own = { ...content(TARGET_ID), pubkey: CASE_PUBKEY };
+    relayReturns([report([['e', TARGET_ID]])], [own]);
+
+    const first = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper: shared });
+    await waitFor(() => expect(first.result.current.isSuccess).toBe(true));
+    const callsAfterFirst = req.mock.calls.length;
+
+    // Same report id, different subject: the author check differs, so the answer
+    // must be recomputed rather than served from the first case's entry.
+    relayReturns([report([['e', TARGET_ID]])], [own]);
+    const second = renderHook(() => useReportedEvent(REPORT_ID, 'ab'.repeat(32)), { wrapper: shared });
+    await waitFor(() => expect(second.result.current.isSuccess).toBe(true));
+
+    expect(req.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+    expect(second.result.current.data).toMatchObject({ status: 'target_foreign' });
   });
 
   it('does not run without a report id', () => {

--- a/src/hooks/useReportedEvent.test.tsx
+++ b/src/hooks/useReportedEvent.test.tsx
@@ -149,7 +149,51 @@ describe('useReportedEvent', () => {
 
     const { result } = render();
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toEqual({ status: 'report_missing' });
+    // Distinct from report_missing: the event IS on the relay, it just is not a report.
+    expect(result.current.data).toEqual({ status: 'not_a_report' });
+  });
+
+  it('refuses to show a banned target authored by someone else', async () => {
+    // The banned path needs the same author check as the plain relay path.
+    const stranger = 'ee'.repeat(32);
+    relayReturns([report([['e', TARGET_ID]])], []);
+    callRelayRpc.mockResolvedValueOnce({ ...content(TARGET_ID), pubkey: stranger });
+
+    const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ status: 'target_foreign', targetEventId: TARGET_ID, authorPubkey: stranger });
+  });
+
+  it('prefers a tagged event this account authored over another tagged event', async () => {
+    // A threaded reply tags its root too, so the first e tag is not always the
+    // reported post. Declaring it foreign would hide real evidence.
+    const root = { ...content('ff'.repeat(32)), pubkey: 'ee'.repeat(32) };
+    const own = { ...content(TARGET_ID), pubkey: CASE_PUBKEY };
+    relayReturns([report([['e', 'ff'.repeat(32)], ['e', TARGET_ID]])], [root, own]);
+
+    const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ status: 'found', event: own, banned: false });
+  });
+
+  it('does not claim an account-level report when the e tag is unparseable', async () => {
+    relayReturns([report([['e', 'not-hex']])]);
+
+    const { result } = render();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ status: 'target_unreadable' });
+  });
+
+  it('does not read a management-endpoint 404 as "not banned"', async () => {
+    // The worker collapses every RPC failure to HTTP 400 and renders a relay
+    // transport failure as "Relay error: 404 Not Found". Treating that as a
+    // negative would tell a moderator the post was deleted during an outage.
+    relayReturns([report([['e', TARGET_ID]])], []);
+    callRelayRpc.mockRejectedValueOnce(new ApiError('Relay error: 404 Not Found', 400, 'Bad Request'));
+
+    const { result } = render();
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
   });
 
   it('does not run without a report id', () => {

--- a/src/hooks/useReportedEvent.test.tsx
+++ b/src/hooks/useReportedEvent.test.tsx
@@ -45,7 +45,10 @@ function wrapper({ children }: { children: ReactNode }) {
 
 const render = () => renderHook(() => useReportedEvent(REPORT_ID, undefined), { wrapper });
 
-beforeEach(() => vi.resetAllMocks());
+// Targeted: resetAllMocks would also clear the shared jsdom mocks in
+// src/test/setup.ts (matchMedia, ResizeObserver), which any component render
+// added to this file would then fail on.
+beforeEach(() => { req.mockReset(); callRelayRpc.mockReset(); });
 
 describe('useReportedEvent', () => {
   it('resolves the reported content through the report, not the report itself', async () => {
@@ -320,6 +323,29 @@ describe('useReportedEvent', () => {
     expect(result.current.data).toEqual({ status: 'found', event: ownBanned, banned: true });
     // The second lookup should never have been issued.
     expect(callRelayRpc).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a foreign target already in hand when a later lookup fails', async () => {
+    // The early return only covers subject-owned events, so without the break a
+    // later tag's failure still discarded a foreign target. This pane
+    // deliberately shows those, labelled, so losing one hides real evidence.
+    const OTHER = 'cc'.repeat(32);
+    const strangerPost = { ...content(TARGET_ID), pubkey: 'ee'.repeat(32) };
+    relayReturns([report([['e', TARGET_ID], ['e', OTHER]])], [strangerPost]);
+    callRelayRpc.mockRejectedValueOnce(new ApiError('Internal Server Error', 500, 'ISE'));
+
+    const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ status: 'target_foreign', event: strangerPost, banned: false });
+  });
+
+  it('still reports an error when a lookup fails and nothing was retrieved', async () => {
+    // The counterpart: with nothing in hand, absence must not be asserted.
+    relayReturns([report([['e', TARGET_ID]])], []);
+    callRelayRpc.mockRejectedValueOnce(new ApiError('Internal Server Error', 500, 'ISE'));
+
+    const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
+    await waitFor(() => expect(result.current.isError).toBe(true));
   });
 
   it('rejects a banned response for a different event than the one requested', async () => {

--- a/src/hooks/useReportedEvent.test.tsx
+++ b/src/hooks/useReportedEvent.test.tsx
@@ -45,7 +45,7 @@ function wrapper({ children }: { children: ReactNode }) {
 
 const render = () => renderHook(() => useReportedEvent(REPORT_ID, undefined), { wrapper });
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => vi.resetAllMocks());
 
 describe('useReportedEvent', () => {
   it('resolves the reported content through the report, not the report itself', async () => {
@@ -189,7 +189,8 @@ describe('useReportedEvent', () => {
 
     const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toMatchObject({ status: 'target_foreign' });
+    // Identity, not just status: without it the ordering guard is unobservable.
+    expect(result.current.data).toEqual({ status: 'target_foreign', event: first, banned: false });
   });
 
   it('ignores a malformed banned response instead of crashing on it', async () => {
@@ -247,13 +248,13 @@ describe('useReportedEvent', () => {
   it('caps how many tagged ids it will chase, so a hostile report cannot fan out', async () => {
     // Each unresolved id costs a signed management request. The tag list comes
     // from an untrusted event, so it must be bounded.
-    const many = Array.from({ length: 40 }, (_, i) => ['e', i.toString(16).padStart(2, '0').repeat(32)]);
+    const many = Array.from({ length: 60 }, (_, i) => ['e', i.toString(16).padStart(2, '0').repeat(32)]);
     relayReturns([report(many)], []);
     callRelayRpc.mockRejectedValue(new ApiError('Event not found or not banned', 400, 'Bad Request'));
 
     const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(callRelayRpc.mock.calls.length).toBeLessThanOrEqual(4);
+    expect(callRelayRpc.mock.calls.length).toBeLessThanOrEqual(16);
   });
 
   it('does not issue duplicate lookups for a repeated tag', async () => {
@@ -301,6 +302,69 @@ describe('useReportedEvent', () => {
 
     expect(req.mock.calls.length).toBeGreaterThan(callsAfterFirst);
     expect(second.result.current.data).toMatchObject({ status: 'target_foreign' });
+  });
+
+  it('keeps a retrieved post when a later unrelated lookup fails', async () => {
+    // Regression: running the loop to completion exposed an already-settled
+    // answer to an unrelated tag's failure, so the moderator lost content we
+    // had in hand and saw a relay error instead.
+    const OTHER = 'cc'.repeat(32);
+    const ownBanned = { ...content(TARGET_ID), pubkey: CASE_PUBKEY };
+    relayReturns([report([['e', TARGET_ID], ['e', OTHER]])], []);
+    callRelayRpc
+      .mockResolvedValueOnce(ownBanned)
+      .mockRejectedValueOnce(new ApiError('Internal Server Error', 500, 'ISE'));
+
+    const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ status: 'found', event: ownBanned, banned: true });
+    // The second lookup should never have been issued.
+    expect(callRelayRpc).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a banned response for a different event than the one requested', async () => {
+    relayReturns([report([['e', TARGET_ID]])], []);
+    callRelayRpc.mockResolvedValueOnce({ ...content('cc'.repeat(32)), pubkey: CASE_PUBKEY });
+
+    const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ status: 'target_missing', targetEventId: TARGET_ID });
+  });
+
+  it('picks the earliest subject-owned tag, not the last', async () => {
+    const FIRST = 'cc'.repeat(32);
+    const firstOwn = { ...content(FIRST), pubkey: CASE_PUBKEY };
+    const secondOwn = { ...content(TARGET_ID), pubkey: CASE_PUBKEY };
+    relayReturns([report([['e', FIRST], ['e', TARGET_ID]])], [secondOwn, firstOwn]);
+
+    const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ status: 'found', event: firstOwn, banned: false });
+  });
+
+  it('stops issuing lookups once the query has been cancelled', async () => {
+    // Unmounting cancels the query and aborts its signal. callRelayRpc takes no
+    // signal and can run for 30s, so without the in-loop check the remaining ids
+    // keep costing signed requests after the moderator has moved on.
+    const A = 'cc'.repeat(32);
+    const B = 'dd'.repeat(32);
+    relayReturns([report([['e', A], ['e', B]])], []);
+    let settleFirst: () => void = () => {};
+    callRelayRpc.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          settleFirst = () => reject(new ApiError('Event not found or not banned', 400, 'Bad Request'));
+        }),
+    );
+
+    const { unmount } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
+    await waitFor(() => expect(callRelayRpc).toHaveBeenCalledTimes(1));
+
+    unmount();
+    settleFirst();
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(callRelayRpc).toHaveBeenCalledTimes(1);
   });
 
   it('does not run without a report id', () => {

--- a/src/hooks/useReportedEvent.test.tsx
+++ b/src/hooks/useReportedEvent.test.tsx
@@ -4,9 +4,19 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import { ApiError } from '@/lib/adminApi';
 
-const { query, callRelayRpc } = vi.hoisted(() => ({ query: vi.fn(), callRelayRpc: vi.fn() }));
+const { req, callRelayRpc } = vi.hoisted(() => ({ req: vi.fn(), callRelayRpc: vi.fn() }));
 
-vi.mock('@/hooks/useNostr', () => ({ useNostr: () => ({ nostr: { query } }) }));
+vi.mock('@/hooks/useNostr', () => ({ useNostr: () => ({ nostr: { req } }) }));
+
+/** Queue one relay response per hop: events then EOSE (a completed read). */
+function relayReturns(...hops: unknown[][]) {
+  for (const events of hops) {
+    req.mockImplementationOnce(async function* () {
+      for (const e of events) yield ['EVENT', 'sub', e];
+      yield ['EOSE', 'sub'];
+    });
+  }
+}
 vi.mock('@/hooks/useAdminApi', () => ({
   useAdminApi: () => ({ callRelayRpc }),
   useApiUrl: () => 'https://api.test',
@@ -19,6 +29,7 @@ import { useReportedEvent } from './useReportedEvent';
 
 const REPORT_ID = 'a1'.repeat(32);
 const TARGET_ID = 'b2'.repeat(32);
+const CASE_PUBKEY = 'd4'.repeat(32);
 
 function report(tags: string[][]) {
   return { id: REPORT_ID, pubkey: 'c3'.repeat(32), created_at: 1, kind: 1984, tags, content: 'spam', sig: '' };
@@ -39,22 +50,18 @@ beforeEach(() => vi.clearAllMocks());
 describe('useReportedEvent', () => {
   it('resolves the reported content through the report, not the report itself', async () => {
     // report_id identifies the kind-1984 report; the content is in its `e` tag.
-    query
-      .mockResolvedValueOnce([report([['e', TARGET_ID], ['p', 'd4'.repeat(32)]])])
-      .mockResolvedValueOnce([content(TARGET_ID)]);
+    relayReturns([report([['e', TARGET_ID], ['p', 'd4'.repeat(32)]])], [content(TARGET_ID)]);
 
     const { result } = render();
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data).toEqual({ status: 'found', event: content(TARGET_ID), banned: false });
-    expect(query).toHaveBeenNthCalledWith(1, [{ ids: [REPORT_ID] }], expect.anything());
-    expect(query).toHaveBeenNthCalledWith(2, [{ ids: [TARGET_ID] }], expect.anything());
+    expect(req).toHaveBeenNthCalledWith(1, [{ ids: [REPORT_ID] }], expect.anything());
+    expect(req).toHaveBeenNthCalledWith(2, [{ ids: [TARGET_ID] }], expect.anything());
   });
 
   it('falls back to getbannedevent when the target is not publicly readable', async () => {
-    query
-      .mockResolvedValueOnce([report([['e', TARGET_ID]])])
-      .mockResolvedValueOnce([]);
+    relayReturns([report([['e', TARGET_ID]])], []);
     callRelayRpc.mockResolvedValueOnce(content(TARGET_ID));
 
     const { result } = render();
@@ -65,7 +72,7 @@ describe('useReportedEvent', () => {
   });
 
   it('reports an account-level report instead of inventing a missing post', async () => {
-    query.mockResolvedValueOnce([report([['p', 'd4'.repeat(32)]])]);
+    relayReturns([report([['p', 'd4'.repeat(32)]])]);
 
     const { result } = render();
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -74,7 +81,7 @@ describe('useReportedEvent', () => {
   });
 
   it('reports a missing report event distinctly from a missing target', async () => {
-    query.mockResolvedValueOnce([]);
+    relayReturns([]);
 
     const { result } = render();
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -82,13 +89,11 @@ describe('useReportedEvent', () => {
   });
 
   it('treats "not banned" as a genuine negative, not an error', async () => {
-    // Verified against the live relay: getbannedevent answers success:false with
-    // "Event not found or not banned", which callRelayRpc raises as an ApiError
-    // carrying no HTTP status.
-    query
-      .mockResolvedValueOnce([report([['e', TARGET_ID]])])
-      .mockResolvedValueOnce([]);
-    callRelayRpc.mockRejectedValueOnce(new ApiError('Event not found or not banned'));
+    // Verified end to end against production, status code included: the relay
+    // answers success:false with "Event not found or not banned" and the worker
+    // returns that as HTTP 400, so the ApiError DOES carry a status.
+    relayReturns([report([['e', TARGET_ID]])], []);
+    callRelayRpc.mockRejectedValueOnce(new ApiError('Event not found or not banned', 400, 'Bad Request'));
 
     const { result } = render();
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -97,9 +102,7 @@ describe('useReportedEvent', () => {
 
   it('surfaces a transport failure as an error rather than a missing target', async () => {
     // An expired CF Access session must never render as "the post was deleted".
-    query
-      .mockResolvedValueOnce([report([['e', TARGET_ID]])])
-      .mockResolvedValueOnce([]);
+    relayReturns([report([['e', TARGET_ID]])], []);
     callRelayRpc.mockRejectedValueOnce(new ApiError('Forbidden', 403, 'Forbidden'));
 
     const { result } = render();
@@ -107,9 +110,51 @@ describe('useReportedEvent', () => {
     expect(result.current.data).toBeUndefined();
   });
 
+  it('refuses to show a target authored by someone other than the case subject', async () => {
+    // NIP-56 does not require the reported event to be authored by the reported
+    // pubkey, and case creation does not check it, so a crafted report could put
+    // a stranger's video in front of a moderator as this account's content.
+    const stranger = 'ee'.repeat(32);
+    const foreign = { ...content(TARGET_ID), pubkey: stranger };
+    relayReturns([report([['e', TARGET_ID]])], [foreign]);
+
+    const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ status: 'target_foreign', targetEventId: TARGET_ID, authorPubkey: stranger });
+  });
+
+  it('shows a target authored by the case subject', async () => {
+    const own = { ...content(TARGET_ID), pubkey: CASE_PUBKEY };
+    relayReturns([report([['e', TARGET_ID]])], [own]);
+
+    const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ status: 'found', event: own, banned: false });
+  });
+
+  it('errors rather than reporting a missing report when the relay closes the read', async () => {
+    // A relay CLOSED resolves NPool.query to [] with no abort and no throw, which
+    // would otherwise render as "the report event is no longer on the relay".
+    req.mockImplementationOnce(async function* () {
+      yield ['CLOSED', 'sub', 'error: could not complete query'];
+    });
+
+    const { result } = render();
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('does not interpret a non-report event as a report', async () => {
+    relayReturns([{ ...content(REPORT_ID), kind: 1, tags: [['e', TARGET_ID]] }]);
+
+    const { result } = render();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ status: 'report_missing' });
+  });
+
   it('does not run without a report id', () => {
     const { result } = renderHook(() => useReportedEvent(undefined), { wrapper });
     expect(result.current.fetchStatus).toBe('idle');
-    expect(query).not.toHaveBeenCalled();
+    expect(req).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useReportedEvent.test.tsx
+++ b/src/hooks/useReportedEvent.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { ApiError } from '@/lib/adminApi';
+
+const { query, callRelayRpc } = vi.hoisted(() => ({ query: vi.fn(), callRelayRpc: vi.fn() }));
+
+vi.mock('@/hooks/useNostr', () => ({ useNostr: () => ({ nostr: { query } }) }));
+vi.mock('@/hooks/useAdminApi', () => ({
+  useAdminApi: () => ({ callRelayRpc }),
+  useApiUrl: () => 'https://api.test',
+}));
+vi.mock('@/hooks/useAppContext', () => ({
+  useAppContext: () => ({ config: { relayUrl: 'wss://relay.test' } }),
+}));
+
+import { useReportedEvent } from './useReportedEvent';
+
+const REPORT_ID = 'a1'.repeat(32);
+const TARGET_ID = 'b2'.repeat(32);
+
+function report(tags: string[][]) {
+  return { id: REPORT_ID, pubkey: 'c3'.repeat(32), created_at: 1, kind: 1984, tags, content: 'spam', sig: '' };
+}
+function content(id: string) {
+  return { id, pubkey: 'd4'.repeat(32), created_at: 2, kind: 34235, tags: [], content: 'clip', sig: '' };
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+const render = () => renderHook(() => useReportedEvent(REPORT_ID), { wrapper });
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useReportedEvent', () => {
+  it('resolves the reported content through the report, not the report itself', async () => {
+    // report_id identifies the kind-1984 report; the content is in its `e` tag.
+    query
+      .mockResolvedValueOnce([report([['e', TARGET_ID], ['p', 'd4'.repeat(32)]])])
+      .mockResolvedValueOnce([content(TARGET_ID)]);
+
+    const { result } = render();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual({ status: 'found', event: content(TARGET_ID), banned: false });
+    expect(query).toHaveBeenNthCalledWith(1, [{ ids: [REPORT_ID] }], expect.anything());
+    expect(query).toHaveBeenNthCalledWith(2, [{ ids: [TARGET_ID] }], expect.anything());
+  });
+
+  it('falls back to getbannedevent when the target is not publicly readable', async () => {
+    query
+      .mockResolvedValueOnce([report([['e', TARGET_ID]])])
+      .mockResolvedValueOnce([]);
+    callRelayRpc.mockResolvedValueOnce(content(TARGET_ID));
+
+    const { result } = render();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual({ status: 'found', event: content(TARGET_ID), banned: true });
+    expect(callRelayRpc).toHaveBeenCalledWith('getbannedevent', [TARGET_ID]);
+  });
+
+  it('reports an account-level report instead of inventing a missing post', async () => {
+    query.mockResolvedValueOnce([report([['p', 'd4'.repeat(32)]])]);
+
+    const { result } = render();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ status: 'account_level' });
+    expect(callRelayRpc).not.toHaveBeenCalled();
+  });
+
+  it('reports a missing report event distinctly from a missing target', async () => {
+    query.mockResolvedValueOnce([]);
+
+    const { result } = render();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ status: 'report_missing' });
+  });
+
+  it('treats "not banned" as a genuine negative, not an error', async () => {
+    // Verified against the live relay: getbannedevent answers success:false with
+    // "Event not found or not banned", which callRelayRpc raises as an ApiError
+    // carrying no HTTP status.
+    query
+      .mockResolvedValueOnce([report([['e', TARGET_ID]])])
+      .mockResolvedValueOnce([]);
+    callRelayRpc.mockRejectedValueOnce(new ApiError('Event not found or not banned'));
+
+    const { result } = render();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ status: 'target_missing', targetEventId: TARGET_ID });
+  });
+
+  it('surfaces a transport failure as an error rather than a missing target', async () => {
+    // An expired CF Access session must never render as "the post was deleted".
+    query
+      .mockResolvedValueOnce([report([['e', TARGET_ID]])])
+      .mockResolvedValueOnce([]);
+    callRelayRpc.mockRejectedValueOnce(new ApiError('Forbidden', 403, 'Forbidden'));
+
+    const { result } = render();
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('does not run without a report id', () => {
+    const { result } = renderHook(() => useReportedEvent(undefined), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useReportedEvent.test.tsx
+++ b/src/hooks/useReportedEvent.test.tsx
@@ -43,7 +43,7 @@ function wrapper({ children }: { children: ReactNode }) {
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
 }
 
-const render = () => renderHook(() => useReportedEvent(REPORT_ID), { wrapper });
+const render = () => renderHook(() => useReportedEvent(REPORT_ID, undefined), { wrapper });
 
 beforeEach(() => vi.clearAllMocks());
 
@@ -120,7 +120,7 @@ describe('useReportedEvent', () => {
 
     const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toEqual({ status: 'target_foreign', targetEventId: TARGET_ID, authorPubkey: stranger });
+    expect(result.current.data).toEqual({ status: 'target_foreign', event: foreign, authorPubkey: stranger, banned: false });
   });
 
   it('shows a target authored by the case subject', async () => {
@@ -153,7 +153,7 @@ describe('useReportedEvent', () => {
     expect(result.current.data).toEqual({ status: 'not_a_report' });
   });
 
-  it('refuses to show a banned target authored by someone else', async () => {
+  it('labels a banned target authored by someone else, and marks it banned', async () => {
     // The banned path needs the same author check as the plain relay path.
     const stranger = 'ee'.repeat(32);
     relayReturns([report([['e', TARGET_ID]])], []);
@@ -161,7 +161,55 @@ describe('useReportedEvent', () => {
 
     const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toEqual({ status: 'target_foreign', targetEventId: TARGET_ID, authorPubkey: stranger });
+    expect(result.current.data).toMatchObject({ status: 'target_foreign', authorPubkey: stranger, banned: true });
+  });
+
+  it('still tries the banned lookup when another tagged event was readable', async () => {
+    // Regression: returning early on any readable event silently disabled the
+    // banned fallback, which is the capability this feature exists for.
+    const OTHER = 'cc'.repeat(32);
+    const strangerRoot = { ...content(OTHER), pubkey: 'ee'.repeat(32) };
+    const ownBanned = { ...content(TARGET_ID), pubkey: CASE_PUBKEY };
+    relayReturns([report([['e', TARGET_ID], ['e', OTHER]])], [strangerRoot]);
+    callRelayRpc.mockResolvedValueOnce(ownBanned);
+
+    const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(callRelayRpc).toHaveBeenCalledWith('getbannedevent', [TARGET_ID]);
+    expect(result.current.data).toEqual({ status: 'found', event: ownBanned, banned: true });
+  });
+
+  it('names the first tagged event, not whichever the relay returned first', async () => {
+    // Relay arrival order is arbitrary; the pane must agree with any other code
+    // that treats the first e tag as the target.
+    const FIRST = 'cc'.repeat(32);
+    const first = { ...content(FIRST), pubkey: 'ee'.repeat(32) };
+    const second = { ...content(TARGET_ID), pubkey: 'ff'.repeat(32) };
+    relayReturns([report([['e', FIRST], ['e', TARGET_ID]])], [second, first]);
+
+    const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toMatchObject({ status: 'target_foreign', authorPubkey: 'ee'.repeat(32) });
+  });
+
+  it('ignores a malformed banned response instead of crashing on it', async () => {
+    // Without the shape guard this reaches target_foreign with an undefined
+    // author, which the pane then calls .slice() on during render.
+    relayReturns([report([['e', TARGET_ID]])], []);
+    callRelayRpc.mockResolvedValueOnce({ notAnEvent: true });
+
+    const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ status: 'target_missing', targetEventId: TARGET_ID });
+  });
+
+  it('matches the case subject regardless of hex casing', async () => {
+    const upper = { ...content(TARGET_ID), pubkey: CASE_PUBKEY.toUpperCase() };
+    relayReturns([report([['e', TARGET_ID]])], [upper]);
+
+    const { result } = renderHook(() => useReportedEvent(REPORT_ID, CASE_PUBKEY), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toMatchObject({ status: 'found', banned: false });
   });
 
   it('prefers a tagged event this account authored over another tagged event', async () => {
@@ -197,7 +245,7 @@ describe('useReportedEvent', () => {
   });
 
   it('does not run without a report id', () => {
-    const { result } = renderHook(() => useReportedEvent(undefined), { wrapper });
+    const { result } = renderHook(() => useReportedEvent(undefined, undefined), { wrapper });
     expect(result.current.fetchStatus).toBe('idle');
     expect(req).not.toHaveBeenCalled();
   });

--- a/src/hooks/useReportedEvent.ts
+++ b/src/hooks/useReportedEvent.ts
@@ -1,0 +1,42 @@
+// ABOUTME: Fetches the reported event by id for the age-review case — normal relay
+// ABOUTME: query first, then a getbannedevent fallback so a banned/removed reported
+// ABOUTME: event still shows to moderators. Mirrors EventsList's direct-lookup path.
+import { useQuery } from "@tanstack/react-query";
+import type { NostrEvent } from "@nostrify/nostrify";
+import { useNostr } from "@/hooks/useNostr";
+import { useAdminApi, useApiUrl } from "@/hooks/useAdminApi";
+
+export interface ReportedEventResult {
+  event: NostrEvent;
+  banned: boolean;
+}
+
+export function useReportedEvent(eventId: string | undefined) {
+  const { nostr } = useNostr();
+  const { callRelayRpc } = useAdminApi();
+  // Environment id in the key: the QueryClient is a singleton while the relay
+  // swaps per environment, so without it a repeat lookup could serve another
+  // environment's result within the staleTime window (same caution as EventsList).
+  const apiUrl = useApiUrl();
+
+  return useQuery<ReportedEventResult | null>({
+    queryKey: ["reported-event", apiUrl, eventId],
+    queryFn: async ({ signal }) => {
+      if (!eventId) return null;
+      const timeoutSignal = AbortSignal.any([signal, AbortSignal.timeout(5000)]);
+      // Relay-visible first.
+      const events = await nostr.query([{ ids: [eventId] }], { signal: timeoutSignal });
+      if (events[0]) return { event: events[0], banned: false };
+      // Fallback: retrieve it via the management API if it was banned/removed.
+      try {
+        const banned = await callRelayRpc<NostrEvent>("getbannedevent", [eventId]);
+        if (banned) return { event: banned, banned: true };
+      } catch {
+        // not banned, or the RPC failed — treat as not found
+      }
+      return null;
+    },
+    enabled: !!eventId,
+    staleTime: 60_000,
+  });
+}

--- a/src/hooks/useReportedEvent.ts
+++ b/src/hooks/useReportedEvent.ts
@@ -24,8 +24,13 @@ export type ReportedEventResult =
   | { status: "not_a_report" }
   /** The report carries an `e` tag we cannot parse, so its target is unknown. */
   | { status: "target_unreadable" }
-  /** The report points at an event authored by someone other than this case's subject. */
-  | { status: "target_foreign"; targetEventId: string; authorPubkey: string };
+  /**
+   * The report points at an event authored by someone other than this case's
+   * subject. The event is carried so the pane can still show it, labelled, since
+   * hiding it would lose evidence a moderator may legitimately need (a report
+   * about a repost can name the original, which a third party authored).
+   */
+  | { status: "target_foreign"; event: NostrEvent; authorPubkey: string; banned: boolean };
 
 // Per hop, not shared: a single budget across both hops meant a healthy but slow
 // relay got roughly half the time the pre-two-hop lookup had.
@@ -33,7 +38,7 @@ const HOP_TIMEOUT_MS = 5000;
 
 const REPORT_KIND = 1984;
 
-export function useReportedEvent(reportId: string | undefined, casePubkey?: string) {
+export function useReportedEvent(reportId: string | undefined, casePubkey: string | undefined) {
   const { nostr } = useNostr();
   const { callRelayRpc } = useAdminApi();
   // Both the relay and the management API change with the environment, and the
@@ -62,9 +67,13 @@ export function useReportedEvent(reportId: string | undefined, casePubkey?: stri
       // A report may carry more than one `e` tag (a threaded reply also tags its
       // root, a repost its original), so consider all of them rather than
       // declaring the first one foreign and hiding the real target.
+      // Hex is compared lowercased throughout: isHex64 accepts either case and
+      // the case pubkey is stored verbatim from the reporter's `p` tag, so a
+      // non-canonical client could otherwise make an account look foreign to
+      // its own post.
       const targetIds = report.tags
         .filter((t) => t[0] === "e" && isHex64(t[1]))
-        .map((t) => t[1]);
+        .map((t) => t[1].toLowerCase());
       if (targetIds.length === 0) {
         // An `e` tag we could not parse is not the same as no `e` tag at all:
         // saying "filed against the account" would be a claim about the report.
@@ -72,36 +81,53 @@ export function useReportedEvent(reportId: string | undefined, casePubkey?: stri
           ? { status: "target_unreadable" }
           : { status: "account_level" };
       }
+      const subject = casePubkey?.toLowerCase();
 
       const events = await queryStrict(nostr, [{ ids: targetIds }], { signal, timeoutMs: HOP_TIMEOUT_MS });
-      if (events.length > 0) {
-        // NIP-56 does not require the reported event to be authored by the
-        // reported pubkey, and case creation does not check it, so a mis-filed
-        // or crafted report can point at a stranger's post. Showing that as this
-        // account's "reported content" would put a moderator's age judgement on
-        // the wrong person's video. Prefer a tagged event this account actually
-        // wrote; only if none of them is do we treat the report as mis-targeted.
-        const own = casePubkey ? events.find((e) => e.pubkey === casePubkey) : events[0];
-        if (own) return { status: "found", event: own, banned: false };
-        return { status: "target_foreign", targetEventId: events[0].id, authorPubkey: events[0].pubkey };
+      const byId = new Map(events.map((e) => [e.id.toLowerCase(), e]));
+      // Walk in tag order, not relay arrival order, so the pane always names the
+      // same event as any other code that reads the first `e` tag.
+      const readable = targetIds.map((id) => byId.get(id)).filter((e): e is NostrEvent => !!e);
+
+      // NIP-56 does not require the reported event to be authored by the reported
+      // pubkey, and case creation does not check it, so a mis-filed report can
+      // name a third party's post. Prefer one this account actually wrote.
+      const own = subject ? readable.find((e) => e.pubkey.toLowerCase() === subject) : readable[0];
+      if (own) return { status: "found", event: own, banned: false };
+
+      // Anything not publicly readable may be banned, which admins can still
+      // fetch. This runs even when another tagged event was readable: skipping it
+      // would silently disable the banned-content path this feature exists for.
+      let bannedForeign: NostrEvent | undefined;
+      for (const id of targetIds.filter((i) => !byId.has(i))) {
+        try {
+          const banned = await callRelayRpc<NostrEvent>("getbannedevent", [id]);
+          // Shape-check before trusting it: a malformed response would otherwise
+          // fail the author comparison and then crash the render on .slice().
+          if (!banned || !isHex64(banned.pubkey)) continue;
+          if (!subject || banned.pubkey.toLowerCase() === subject) {
+            return { status: "found", event: banned, banned: true };
+          }
+          bannedForeign ??= banned;
+        } catch (e) {
+          // Only "the relay says it is not banned" is a real negative. Transport,
+          // auth, and unknown failures propagate, so the pane shows an error
+          // rather than asserting the content was deleted.
+          if (!isDefinitiveRpcNegative(e)) throw e;
+        }
       }
 
-      // Not publicly readable. It may be banned, which admins can still fetch.
-      try {
-        const banned = await callRelayRpc<NostrEvent>("getbannedevent", [targetIds[0]]);
-        // Shape-check before trusting it: a malformed response would otherwise
-        // fail the author comparison and then crash the render on .slice().
-        if (banned && isHex64(banned.pubkey)) {
-          if (casePubkey && banned.pubkey !== casePubkey) {
-            return { status: "target_foreign", targetEventId: targetIds[0], authorPubkey: banned.pubkey };
-          }
-          return { status: "found", event: banned, banned: true };
-        }
-      } catch (e) {
-        // Only "the relay says it is not banned" is a real negative. Transport,
-        // auth, and unknown failures propagate, so the pane shows an error
-        // rather than asserting the content was deleted.
-        if (!isDefinitiveRpcNegative(e)) throw e;
+      // Nothing the subject authored. Show what the report does name, labelled,
+      // rather than hiding it: a report about a repost legitimately names the
+      // original, and a moderator may need to see it.
+      const foreign = readable[0] ?? bannedForeign;
+      if (foreign) {
+        return {
+          status: "target_foreign",
+          event: foreign,
+          authorPubkey: foreign.pubkey,
+          banned: foreign === bannedForeign,
+        };
       }
 
       return { status: "target_missing", targetEventId: targetIds[0] };

--- a/src/hooks/useReportedEvent.ts
+++ b/src/hooks/useReportedEvent.ts
@@ -40,9 +40,10 @@ const HOP_TIMEOUT_MS = 5000;
 
 const REPORT_KIND = 1984;
 
-// A NIP-56 report names one target. The list is untrusted input and each
-// unresolved id costs a signed management request, so cap it.
-const MAX_TARGET_IDS = 4;
+// A NIP-56 report names one target, so this is far above any legitimate shape.
+// The list is untrusted input and each unresolved id costs a signed management
+// request, so it still has to be bounded.
+const MAX_TARGET_IDS = 16;
 
 /**
  * Whether a management-API result is shaped well enough to render. The RPC
@@ -145,7 +146,20 @@ export function useReportedEvent(reportId: string | undefined, casePubkey: strin
         if (signal.aborted) throw signal.reason ?? new DOMException("Aborted", "AbortError");
         try {
           const banned = await callRelayRpc<NostrEvent>("getbannedevent", [id]);
-          if (isRenderableEvent(banned)) resolved.set(id, { event: banned, banned: true });
+          // Must be the event we asked for: results are keyed by the requested
+          // id, so a mismatched response would otherwise be adopted under it.
+          if (isRenderableEvent(banned) && banned.id.toLowerCase() === id) {
+            resolved.set(id, { event: banned, banned: true });
+            // Return as soon as the subject's own post is in hand. Every earlier
+            // id was already ruled out, and this loop walks tag order, so this is
+            // the earliest subject-owned target: exactly what the post-loop pick
+            // would choose. Continuing would expose a settled answer to an
+            // unrelated later lookup failing, throwing away content we already
+            // have and showing the moderator a relay error instead.
+            if (!subject || banned.pubkey.toLowerCase() === subject) {
+              return { status: "found", event: banned, banned: true };
+            }
+          }
         } catch (e) {
           // Only "the relay says it is not banned" is a real negative. Transport,
           // auth, and unknown failures propagate, so the pane shows an error

--- a/src/hooks/useReportedEvent.ts
+++ b/src/hooks/useReportedEvent.ts
@@ -8,22 +8,28 @@ import { useNostr } from "@/hooks/useNostr";
 import { useAdminApi, useApiUrl } from "@/hooks/useAdminApi";
 import { useAppContext } from "@/hooks/useAppContext";
 import { getReportTargetIds } from "@/lib/constants";
-import { assertRelayReadCompleted, isDefinitiveRpcNegative } from "@/lib/relayRead";
+import { queryStrict, isDefinitiveRpcNegative } from "@/lib/relayRead";
 
 /**
  * Every outcome is named, so the UI never has to infer a reason from a bare
- * null. `target_missing` means we asked and the event is genuinely not
- * retrievable; a read that failed throws instead and surfaces as a query error.
+ * null. A read that failed throws instead of returning one of these, so a
+ * "missing" answer here always means we asked and got a real answer.
  */
 export type ReportedEventResult =
   | { status: "found"; event: NostrEvent; banned: boolean }
   | { status: "account_level" }
   | { status: "target_missing"; targetEventId: string }
-  | { status: "report_missing" };
+  | { status: "report_missing" }
+  /** The report points at an event authored by someone other than this case's subject. */
+  | { status: "target_foreign"; targetEventId: string; authorPubkey: string };
 
-const READ_TIMEOUT_MS = 5000;
+// Per hop, not shared: a single budget across both hops meant a healthy but slow
+// relay got roughly half the time the pre-two-hop lookup had.
+const HOP_TIMEOUT_MS = 5000;
 
-export function useReportedEvent(reportId: string | undefined) {
+const REPORT_KIND = 1984;
+
+export function useReportedEvent(reportId: string | undefined, casePubkey?: string) {
   const { nostr } = useNostr();
   const { callRelayRpc } = useAdminApi();
   // Both the relay and the management API change with the environment, and the
@@ -34,31 +40,46 @@ export function useReportedEvent(reportId: string | undefined) {
   const relayUrl = config.relayUrl;
 
   return useQuery<ReportedEventResult>({
-    queryKey: ["reported-event", apiUrl, relayUrl, reportId],
+    queryKey: ["reported-event", apiUrl, relayUrl, reportId, casePubkey],
     queryFn: async ({ signal }) => {
-      const timeout = AbortSignal.timeout(READ_TIMEOUT_MS);
-      const combined = AbortSignal.any([signal, timeout]);
-
       // Hop 1: the kind-1984 report itself. `report_id` is written from the
       // report event's own id (ReportWatcher), not from what it reports on.
-      const reports = await nostr.query([{ ids: [reportId!] }], { signal: combined });
-      assertRelayReadCompleted(timeout, signal);
+      const reports = await queryStrict(nostr, [{ ids: [reportId!] }], { signal, timeoutMs: HOP_TIMEOUT_MS });
       const report = reports[0];
       if (!report) return { status: "report_missing" };
+      // Only a report's tags describe a report target. Anything else with this
+      // id is not something we can interpret, and guessing from its tags would
+      // be worse than saying so.
+      if (report.kind !== REPORT_KIND) return { status: "report_missing" };
 
       // Hop 2: what the report points at. Under-16 cases are filed against the
       // account (a `p` tag and no `e` tag), so there is no single post to show.
       const { eventId } = getReportTargetIds(report);
       if (!eventId) return { status: "account_level" };
 
-      const events = await nostr.query([{ ids: [eventId] }], { signal: combined });
-      assertRelayReadCompleted(timeout, signal);
-      if (events[0]) return { status: "found", event: events[0], banned: false };
+      const events = await queryStrict(nostr, [{ ids: [eventId] }], { signal, timeoutMs: HOP_TIMEOUT_MS });
+      const target = events[0];
+      if (target) {
+        // NIP-56 does not require the reported event to be authored by the
+        // reported pubkey, and case creation does not check it, so a mis-filed
+        // or crafted report can point at a stranger's post. Showing that as this
+        // account's "reported content" would put a moderator's age judgement on
+        // the wrong person's video.
+        if (casePubkey && target.pubkey !== casePubkey) {
+          return { status: "target_foreign", targetEventId: eventId, authorPubkey: target.pubkey };
+        }
+        return { status: "found", event: target, banned: false };
+      }
 
       // Not publicly readable. It may be banned, which admins can still fetch.
       try {
         const banned = await callRelayRpc<NostrEvent>("getbannedevent", [eventId]);
-        if (banned) return { status: "found", event: banned, banned: true };
+        if (banned) {
+          if (casePubkey && banned.pubkey !== casePubkey) {
+            return { status: "target_foreign", targetEventId: eventId, authorPubkey: banned.pubkey };
+          }
+          return { status: "found", event: banned, banned: true };
+        }
       } catch (e) {
         // Only "the relay says it is not banned" is a real negative. Transport,
         // auth, and unknown failures propagate, so the pane shows an error

--- a/src/hooks/useReportedEvent.ts
+++ b/src/hooks/useReportedEvent.ts
@@ -108,7 +108,7 @@ export function useReportedEvent(reportId: string | undefined, casePubkey: strin
           ? { status: "target_unreadable" }
           : { status: "account_level" };
       }
-      const subject = casePubkey?.toLowerCase();
+      const subject = casePubkey ? casePubkey.toLowerCase() : undefined;
       // Deduped and capped. The tag list comes from an untrusted event: anyone
       // can publish a report, and each unresolved id below costs a signed
       // management request. A NIP-56 report names one target, so a handful is
@@ -129,7 +129,7 @@ export function useReportedEvent(reportId: string | undefined, casePubkey: strin
       const pickSubjectOwned = () => {
         for (const id of uniqueIds) {
           const hit = resolved.get(id);
-          if (hit && (!subject || hit.event.pubkey.toLowerCase() === subject)) return hit;
+          if (hit && (subject === undefined || hit.event.pubkey.toLowerCase() === subject)) return hit;
         }
       };
 
@@ -156,7 +156,7 @@ export function useReportedEvent(reportId: string | undefined, casePubkey: strin
             // would choose. Continuing would expose a settled answer to an
             // unrelated later lookup failing, throwing away content we already
             // have and showing the moderator a relay error instead.
-            if (!subject || banned.pubkey.toLowerCase() === subject) {
+            if (subject === undefined || banned.pubkey.toLowerCase() === subject) {
               return { status: "found", event: banned, banned: true };
             }
           }
@@ -164,7 +164,16 @@ export function useReportedEvent(reportId: string | undefined, casePubkey: strin
           // Only "the relay says it is not banned" is a real negative. Transport,
           // auth, and unknown failures propagate, so the pane shows an error
           // rather than asserting the content was deleted.
-          if (!isDefinitiveRpcNegative(e)) throw e;
+          if (!isDefinitiveRpcNegative(e)) {
+            // ...unless we already hold a target. The subject-owned case returns
+            // above, so what we hold here is foreign, which this pane deliberately
+            // shows with an attribution warning. Discarding it because an
+            // unrelated later tag failed would hide evidence behind a relay
+            // error, and a persistent failure makes Retry useless. Absence is
+            // only asserted when we have nothing at all.
+            if (uniqueIds.some((i) => resolved.has(i))) break;
+            throw e;
+          }
         }
       }
 

--- a/src/hooks/useReportedEvent.ts
+++ b/src/hooks/useReportedEvent.ts
@@ -7,7 +7,7 @@ import type { NostrEvent } from "@nostrify/nostrify";
 import { useNostr } from "@/hooks/useNostr";
 import { useAdminApi, useApiUrl } from "@/hooks/useAdminApi";
 import { useAppContext } from "@/hooks/useAppContext";
-import { getReportTargetIds } from "@/lib/constants";
+import { isHex64 } from "@/lib/constants";
 import { queryStrict, isDefinitiveRpcNegative } from "@/lib/relayRead";
 
 /**
@@ -20,6 +20,10 @@ export type ReportedEventResult =
   | { status: "account_level" }
   | { status: "target_missing"; targetEventId: string }
   | { status: "report_missing" }
+  /** The id resolved to something that is not a report, so its tags mean nothing here. */
+  | { status: "not_a_report" }
+  /** The report carries an `e` tag we cannot parse, so its target is unknown. */
+  | { status: "target_unreadable" }
   /** The report points at an event authored by someone other than this case's subject. */
   | { status: "target_foreign"; targetEventId: string; authorPubkey: string };
 
@@ -49,34 +53,47 @@ export function useReportedEvent(reportId: string | undefined, casePubkey?: stri
       if (!report) return { status: "report_missing" };
       // Only a report's tags describe a report target. Anything else with this
       // id is not something we can interpret, and guessing from its tags would
-      // be worse than saying so.
-      if (report.kind !== REPORT_KIND) return { status: "report_missing" };
+      // be worse than saying so. Distinct from report_missing: the event is
+      // there, it just is not a report.
+      if (report.kind !== REPORT_KIND) return { status: "not_a_report" };
 
       // Hop 2: what the report points at. Under-16 cases are filed against the
       // account (a `p` tag and no `e` tag), so there is no single post to show.
-      const { eventId } = getReportTargetIds(report);
-      if (!eventId) return { status: "account_level" };
+      // A report may carry more than one `e` tag (a threaded reply also tags its
+      // root, a repost its original), so consider all of them rather than
+      // declaring the first one foreign and hiding the real target.
+      const targetIds = report.tags
+        .filter((t) => t[0] === "e" && isHex64(t[1]))
+        .map((t) => t[1]);
+      if (targetIds.length === 0) {
+        // An `e` tag we could not parse is not the same as no `e` tag at all:
+        // saying "filed against the account" would be a claim about the report.
+        return report.tags.some((t) => t[0] === "e")
+          ? { status: "target_unreadable" }
+          : { status: "account_level" };
+      }
 
-      const events = await queryStrict(nostr, [{ ids: [eventId] }], { signal, timeoutMs: HOP_TIMEOUT_MS });
-      const target = events[0];
-      if (target) {
+      const events = await queryStrict(nostr, [{ ids: targetIds }], { signal, timeoutMs: HOP_TIMEOUT_MS });
+      if (events.length > 0) {
         // NIP-56 does not require the reported event to be authored by the
         // reported pubkey, and case creation does not check it, so a mis-filed
         // or crafted report can point at a stranger's post. Showing that as this
         // account's "reported content" would put a moderator's age judgement on
-        // the wrong person's video.
-        if (casePubkey && target.pubkey !== casePubkey) {
-          return { status: "target_foreign", targetEventId: eventId, authorPubkey: target.pubkey };
-        }
-        return { status: "found", event: target, banned: false };
+        // the wrong person's video. Prefer a tagged event this account actually
+        // wrote; only if none of them is do we treat the report as mis-targeted.
+        const own = casePubkey ? events.find((e) => e.pubkey === casePubkey) : events[0];
+        if (own) return { status: "found", event: own, banned: false };
+        return { status: "target_foreign", targetEventId: events[0].id, authorPubkey: events[0].pubkey };
       }
 
       // Not publicly readable. It may be banned, which admins can still fetch.
       try {
-        const banned = await callRelayRpc<NostrEvent>("getbannedevent", [eventId]);
-        if (banned) {
+        const banned = await callRelayRpc<NostrEvent>("getbannedevent", [targetIds[0]]);
+        // Shape-check before trusting it: a malformed response would otherwise
+        // fail the author comparison and then crash the render on .slice().
+        if (banned && isHex64(banned.pubkey)) {
           if (casePubkey && banned.pubkey !== casePubkey) {
-            return { status: "target_foreign", targetEventId: eventId, authorPubkey: banned.pubkey };
+            return { status: "target_foreign", targetEventId: targetIds[0], authorPubkey: banned.pubkey };
           }
           return { status: "found", event: banned, banned: true };
         }
@@ -87,7 +104,7 @@ export function useReportedEvent(reportId: string | undefined, casePubkey?: stri
         if (!isDefinitiveRpcNegative(e)) throw e;
       }
 
-      return { status: "target_missing", targetEventId: eventId };
+      return { status: "target_missing", targetEventId: targetIds[0] };
     },
     enabled: !!reportId,
     staleTime: 60_000,

--- a/src/hooks/useReportedEvent.ts
+++ b/src/hooks/useReportedEvent.ts
@@ -1,42 +1,74 @@
-// ABOUTME: Fetches the reported event by id for the age-review case — normal relay
-// ABOUTME: query first, then a getbannedevent fallback so a banned/removed reported
-// ABOUTME: event still shows to moderators. Mirrors EventsList's direct-lookup path.
+// ABOUTME: Resolves the content a kind-1984 report is about, for the age-review
+// ABOUTME: case pane. `report_id` is the REPORT's id, not the content's, so this
+// ABOUTME: is a two-hop lookup: fetch the report, read its target from the tags,
+// ABOUTME: then fetch that event (with a getbannedevent fallback when banned).
 import { useQuery } from "@tanstack/react-query";
 import type { NostrEvent } from "@nostrify/nostrify";
 import { useNostr } from "@/hooks/useNostr";
 import { useAdminApi, useApiUrl } from "@/hooks/useAdminApi";
+import { useAppContext } from "@/hooks/useAppContext";
+import { getReportTargetIds } from "@/lib/constants";
+import { assertRelayReadCompleted, isDefinitiveRpcNegative } from "@/lib/relayRead";
 
-export interface ReportedEventResult {
-  event: NostrEvent;
-  banned: boolean;
-}
+/**
+ * Every outcome is named, so the UI never has to infer a reason from a bare
+ * null. `target_missing` means we asked and the event is genuinely not
+ * retrievable; a read that failed throws instead and surfaces as a query error.
+ */
+export type ReportedEventResult =
+  | { status: "found"; event: NostrEvent; banned: boolean }
+  | { status: "account_level" }
+  | { status: "target_missing"; targetEventId: string }
+  | { status: "report_missing" };
 
-export function useReportedEvent(eventId: string | undefined) {
+const READ_TIMEOUT_MS = 5000;
+
+export function useReportedEvent(reportId: string | undefined) {
   const { nostr } = useNostr();
   const { callRelayRpc } = useAdminApi();
-  // Environment id in the key: the QueryClient is a singleton while the relay
-  // swaps per environment, so without it a repeat lookup could serve another
-  // environment's result within the staleTime window (same caution as EventsList).
+  // Both the relay and the management API change with the environment, and the
+  // QueryClient is a singleton, so both belong in the key or a repeat lookup
+  // could serve another environment's result inside the staleTime window.
   const apiUrl = useApiUrl();
+  const { config } = useAppContext();
+  const relayUrl = config.relayUrl;
 
-  return useQuery<ReportedEventResult | null>({
-    queryKey: ["reported-event", apiUrl, eventId],
+  return useQuery<ReportedEventResult>({
+    queryKey: ["reported-event", apiUrl, relayUrl, reportId],
     queryFn: async ({ signal }) => {
-      if (!eventId) return null;
-      const timeoutSignal = AbortSignal.any([signal, AbortSignal.timeout(5000)]);
-      // Relay-visible first.
-      const events = await nostr.query([{ ids: [eventId] }], { signal: timeoutSignal });
-      if (events[0]) return { event: events[0], banned: false };
-      // Fallback: retrieve it via the management API if it was banned/removed.
+      const timeout = AbortSignal.timeout(READ_TIMEOUT_MS);
+      const combined = AbortSignal.any([signal, timeout]);
+
+      // Hop 1: the kind-1984 report itself. `report_id` is written from the
+      // report event's own id (ReportWatcher), not from what it reports on.
+      const reports = await nostr.query([{ ids: [reportId!] }], { signal: combined });
+      assertRelayReadCompleted(timeout, signal);
+      const report = reports[0];
+      if (!report) return { status: "report_missing" };
+
+      // Hop 2: what the report points at. Under-16 cases are filed against the
+      // account (a `p` tag and no `e` tag), so there is no single post to show.
+      const { eventId } = getReportTargetIds(report);
+      if (!eventId) return { status: "account_level" };
+
+      const events = await nostr.query([{ ids: [eventId] }], { signal: combined });
+      assertRelayReadCompleted(timeout, signal);
+      if (events[0]) return { status: "found", event: events[0], banned: false };
+
+      // Not publicly readable. It may be banned, which admins can still fetch.
       try {
         const banned = await callRelayRpc<NostrEvent>("getbannedevent", [eventId]);
-        if (banned) return { event: banned, banned: true };
-      } catch {
-        // not banned, or the RPC failed — treat as not found
+        if (banned) return { status: "found", event: banned, banned: true };
+      } catch (e) {
+        // Only "the relay says it is not banned" is a real negative. Transport,
+        // auth, and unknown failures propagate, so the pane shows an error
+        // rather than asserting the content was deleted.
+        if (!isDefinitiveRpcNegative(e)) throw e;
       }
-      return null;
+
+      return { status: "target_missing", targetEventId: eventId };
     },
-    enabled: !!eventId,
+    enabled: !!reportId,
     staleTime: 60_000,
   });
 }

--- a/src/hooks/useReportedEvent.ts
+++ b/src/hooks/useReportedEvent.ts
@@ -28,15 +28,41 @@ export type ReportedEventResult =
    * The report points at an event authored by someone other than this case's
    * subject. The event is carried so the pane can still show it, labelled, since
    * hiding it would lose evidence a moderator may legitimately need (a report
-   * about a repost can name the original, which a third party authored).
+   * about a repost can name the original, which a third party authored). The
+   * author is read from the event itself, so the label and the byline cannot
+   * disagree.
    */
-  | { status: "target_foreign"; event: NostrEvent; authorPubkey: string; banned: boolean };
+  | { status: "target_foreign"; event: NostrEvent; banned: boolean };
 
 // Per hop, not shared: a single budget across both hops meant a healthy but slow
 // relay got roughly half the time the pre-two-hop lookup had.
 const HOP_TIMEOUT_MS = 5000;
 
 const REPORT_KIND = 1984;
+
+// A NIP-56 report names one target. The list is untrusted input and each
+// unresolved id costs a signed management request, so cap it.
+const MAX_TARGET_IDS = 4;
+
+/**
+ * Whether a management-API result is shaped well enough to render. The RPC
+ * result is unvalidated `unknown` at the type level, and ContentCard reads
+ * `pubkey`, `kind`, `created_at` and `content` directly, so a malformed
+ * response would otherwise crash the pane during render (an object in
+ * `content` throws "Objects are not valid as a React child").
+ */
+function isRenderableEvent(value: unknown): value is NostrEvent {
+  if (!value || typeof value !== "object") return false;
+  const e = value as Partial<NostrEvent>;
+  return (
+    isHex64(e.pubkey) &&
+    isHex64(e.id) &&
+    typeof e.kind === "number" &&
+    typeof e.created_at === "number" &&
+    typeof e.content === "string" &&
+    Array.isArray(e.tags)
+  );
+}
 
 export function useReportedEvent(reportId: string | undefined, casePubkey: string | undefined) {
   const { nostr } = useNostr();
@@ -82,33 +108,44 @@ export function useReportedEvent(reportId: string | undefined, casePubkey: strin
           : { status: "account_level" };
       }
       const subject = casePubkey?.toLowerCase();
+      // Deduped and capped. The tag list comes from an untrusted event: anyone
+      // can publish a report, and each unresolved id below costs a signed
+      // management request. A NIP-56 report names one target, so a handful is
+      // already generous, and the cap keeps a hostile report from turning one
+      // case-open into hundreds of RPCs.
+      const uniqueIds = [...new Set(targetIds)].slice(0, MAX_TARGET_IDS);
 
-      const events = await queryStrict(nostr, [{ ids: targetIds }], { signal, timeoutMs: HOP_TIMEOUT_MS });
-      const byId = new Map(events.map((e) => [e.id.toLowerCase(), e]));
-      // Walk in tag order, not relay arrival order, so the pane always names the
-      // same event as any other code that reads the first `e` tag.
-      const readable = targetIds.map((id) => byId.get(id)).filter((e): e is NostrEvent => !!e);
+      const events = await queryStrict(nostr, [{ ids: uniqueIds }], { signal, timeoutMs: HOP_TIMEOUT_MS });
+      // Keyed by id so selection can walk tag order rather than relay arrival
+      // order, and so the banned results below join the same ordering.
+      const resolved = new Map<string, { event: NostrEvent; banned: boolean }>();
+      for (const e of events) resolved.set(e.id.toLowerCase(), { event: e, banned: false });
 
       // NIP-56 does not require the reported event to be authored by the reported
       // pubkey, and case creation does not check it, so a mis-filed report can
-      // name a third party's post. Prefer one this account actually wrote.
-      const own = subject ? readable.find((e) => e.pubkey.toLowerCase() === subject) : readable[0];
-      if (own) return { status: "found", event: own, banned: false };
+      // name a third party's post. Prefer one this account actually wrote, taking
+      // the earliest such tag.
+      const pickSubjectOwned = () => {
+        for (const id of uniqueIds) {
+          const hit = resolved.get(id);
+          if (hit && (!subject || hit.event.pubkey.toLowerCase() === subject)) return hit;
+        }
+      };
+
+      const ownReadable = pickSubjectOwned();
+      if (ownReadable) return { status: "found", event: ownReadable.event, banned: ownReadable.banned };
 
       // Anything not publicly readable may be banned, which admins can still
       // fetch. This runs even when another tagged event was readable: skipping it
       // would silently disable the banned-content path this feature exists for.
-      let bannedForeign: NostrEvent | undefined;
-      for (const id of targetIds.filter((i) => !byId.has(i))) {
+      for (const id of uniqueIds.filter((i) => !resolved.has(i))) {
+        // callRelayRpc takes no signal and each call can run for 30s, so check
+        // between iterations: without this the loop keeps issuing signed requests
+        // after the moderator has moved to another case.
+        if (signal.aborted) throw signal.reason ?? new DOMException("Aborted", "AbortError");
         try {
           const banned = await callRelayRpc<NostrEvent>("getbannedevent", [id]);
-          // Shape-check before trusting it: a malformed response would otherwise
-          // fail the author comparison and then crash the render on .slice().
-          if (!banned || !isHex64(banned.pubkey)) continue;
-          if (!subject || banned.pubkey.toLowerCase() === subject) {
-            return { status: "found", event: banned, banned: true };
-          }
-          bannedForeign ??= banned;
+          if (isRenderableEvent(banned)) resolved.set(id, { event: banned, banned: true });
         } catch (e) {
           // Only "the relay says it is not banned" is a real negative. Transport,
           // auth, and unknown failures propagate, so the pane shows an error
@@ -117,20 +154,19 @@ export function useReportedEvent(reportId: string | undefined, casePubkey: strin
         }
       }
 
+      const own = pickSubjectOwned();
+      if (own) return { status: "found", event: own.event, banned: own.banned };
+
       // Nothing the subject authored. Show what the report does name, labelled,
       // rather than hiding it: a report about a repost legitimately names the
-      // original, and a moderator may need to see it.
-      const foreign = readable[0] ?? bannedForeign;
-      if (foreign) {
-        return {
-          status: "target_foreign",
-          event: foreign,
-          authorPubkey: foreign.pubkey,
-          banned: foreign === bannedForeign,
-        };
+      // original, and a moderator may need to see it. Tag order again, so a
+      // banned first tag is not passed over for a readable second one.
+      for (const id of uniqueIds) {
+        const hit = resolved.get(id);
+        if (hit) return { status: "target_foreign", event: hit.event, banned: hit.banned };
       }
 
-      return { status: "target_missing", targetEventId: targetIds[0] };
+      return { status: "target_missing", targetEventId: uniqueIds[0] };
     },
     enabled: !!reportId,
     staleTime: 60_000,

--- a/src/hooks/useUserStats.test.tsx
+++ b/src/hooks/useUserStats.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+const { req } = vi.hoisted(() => ({ req: vi.fn() }));
+vi.mock('@nostrify/react', () => ({ useNostr: () => ({ nostr: { req } }) }));
+vi.mock('@/hooks/useAppContext', () => ({
+  useAppContext: () => ({ config: { relayUrl: 'wss://relay.test' } }),
+}));
+
+import { useUserStats } from './useUserStats';
+
+const PUBKEY = 'd4'.repeat(32);
+
+function post(id: string) {
+  return { id, pubkey: PUBKEY, created_at: 2, kind: 1, tags: [], content: 'hi', sig: '' };
+}
+
+/** A completed read: events then EOSE. */
+function completes(events: unknown[] = []) {
+  return async function* () {
+    for (const e of events) yield ['EVENT', 'sub', e];
+    yield ['EOSE', 'sub'];
+  };
+}
+/** A read the relay cut short. */
+function closes() {
+  return async function* () {
+    yield ['CLOSED', 'sub', 'error: could not complete query'];
+  };
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+const show = () => renderHook(() => useUserStats(PUBKEY), { wrapper });
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useUserStats', () => {
+  it('reports a completed empty read as genuinely empty', async () => {
+    req.mockImplementation(completes([]));
+    const { result } = show();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.postCount).toBe(0);
+    expect(result.current.data?.relayIncomplete).toBe(false);
+  });
+
+  it('flags a read the relay closed, so a zero count is not read as absence', async () => {
+    // The whole point: without this flag, postCount 0 from a failed read is
+    // indistinguishable from an account that has posted nothing.
+    req.mockImplementation(closes());
+    const { result } = show();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.postCount).toBe(0);
+    expect(result.current.data?.relayIncomplete).toBe(true);
+  });
+
+  it('flags the result when only one of the three reads fails', async () => {
+    req
+      .mockImplementationOnce(completes([post('a')]))
+      .mockImplementationOnce(closes())
+      .mockImplementationOnce(completes([]));
+    const { result } = show();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.relayIncomplete).toBe(true);
+  });
+
+  it('does not disguise a programming error as a relay problem', async () => {
+    // A TypeError from our own code must surface as a query error, not as
+    // "relay error, retry" that no retry can ever clear.
+    req.mockImplementation(() => { throw new TypeError('nostr.req is not a function'); });
+    const { result } = show();
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/src/hooks/useUserStats.test.tsx
+++ b/src/hooks/useUserStats.test.tsx
@@ -47,9 +47,12 @@ describe('useUserStats', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data?.postCount).toBe(0);
     expect(result.current.data?.relayIncomplete).toBe(false);
+    expect(result.current.data?.authoredContentIncomplete).toBe(false);
+    expect(result.current.data?.labelsIncomplete).toBe(false);
+    expect(result.current.data?.reportsIncomplete).toBe(false);
   });
 
-  it('flags a read the relay closed, so a zero count is not read as absence', async () => {
+  it('flags an authored-content read the relay closed, so a zero count is not read as absence', async () => {
     // The whole point: without this flag, postCount 0 from a failed read is
     // indistinguishable from an account that has posted nothing.
     req.mockImplementation(closes());
@@ -57,9 +60,10 @@ describe('useUserStats', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data?.postCount).toBe(0);
     expect(result.current.data?.relayIncomplete).toBe(true);
+    expect(result.current.data?.authoredContentIncomplete).toBe(true);
   });
 
-  it('flags the result when only one of the three reads fails', async () => {
+  it('keeps a label-only failure separate from authored-content completeness', async () => {
     req
       .mockImplementationOnce(completes([post('a')]))
       .mockImplementationOnce(closes())
@@ -67,6 +71,22 @@ describe('useUserStats', () => {
     const { result } = show();
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data?.relayIncomplete).toBe(true);
+    expect(result.current.data?.authoredContentIncomplete).toBe(false);
+    expect(result.current.data?.labelsIncomplete).toBe(true);
+    expect(result.current.data?.reportsIncomplete).toBe(false);
+  });
+
+  it('keeps a report-only failure separate from authored-content completeness', async () => {
+    req
+      .mockImplementationOnce(completes([]))
+      .mockImplementationOnce(completes([]))
+      .mockImplementationOnce(closes());
+    const { result } = show();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.relayIncomplete).toBe(true);
+    expect(result.current.data?.authoredContentIncomplete).toBe(false);
+    expect(result.current.data?.labelsIncomplete).toBe(false);
+    expect(result.current.data?.reportsIncomplete).toBe(true);
   });
 
   it('does not disguise a programming error as a relay problem', async () => {

--- a/src/hooks/useUserStats.ts
+++ b/src/hooks/useUserStats.ts
@@ -4,7 +4,7 @@
 import { useNostr } from "@nostrify/react";
 import { useQuery } from "@tanstack/react-query";
 import { useAppContext } from "@/hooks/useAppContext";
-import { queryStrict } from "@/lib/relayRead";
+import { queryStrict, RelayReadError } from "@/lib/relayRead";
 import { RECENT_CONTENT_KINDS } from "@/lib/constants";
 import type { NostrEvent } from "@nostrify/nostrify";
 
@@ -57,7 +57,13 @@ export function useUserStats(pubkey: string | undefined) {
       const read = async (filters: Parameters<typeof queryStrict>[1]) => {
         try {
           return await queryStrict(nostr, filters, { signal, timeoutMs: 8000 });
-        } catch {
+        } catch (e) {
+          // Only classify as a relay problem what queryStrict actually raises for
+          // one. A TypeError from our own code would otherwise be reported to the
+          // moderator as "relay error, retry" forever, with nothing logged.
+          const isReadFailure =
+            e instanceof RelayReadError || (e instanceof DOMException && e.name === 'AbortError');
+          if (!isReadFailure) throw e;
           incomplete = true;
           return [];
         }

--- a/src/hooks/useUserStats.ts
+++ b/src/hooks/useUserStats.ts
@@ -4,6 +4,7 @@
 import { useNostr } from "@nostrify/react";
 import { useQuery } from "@tanstack/react-query";
 import { useAppContext } from "@/hooks/useAppContext";
+import { queryStrict } from "@/lib/relayRead";
 import { RECENT_CONTENT_KINDS } from "@/lib/constants";
 import type { NostrEvent } from "@nostrify/nostrify";
 
@@ -47,27 +48,30 @@ export function useUserStats(pubkey: string | undefined) {
         };
       }
 
-      const timeout = AbortSignal.timeout(8000);
-      const combinedSignal = AbortSignal.any([signal, timeout]);
+      // queryStrict throws on anything short of a completed read (timeout, a
+      // relay CLOSED, no route). We record that rather than rethrowing: this
+      // hook has four other consumers whose behaviour is not in scope to change
+      // here, so the failure is reported as a flag and only callers that state
+      // absence to a user act on it. Promoting this to a real error is #210.
+      let incomplete = false;
+      const read = async (filters: Parameters<typeof queryStrict>[1]) => {
+        try {
+          return await queryStrict(nostr, filters, { signal, timeoutMs: 8000 });
+        } catch {
+          incomplete = true;
+          return [];
+        }
+      };
 
       // Fetch in parallel
       const [recentPosts, existingLabels, previousReports] = await Promise.all([
         // User's recent authored content — RECENT_CONTENT_KINDS is shared with
         // BannedUserCard so the two review surfaces stay aligned (#159).
-        nostr.query(
-          [{ kinds: [...RECENT_CONTENT_KINDS], authors: [pubkey], limit: 20 }],
-          { signal: combinedSignal }
-        ),
+        read([{ kinds: [...RECENT_CONTENT_KINDS], authors: [pubkey], limit: 20 }]),
         // Labels against this user
-        nostr.query(
-          [{ kinds: [1985], '#p': [pubkey], limit: 50 }],
-          { signal: combinedSignal }
-        ),
+        read([{ kinds: [1985], '#p': [pubkey], limit: 50 }]),
         // Reports against this user
-        nostr.query(
-          [{ kinds: [1984], '#p': [pubkey], limit: 50 }],
-          { signal: combinedSignal }
-        ),
+        read([{ kinds: [1984], '#p': [pubkey], limit: 50 }]),
       ]);
 
       return {
@@ -77,9 +81,9 @@ export function useUserStats(pubkey: string | undefined) {
         recentPosts: recentPosts.sort((a, b) => b.created_at - a.created_at),
         existingLabels,
         previousReports,
-        // Our timeout fired rather than the query being cancelled upstream, so
-        // the relay did not finish answering and these counts understate.
-        relayIncomplete: timeout.aborted && !signal.aborted,
+        // At least one read did not finish, so these counts are a floor, not a
+        // fact, and a zero here proves nothing about the account.
+        relayIncomplete: incomplete,
       };
     },
     enabled: !!pubkey,

--- a/src/hooks/useUserStats.ts
+++ b/src/hooks/useUserStats.ts
@@ -15,13 +15,15 @@ export interface UserStats {
   recentPosts: NostrEvent[];
   existingLabels: NostrEvent[];
   previousReports: NostrEvent[];
+  /** True when the authored-content read did not complete. */
+  authoredContentIncomplete: boolean;
+  /** True when the labels-against-this-user read did not complete. */
+  labelsIncomplete: boolean;
+  /** True when the reports-against-this-user read did not complete. */
+  reportsIncomplete: boolean;
   /**
-   * True when the relay read was cut short by our timeout, so the counts below
-   * are a floor rather than a fact. `NPool.query` resolves with partial results
-   * instead of throwing, so without this a dead relay is indistinguishable from
-   * an empty account. Reported as a flag rather than a thrown error to keep this
-   * shared hook's behaviour unchanged for its other consumers; callers that
-   * state absence to a user (age review) must check it.
+   * Aggregate compatibility signal for consumers that treat these stats as a
+   * single unit. Read-specific consumers should use the flags above.
    */
   relayIncomplete: boolean;
 }
@@ -44,6 +46,9 @@ export function useUserStats(pubkey: string | undefined) {
           recentPosts: [],
           existingLabels: [],
           previousReports: [],
+          authoredContentIncomplete: false,
+          labelsIncomplete: false,
+          reportsIncomplete: false,
           relayIncomplete: false,
         };
       }
@@ -53,10 +58,12 @@ export function useUserStats(pubkey: string | undefined) {
       // hook has four other consumers whose behaviour is not in scope to change
       // here, so the failure is reported as a flag and only callers that state
       // absence to a user act on it. Promoting this to a real error is #210.
-      let incomplete = false;
       const read = async (filters: Parameters<typeof queryStrict>[1]) => {
         try {
-          return await queryStrict(nostr, filters, { signal, timeoutMs: 8000 });
+          return {
+            events: await queryStrict(nostr, filters, { signal, timeoutMs: 8000 }),
+            incomplete: false,
+          };
         } catch (e) {
           // Only classify as a relay problem what queryStrict actually raises for
           // one. A TypeError from our own code would otherwise be reported to the
@@ -64,13 +71,12 @@ export function useUserStats(pubkey: string | undefined) {
           const isReadFailure =
             e instanceof RelayReadError || (e instanceof DOMException && e.name === 'AbortError');
           if (!isReadFailure) throw e;
-          incomplete = true;
-          return [];
+          return { events: [], incomplete: true };
         }
       };
 
       // Fetch in parallel
-      const [recentPosts, existingLabels, previousReports] = await Promise.all([
+      const [authoredContentRead, labelsRead, reportsRead] = await Promise.all([
         // User's recent authored content — RECENT_CONTENT_KINDS is shared with
         // BannedUserCard so the two review surfaces stay aligned (#159).
         read([{ kinds: [...RECENT_CONTENT_KINDS], authors: [pubkey], limit: 20 }]),
@@ -79,6 +85,9 @@ export function useUserStats(pubkey: string | undefined) {
         // Reports against this user
         read([{ kinds: [1984], '#p': [pubkey], limit: 50 }]),
       ]);
+      const recentPosts = authoredContentRead.events;
+      const existingLabels = labelsRead.events;
+      const previousReports = reportsRead.events;
 
       return {
         postCount: recentPosts.length, // Recent authored events of any queried kind (posts, comments, reposts) — not a total
@@ -87,9 +96,13 @@ export function useUserStats(pubkey: string | undefined) {
         recentPosts: recentPosts.sort((a, b) => b.created_at - a.created_at),
         existingLabels,
         previousReports,
-        // At least one read did not finish, so these counts are a floor, not a
-        // fact, and a zero here proves nothing about the account.
-        relayIncomplete: incomplete,
+        authoredContentIncomplete: authoredContentRead.incomplete,
+        labelsIncomplete: labelsRead.incomplete,
+        reportsIncomplete: reportsRead.incomplete,
+        relayIncomplete:
+          authoredContentRead.incomplete ||
+          labelsRead.incomplete ||
+          reportsRead.incomplete,
       };
     },
     enabled: !!pubkey,

--- a/src/hooks/useUserStats.ts
+++ b/src/hooks/useUserStats.ts
@@ -3,6 +3,7 @@
 
 import { useNostr } from "@nostrify/react";
 import { useQuery } from "@tanstack/react-query";
+import { useAppContext } from "@/hooks/useAppContext";
 import { RECENT_CONTENT_KINDS } from "@/lib/constants";
 import type { NostrEvent } from "@nostrify/nostrify";
 
@@ -13,13 +14,26 @@ export interface UserStats {
   recentPosts: NostrEvent[];
   existingLabels: NostrEvent[];
   previousReports: NostrEvent[];
+  /**
+   * True when the relay read was cut short by our timeout, so the counts below
+   * are a floor rather than a fact. `NPool.query` resolves with partial results
+   * instead of throwing, so without this a dead relay is indistinguishable from
+   * an empty account. Reported as a flag rather than a thrown error to keep this
+   * shared hook's behaviour unchanged for its other consumers; callers that
+   * state absence to a user (age review) must check it.
+   */
+  relayIncomplete: boolean;
 }
 
 export function useUserStats(pubkey: string | undefined) {
   const { nostr } = useNostr();
+  const { config } = useAppContext();
+  const relayUrl = config.relayUrl;
 
   return useQuery<UserStats>({
-    queryKey: ['user-stats', pubkey],
+    // relayUrl in the key: the QueryClient is a singleton and these events are
+    // shown as evidence, so a cached read must never cross environments.
+    queryKey: ['user-stats', relayUrl, pubkey],
     queryFn: async ({ signal }) => {
       if (!pubkey) {
         return {
@@ -29,6 +43,7 @@ export function useUserStats(pubkey: string | undefined) {
           recentPosts: [],
           existingLabels: [],
           previousReports: [],
+          relayIncomplete: false,
         };
       }
 
@@ -62,6 +77,9 @@ export function useUserStats(pubkey: string | undefined) {
         recentPosts: recentPosts.sort((a, b) => b.created_at - a.created_at),
         existingLabels,
         previousReports,
+        // Our timeout fired rather than the query being cancelled upstream, so
+        // the relay did not finish answering and these counts understate.
+        relayIncomplete: timeout.aborted && !signal.aborted,
       };
     },
     enabled: !!pubkey,

--- a/src/lib/contentVisibility.test.ts
+++ b/src/lib/contentVisibility.test.ts
@@ -86,12 +86,21 @@ describe('deriveContentVisibility', () => {
     expect(r.state).toBe('unknown');
   });
 
-  it('keeps using the last definitive status after a failed refetch (data-first)', () => {
-    // Deliberate: deriveAccountVerdict renders immediately above this and is
-    // data-first on stale status. Diverging here would put two contradictory
-    // claims about the same account on one screen.
-    const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: suspended });
-    expect(r.state).toBe('suspended');
+  it('keeps the state but marks the claim when the status could not be refreshed', () => {
+    // Data-first on the STATE, so this and deriveAccountVerdict (rendered
+    // directly above) cannot contradict each other, while the moderator still
+    // learns the answer may be minutes old.
+    const fresh = deriveContentVisibility({ ...base, postCount: 0, accountStatus: suspended });
+    const stale = deriveContentVisibility({ ...base, postCount: 0, accountStatus: suspended, accountStatusFailed: true });
+    expect(stale.state).toBe(fresh.state);
+    expect(stale.message).not.toBe(fresh.message);
+    expect(stale.message.toLowerCase()).toContain('could not be refreshed');
+  });
+
+  it('marks a confirmed-absent claim as stale too, since it also rests on the status', () => {
+    const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: active, accountStatusFailed: true });
+    expect(r.state).toBe('absent');
+    expect(r.message.toLowerCase()).toContain('could not be refreshed');
   });
 
   it('treats self-custody (not_found) as a definitive answer, not as unavailable', () => {

--- a/src/lib/contentVisibility.test.ts
+++ b/src/lib/contentVisibility.test.ts
@@ -14,7 +14,6 @@ const base = {
   contentLoading: false,
   contentError: false,
   accountStatus: active,
-  accountStatusFailed: false,
 };
 
 describe('deriveContentVisibility', () => {
@@ -68,8 +67,8 @@ describe('deriveContentVisibility', () => {
     expect(r.state).toBe('error');
   });
 
-  it('does not rule out suspension when the status read failed', () => {
-    const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: statusUnavailable, accountStatusFailed: true });
+  it('does not rule out suspension when keycast could not answer', () => {
+    const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: statusUnavailable });
     expect(r.state).toBe('unknown');
     expect(r.state).not.toBe('absent');
     expect(r.message.toLowerCase()).toContain('cannot be ruled out');
@@ -87,12 +86,12 @@ describe('deriveContentVisibility', () => {
     expect(r.state).toBe('unknown');
   });
 
-  it('does not trust stale successful status data once the read has failed', () => {
-    // TanStack retains the last good `data` while isError is true, so a stale
-    // "active" must not be read as current truth.
-    const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: active, accountStatusFailed: true });
-    expect(r.state).toBe('unknown');
-    expect(r.state).not.toBe('absent');
+  it('keeps using the last definitive status after a failed refetch (data-first)', () => {
+    // Deliberate: deriveAccountVerdict renders immediately above this and is
+    // data-first on stale status. Diverging here would put two contradictory
+    // claims about the same account on one screen.
+    const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: suspended });
+    expect(r.state).toBe('suspended');
   });
 
   it('treats self-custody (not_found) as a definitive answer, not as unavailable', () => {

--- a/src/lib/contentVisibility.test.ts
+++ b/src/lib/contentVisibility.test.ts
@@ -14,7 +14,6 @@ const base = {
   contentLoading: false,
   contentError: false,
   accountStatus: active,
-  accountStatusLoading: false,
   accountStatusFailed: false,
 };
 
@@ -77,7 +76,7 @@ describe('deriveContentVisibility', () => {
   });
 
   it('does not rule out suspension while the status read is still in flight', () => {
-    const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: undefined, accountStatusLoading: true });
+    const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: undefined });
     expect(r.state).toBe('unknown');
     expect(r.state).not.toBe('absent');
   });
@@ -86,5 +85,21 @@ describe('deriveContentVisibility', () => {
     // A keycast blip resolves to success:false, which is not evidence of anything.
     const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: statusUnavailable });
     expect(r.state).toBe('unknown');
+  });
+
+  it('does not trust stale successful status data once the read has failed', () => {
+    // TanStack retains the last good `data` while isError is true, so a stale
+    // "active" must not be read as current truth.
+    const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: active, accountStatusFailed: true });
+    expect(r.state).toBe('unknown');
+    expect(r.state).not.toBe('absent');
+  });
+
+  it('treats self-custody (not_found) as a definitive answer, not as unavailable', () => {
+    // keycast has no such account, so no keycast suspension can be hiding content.
+    // Calling this "unavailable" would contradict the account-type indicator.
+    const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: { success: false, not_found: true } });
+    expect(r.state).toBe('absent');
+    expect(r.message.toLowerCase()).toContain('self-custody');
   });
 });

--- a/src/lib/contentVisibility.test.ts
+++ b/src/lib/contentVisibility.test.ts
@@ -5,8 +5,18 @@ import type { AccountStatusResponse } from './adminApi';
 const active: AccountStatusResponse = { success: true, status: 'active' };
 const suspended: AccountStatusResponse = { success: true, status: 'suspended' };
 const banned: AccountStatusResponse = { success: true, status: 'banned' };
+const statusUnavailable: AccountStatusResponse = { success: false };
 
-const base = { postCount: 0, contentLoading: false, contentError: false, accountStatus: active };
+// Account status resolved successfully by default, so the absent-vs-unknown
+// distinction is only exercised when a test opts into it.
+const base = {
+  postCount: 0,
+  contentLoading: false,
+  contentError: false,
+  accountStatus: active,
+  accountStatusLoading: false,
+  accountStatusFailed: false,
+};
 
 describe('deriveContentVisibility', () => {
   it('loading while the content read is in flight', () => {
@@ -17,13 +27,13 @@ describe('deriveContentVisibility', () => {
     expect(deriveContentVisibility({ ...base, postCount: 3 }).state).toBe('has_content');
   });
 
-  it('suspended → hidden by suspension (verified, reversible)', () => {
+  it('suspended means hidden by suspension (verified, reversible)', () => {
     const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: suspended });
     expect(r.state).toBe('suspended');
     expect(r.message.toLowerCase()).toContain('suspension');
   });
 
-  it('banned → content removed', () => {
+  it('banned means content removed', () => {
     const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: banned });
     expect(r.state).toBe('banned');
     expect(r.message.toLowerCase()).toContain('banned');
@@ -36,18 +46,45 @@ describe('deriveContentVisibility', () => {
     expect(r.message.toLowerCase()).toContain("couldn't load");
   });
 
-  it('absent (confirmed empty, not suspended) is stated as such, not blamed on suspension', () => {
+  it('a truncated read is an error, not an absence', () => {
+    // NPool.query resolves partial results rather than throwing, so a cut-short
+    // read looks exactly like an empty one except for this flag.
+    const r = deriveContentVisibility({ ...base, postCount: 0, contentIncomplete: true });
+    expect(r.state).toBe('error');
+    expect(r.state).not.toBe('absent');
+  });
+
+  it('absent only when the read was clean and the account is known not suspended', () => {
     const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: active });
     expect(r.state).toBe('absent');
-    expect(r.message.toLowerCase()).toContain('not attributable to suspension');
+    expect(r.message.toLowerCase()).toContain('not suspended');
   });
 
   it('a confirmed suspended state wins over a content-read error (we know it is hidden)', () => {
     expect(deriveContentVisibility({ ...base, postCount: 0, contentError: true, accountStatus: suspended }).state).toBe('suspended');
   });
 
-  it('unknown account status + read error → error (do not claim suspension we cannot confirm)', () => {
+  it('unknown account status + read error means error (do not claim suspension we cannot confirm)', () => {
     const r = deriveContentVisibility({ ...base, postCount: undefined, contentError: true, accountStatus: undefined });
     expect(r.state).toBe('error');
+  });
+
+  it('does not rule out suspension when the status read failed', () => {
+    const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: statusUnavailable, accountStatusFailed: true });
+    expect(r.state).toBe('unknown');
+    expect(r.state).not.toBe('absent');
+    expect(r.message.toLowerCase()).toContain('cannot be ruled out');
+  });
+
+  it('does not rule out suspension while the status read is still in flight', () => {
+    const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: undefined, accountStatusLoading: true });
+    expect(r.state).toBe('unknown');
+    expect(r.state).not.toBe('absent');
+  });
+
+  it('does not rule out suspension when keycast answered without a status', () => {
+    // A keycast blip resolves to success:false, which is not evidence of anything.
+    const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: statusUnavailable });
+    expect(r.state).toBe('unknown');
   });
 });

--- a/src/lib/contentVisibility.test.ts
+++ b/src/lib/contentVisibility.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { deriveContentVisibility } from './contentVisibility';
+import type { AccountStatusResponse } from './adminApi';
+
+const active: AccountStatusResponse = { success: true, status: 'active' };
+const suspended: AccountStatusResponse = { success: true, status: 'suspended' };
+const banned: AccountStatusResponse = { success: true, status: 'banned' };
+
+const base = { postCount: 0, contentLoading: false, contentError: false, accountStatus: active };
+
+describe('deriveContentVisibility', () => {
+  it('loading while the content read is in flight', () => {
+    expect(deriveContentVisibility({ ...base, postCount: undefined, contentLoading: true }).state).toBe('loading');
+  });
+
+  it('has_content when there is visible content', () => {
+    expect(deriveContentVisibility({ ...base, postCount: 3 }).state).toBe('has_content');
+  });
+
+  it('suspended → hidden by suspension (verified, reversible)', () => {
+    const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: suspended });
+    expect(r.state).toBe('suspended');
+    expect(r.message.toLowerCase()).toContain('suspension');
+  });
+
+  it('banned → content removed', () => {
+    const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: banned });
+    expect(r.state).toBe('banned');
+    expect(r.message.toLowerCase()).toContain('banned');
+  });
+
+  it('error (non-suspended) surfaces the failure, never masked as absent', () => {
+    const r = deriveContentVisibility({ ...base, postCount: undefined, contentError: true, accountStatus: active });
+    expect(r.state).toBe('error');
+    expect(r.state).not.toBe('absent');
+    expect(r.message.toLowerCase()).toContain("couldn't load");
+  });
+
+  it('absent (confirmed empty, not suspended) is stated as such, not blamed on suspension', () => {
+    const r = deriveContentVisibility({ ...base, postCount: 0, accountStatus: active });
+    expect(r.state).toBe('absent');
+    expect(r.message.toLowerCase()).toContain('not attributable to suspension');
+  });
+
+  it('a confirmed suspended state wins over a content-read error (we know it is hidden)', () => {
+    expect(deriveContentVisibility({ ...base, postCount: 0, contentError: true, accountStatus: suspended }).state).toBe('suspended');
+  });
+
+  it('unknown account status + read error → error (do not claim suspension we cannot confirm)', () => {
+    const r = deriveContentVisibility({ ...base, postCount: undefined, contentError: true, accountStatus: undefined });
+    expect(r.state).toBe('error');
+  });
+});

--- a/src/lib/contentVisibility.ts
+++ b/src/lib/contentVisibility.ts
@@ -9,6 +9,7 @@ export type ContentVisibility =
   | 'banned'
   | 'absent'
   | 'error'
+  | 'unknown'
   | 'loading';
 
 export interface ContentVisibilityInput {
@@ -16,8 +17,16 @@ export interface ContentVisibilityInput {
   postCount: number | undefined;
   contentLoading: boolean;
   contentError: boolean;
+  // The relay read resolved but was cut short, so postCount understates and a
+  // zero count proves nothing (NPool.query returns partial results on failure).
+  contentIncomplete?: boolean;
   // Keycast account status — the verified source for suspended/banned.
   accountStatus: AccountStatusResponse | undefined;
+  // Whether that status is actually known yet. Without these, an in-flight or
+  // failed status read silently becomes "not suspended", which is how "not
+  // attributable to suspension" gets asserted about an account we never checked.
+  accountStatusLoading?: boolean;
+  accountStatusFailed?: boolean;
 }
 
 export interface ContentVisibilityResult {
@@ -26,7 +35,15 @@ export interface ContentVisibilityResult {
 }
 
 export function deriveContentVisibility(input: ContentVisibilityInput): ContentVisibilityResult {
-  const { postCount, contentLoading, contentError, accountStatus } = input;
+  const {
+    postCount,
+    contentLoading,
+    contentError,
+    contentIncomplete,
+    accountStatus,
+    accountStatusLoading,
+    accountStatusFailed,
+  } = input;
 
   if (contentLoading && postCount === undefined) {
     return { state: 'loading', message: 'Checking for content…' };
@@ -38,15 +55,29 @@ export function deriveContentVisibility(input: ContentVisibilityInput): ContentV
   // No visible content. Attribute the invisibility to a *verified* cause, in order:
   // a confirmed suspend/ban explains it definitively (content is hidden/removed
   // regardless of the read result); otherwise a failed read is surfaced as an
-  // error (never claimed as "absent"); only a clean, empty read is "absent".
+  // error (never claimed as "absent"); only a clean, complete, empty read against
+  // a known-unsuspended account is "absent".
   if (accountStatus?.status === 'suspended') {
     return { state: 'suspended', message: 'Content hidden by suspension (reversible; visible again if cleared).' };
   }
   if (accountStatus?.status === 'banned') {
     return { state: 'banned', message: 'Content removed (account banned).' };
   }
-  if (contentError) {
-    return { state: 'error', message: "Couldn't load this account's content (relay error) — retry." };
+  if (contentError || contentIncomplete) {
+    return { state: 'error', message: "Couldn't load this account's content (relay error). Retry." };
   }
-  return { state: 'absent', message: 'No content found on the relay — not attributable to suspension.' };
+
+  // The read was clean and empty, but "absent" is only honest if we also know the
+  // account is not suspended. If that status is unknown, say so rather than
+  // ruling out a cause we never checked.
+  const statusKnown =
+    !accountStatusLoading && !accountStatusFailed && accountStatus?.success === true;
+  if (!statusKnown) {
+    return {
+      state: 'unknown',
+      message: 'No content found on the relay. Account status is unavailable, so suspension cannot be ruled out.',
+    };
+  }
+
+  return { state: 'absent', message: 'No content found on the relay, and the account is not suspended.' };
 }

--- a/src/lib/contentVisibility.ts
+++ b/src/lib/contentVisibility.ts
@@ -22,12 +22,6 @@ export interface ContentVisibilityInput {
   contentIncomplete?: boolean;
   // Keycast account status — the verified source for suspended/banned.
   accountStatus: AccountStatusResponse | undefined;
-  // Whether the status read failed. Needed because TanStack keeps the last
-  // successful `data` while `isError` is true after a failed refetch, so without
-  // this a stale success would be treated as current and "not suspended" would be
-  // asserted from an answer we no longer trust. An in-flight read needs no flag:
-  // it has no `accountStatus` yet, which is already treated as not-known below.
-  accountStatusFailed?: boolean;
 }
 
 export interface ContentVisibilityResult {
@@ -42,7 +36,6 @@ export function deriveContentVisibility(input: ContentVisibilityInput): ContentV
     contentError,
     contentIncomplete,
     accountStatus,
-    accountStatusFailed,
   } = input;
 
   if (contentLoading && postCount === undefined) {
@@ -57,18 +50,17 @@ export function deriveContentVisibility(input: ContentVisibilityInput): ContentV
   // regardless of the read result); otherwise a failed read is surfaced as an
   // error (never claimed as "absent"); only a clean, complete, empty read against
   // a known-unsuspended account is "absent".
-  // Only attribute to enforcement while the status is still trusted. TanStack
-  // keeps the last successful data after a failed refetch, so without this gate
-  // a lifted suspension could keep being blamed, and this section would assert a
-  // suspension while the reported-content section above says the status is
-  // unavailable. Both halves of the pane must reach the same conclusion.
-  if (!accountStatusFailed) {
-    if (accountStatus?.status === 'suspended') {
-      return { state: 'suspended', message: 'Content hidden by suspension (reversible; visible again if cleared).' };
-    }
-    if (accountStatus?.status === 'banned') {
-      return { state: 'banned', message: 'Content removed (account banned).' };
-    }
+  // Data-first, matching deriveAccountVerdict, which renders directly above this
+  // and states the same enforcement. A cached success that a later refetch failed
+  // to renew is still the last thing keycast actually told us, and having one
+  // panel assert a suspension while the card beneath it says the status is
+  // unavailable is worse than either answer alone. The two must agree, so this
+  // follows the policy already shipped rather than inventing a second one.
+  if (accountStatus?.status === 'suspended') {
+    return { state: 'suspended', message: 'Content hidden by suspension (reversible; visible again if cleared).' };
+  }
+  if (accountStatus?.status === 'banned') {
+    return { state: 'banned', message: 'Content removed (account banned).' };
   }
   if (contentError || contentIncomplete) {
     return { state: 'error', message: "Couldn't load this account's content (relay error). Retry." };
@@ -82,9 +74,11 @@ export function deriveContentVisibility(input: ContentVisibilityInput): ContentV
   // account, so it is self-custody and no keycast suspension can be hiding
   // anything. The rest of this screen already treats it that way, and calling it
   // "unavailable" here would contradict the account-type indicator beside it.
-  const statusIsDefinitive =
+  // Data-first here too: a definitive answer stays definitive even if a later
+  // refetch failed. A read that has never succeeded leaves accountStatus
+  // undefined, which falls through to unknown without needing a separate flag.
+  const statusKnown =
     accountStatus?.success === true || accountStatus?.not_found === true;
-  const statusKnown = !accountStatusFailed && statusIsDefinitive;
   if (!statusKnown) {
     return {
       state: 'unknown',

--- a/src/lib/contentVisibility.ts
+++ b/src/lib/contentVisibility.ts
@@ -57,11 +57,18 @@ export function deriveContentVisibility(input: ContentVisibilityInput): ContentV
   // regardless of the read result); otherwise a failed read is surfaced as an
   // error (never claimed as "absent"); only a clean, complete, empty read against
   // a known-unsuspended account is "absent".
-  if (accountStatus?.status === 'suspended') {
-    return { state: 'suspended', message: 'Content hidden by suspension (reversible; visible again if cleared).' };
-  }
-  if (accountStatus?.status === 'banned') {
-    return { state: 'banned', message: 'Content removed (account banned).' };
+  // Only attribute to enforcement while the status is still trusted. TanStack
+  // keeps the last successful data after a failed refetch, so without this gate
+  // a lifted suspension could keep being blamed, and this section would assert a
+  // suspension while the reported-content section above says the status is
+  // unavailable. Both halves of the pane must reach the same conclusion.
+  if (!accountStatusFailed) {
+    if (accountStatus?.status === 'suspended') {
+      return { state: 'suspended', message: 'Content hidden by suspension (reversible; visible again if cleared).' };
+    }
+    if (accountStatus?.status === 'banned') {
+      return { state: 'banned', message: 'Content removed (account banned).' };
+    }
   }
   if (contentError || contentIncomplete) {
     return { state: 'error', message: "Couldn't load this account's content (relay error). Retry." };

--- a/src/lib/contentVisibility.ts
+++ b/src/lib/contentVisibility.ts
@@ -22,10 +22,11 @@ export interface ContentVisibilityInput {
   contentIncomplete?: boolean;
   // Keycast account status — the verified source for suspended/banned.
   accountStatus: AccountStatusResponse | undefined;
-  // Whether that status is actually known yet. Without these, an in-flight or
-  // failed status read silently becomes "not suspended", which is how "not
-  // attributable to suspension" gets asserted about an account we never checked.
-  accountStatusLoading?: boolean;
+  // Whether the status read failed. Needed because TanStack keeps the last
+  // successful `data` while `isError` is true after a failed refetch, so without
+  // this a stale success would be treated as current and "not suspended" would be
+  // asserted from an answer we no longer trust. An in-flight read needs no flag:
+  // it has no `accountStatus` yet, which is already treated as not-known below.
   accountStatusFailed?: boolean;
 }
 
@@ -41,7 +42,6 @@ export function deriveContentVisibility(input: ContentVisibilityInput): ContentV
     contentError,
     contentIncomplete,
     accountStatus,
-    accountStatusLoading,
     accountStatusFailed,
   } = input;
 
@@ -70,12 +70,25 @@ export function deriveContentVisibility(input: ContentVisibilityInput): ContentV
   // The read was clean and empty, but "absent" is only honest if we also know the
   // account is not suspended. If that status is unknown, say so rather than
   // ruling out a cause we never checked.
-  const statusKnown =
-    !accountStatusLoading && !accountStatusFailed && accountStatus?.success === true;
+  //
+  // `not_found` is a definitive answer, not a failure: keycast has no such
+  // account, so it is self-custody and no keycast suspension can be hiding
+  // anything. The rest of this screen already treats it that way, and calling it
+  // "unavailable" here would contradict the account-type indicator beside it.
+  const statusIsDefinitive =
+    accountStatus?.success === true || accountStatus?.not_found === true;
+  const statusKnown = !accountStatusFailed && statusIsDefinitive;
   if (!statusKnown) {
     return {
       state: 'unknown',
       message: 'No content found on the relay. Account status is unavailable, so suspension cannot be ruled out.',
+    };
+  }
+
+  if (accountStatus?.not_found === true) {
+    return {
+      state: 'absent',
+      message: 'No content found on the relay. This is a self-custody account, so it cannot be suspended in keycast.',
     };
   }
 

--- a/src/lib/contentVisibility.ts
+++ b/src/lib/contentVisibility.ts
@@ -1,0 +1,52 @@
+// ABOUTME: Pure derivation of why an age-review target's content is or isn't
+// ABOUTME: visible, attributing invisibility only to a verified cause (never a
+// ABOUTME: guess, never masking an error as absent). No I/O.
+import type { AccountStatusResponse } from './adminApi';
+
+export type ContentVisibility =
+  | 'has_content'
+  | 'suspended'
+  | 'banned'
+  | 'absent'
+  | 'error'
+  | 'loading';
+
+export interface ContentVisibilityInput {
+  // Count of the target's recent relay-visible content (undefined until the read resolves).
+  postCount: number | undefined;
+  contentLoading: boolean;
+  contentError: boolean;
+  // Keycast account status — the verified source for suspended/banned.
+  accountStatus: AccountStatusResponse | undefined;
+}
+
+export interface ContentVisibilityResult {
+  state: ContentVisibility;
+  message: string; // '' for has_content; the "why not visible" reason otherwise
+}
+
+export function deriveContentVisibility(input: ContentVisibilityInput): ContentVisibilityResult {
+  const { postCount, contentLoading, contentError, accountStatus } = input;
+
+  if (contentLoading && postCount === undefined) {
+    return { state: 'loading', message: 'Checking for content…' };
+  }
+  if ((postCount ?? 0) > 0) {
+    return { state: 'has_content', message: '' };
+  }
+
+  // No visible content. Attribute the invisibility to a *verified* cause, in order:
+  // a confirmed suspend/ban explains it definitively (content is hidden/removed
+  // regardless of the read result); otherwise a failed read is surfaced as an
+  // error (never claimed as "absent"); only a clean, empty read is "absent".
+  if (accountStatus?.status === 'suspended') {
+    return { state: 'suspended', message: 'Content hidden by suspension (reversible; visible again if cleared).' };
+  }
+  if (accountStatus?.status === 'banned') {
+    return { state: 'banned', message: 'Content removed (account banned).' };
+  }
+  if (contentError) {
+    return { state: 'error', message: "Couldn't load this account's content (relay error) — retry." };
+  }
+  return { state: 'absent', message: 'No content found on the relay — not attributable to suspension.' };
+}

--- a/src/lib/contentVisibility.ts
+++ b/src/lib/contentVisibility.ts
@@ -22,6 +22,13 @@ export interface ContentVisibilityInput {
   contentIncomplete?: boolean;
   // Keycast account status — the verified source for suspended/banned.
   accountStatus: AccountStatusResponse | undefined;
+  /**
+   * The status refetch failed while cached data was retained. This changes the
+   * *message* only, never the state: the state stays data-first so this card and
+   * the account panel above it cannot contradict each other, while the moderator
+   * still learns the answer may be minutes old rather than current.
+   */
+  accountStatusFailed?: boolean;
 }
 
 export interface ContentVisibilityResult {
@@ -36,6 +43,7 @@ export function deriveContentVisibility(input: ContentVisibilityInput): ContentV
     contentError,
     contentIncomplete,
     accountStatus,
+    accountStatusFailed,
   } = input;
 
   if (contentLoading && postCount === undefined) {
@@ -56,11 +64,17 @@ export function deriveContentVisibility(input: ContentVisibilityInput): ContentV
   // panel assert a suspension while the card beneath it says the status is
   // unavailable is worse than either answer alone. The two must agree, so this
   // follows the policy already shipped rather than inventing a second one.
+  // Appended, not substituted: the claim still stands on the last definitive
+  // answer, but an answer we could not refresh is marked as such.
+  const stale = accountStatusFailed
+    ? ' Status could not be refreshed just now, so this is the last answer keycast gave.'
+    : '';
+
   if (accountStatus?.status === 'suspended') {
-    return { state: 'suspended', message: 'Content hidden by suspension (reversible; visible again if cleared).' };
+    return { state: 'suspended', message: `Content hidden by suspension (reversible; visible again if cleared).${stale}` };
   }
   if (accountStatus?.status === 'banned') {
-    return { state: 'banned', message: 'Content removed (account banned).' };
+    return { state: 'banned', message: `Content removed (account banned).${stale}` };
   }
   if (contentError || contentIncomplete) {
     return { state: 'error', message: "Couldn't load this account's content (relay error). Retry." };
@@ -89,9 +103,9 @@ export function deriveContentVisibility(input: ContentVisibilityInput): ContentV
   if (accountStatus?.not_found === true) {
     return {
       state: 'absent',
-      message: 'No content found on the relay. This is a self-custody account, so it cannot be suspended in keycast.',
+      message: `No content found on the relay. This is a self-custody account, so it cannot be suspended in keycast.${stale}`,
     };
   }
 
-  return { state: 'absent', message: 'No content found on the relay, and the account is not suspended.' };
+  return { state: 'absent', message: `No content found on the relay, and the account is not suspended.${stale}` };
 }

--- a/src/lib/relayRead.test.ts
+++ b/src/lib/relayRead.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { assertRelayReadCompleted, isDefinitiveRpcNegative } from './relayRead';
+import { ApiError } from './adminApi';
+
+function aborted(): AbortSignal {
+  const c = new AbortController();
+  c.abort();
+  return c.signal;
+}
+const live = () => new AbortController().signal;
+
+describe('assertRelayReadCompleted', () => {
+  it('throws when our timeout fired, so an empty result is not read as absence', () => {
+    expect(() => assertRelayReadCompleted(aborted(), live())).toThrow(/timed out/i);
+  });
+
+  it('does not throw when the read completed normally', () => {
+    expect(() => assertRelayReadCompleted(live(), live())).not.toThrow();
+  });
+
+  it('stays silent when the query itself was cancelled', () => {
+    // Unmount or key change aborts TanStack's signal; that is not a failure to
+    // report, and throwing would surface a spurious error to the moderator.
+    expect(() => assertRelayReadCompleted(aborted(), aborted())).not.toThrow();
+  });
+});
+
+describe('isDefinitiveRpcNegative', () => {
+  it('accepts the relay answering "not banned" (no HTTP status)', () => {
+    expect(isDefinitiveRpcNegative(new ApiError('Event not found or not banned'))).toBe(true);
+  });
+
+  it('rejects a transport or auth failure, which must not read as a negative', () => {
+    expect(isDefinitiveRpcNegative(new ApiError('Forbidden', 403, 'Forbidden'))).toBe(false);
+    expect(isDefinitiveRpcNegative(new ApiError('Internal Server Error', 500, 'ISE'))).toBe(false);
+  });
+
+  it('rejects an unrecognised relay-side failure rather than assuming a negative', () => {
+    expect(isDefinitiveRpcNegative(new ApiError('database unavailable'))).toBe(false);
+  });
+
+  it('rejects non-ApiError failures (network, abort)', () => {
+    expect(isDefinitiveRpcNegative(new Error('Failed to fetch'))).toBe(false);
+    expect(isDefinitiveRpcNegative(undefined)).toBe(false);
+  });
+});

--- a/src/lib/relayRead.test.ts
+++ b/src/lib/relayRead.test.ts
@@ -36,9 +36,10 @@ describe('queryStrict', () => {
   it('throws when the relay CLOSES the subscription', async () => {
     // Funnelcake sends CLOSED with "could not complete query" when its query
     // layer degrades. NPool.query would swallow this and return [], which is
-    // indistinguishable from an empty account.
+    // indistinguishable from an empty account. Assert the message, not just the
+    // type, or turning this throw into a break still passes via the EOSE check.
     const relay = fakeRelay([['CLOSED', 'sub', 'error: could not complete query']]);
-    await expect(queryStrict(relay, [{ ids: ['a'] }], opts())).rejects.toBeInstanceOf(RelayReadError);
+    await expect(queryStrict(relay, [{ ids: ['a'] }], opts())).rejects.toThrow(/closed the subscription/i);
   });
 
   it('throws when the stream ends without EOSE', async () => {
@@ -76,6 +77,20 @@ describe('isDefinitiveRpcNegative', () => {
 
   it('rejects an unrecognised relay-side failure rather than assuming a negative', () => {
     expect(isDefinitiveRpcNegative(new ApiError('database unavailable', 400, 'Bad Request'))).toBe(false);
+  });
+
+  it('rejects a management-endpoint 404, which the worker also delivers as a 400', () => {
+    // callNip86Rpc renders any non-ok relay response as "Relay error: <status>
+    // <text>" and handleRelayRpc returns every failure as HTTP 400. A loose
+    // match would read this as "not banned" and report a deletion during an
+    // outage, which is the failure this whole module exists to prevent.
+    expect(isDefinitiveRpcNegative(new ApiError('Relay error: 404 Not Found', 400, 'Bad Request'))).toBe(false);
+  });
+
+  it('rejects the relay sentence when it arrives with a non-400 status', () => {
+    // Exercises the status gate independently of the message, so neither check
+    // can be removed without a test noticing.
+    expect(isDefinitiveRpcNegative(new ApiError('Event not found or not banned', 500, 'ISE'))).toBe(false);
   });
 
   it('rejects non-ApiError failures (network, abort)', () => {

--- a/src/lib/relayRead.test.ts
+++ b/src/lib/relayRead.test.ts
@@ -9,7 +9,6 @@ function ev(id: string) {
 /** A relay whose stream yields exactly the given messages, then ends. */
 function fakeRelay(msgs: Array<[string, ...unknown[]]>): ReqCapable {
   return {
-    // eslint-disable-next-line require-yield
     async *req() {
       for (const m of msgs) yield m;
     },

--- a/src/lib/relayRead.test.ts
+++ b/src/lib/relayRead.test.ts
@@ -1,42 +1,81 @@
 import { describe, it, expect } from 'vitest';
-import { assertRelayReadCompleted, isDefinitiveRpcNegative } from './relayRead';
+import { queryStrict, isDefinitiveRpcNegative, RelayReadError, type ReqCapable } from './relayRead';
 import { ApiError } from './adminApi';
 
-function aborted(): AbortSignal {
-  const c = new AbortController();
-  c.abort();
-  return c.signal;
+function ev(id: string) {
+  return { id, pubkey: 'd4'.repeat(32), created_at: 1, kind: 1, tags: [], content: '', sig: '' };
 }
-const live = () => new AbortController().signal;
 
-describe('assertRelayReadCompleted', () => {
-  it('throws when our timeout fired, so an empty result is not read as absence', () => {
-    expect(() => assertRelayReadCompleted(aborted(), live())).toThrow(/timed out/i);
+/** A relay whose stream yields exactly the given messages, then ends. */
+function fakeRelay(msgs: Array<[string, ...unknown[]]>): ReqCapable {
+  return {
+    // eslint-disable-next-line require-yield
+    async *req() {
+      for (const m of msgs) yield m;
+    },
+  } as ReqCapable;
+}
+
+const opts = () => ({ signal: new AbortController().signal, timeoutMs: 1000 });
+
+describe('queryStrict', () => {
+  it('returns events once the relay signals EOSE', async () => {
+    const relay = fakeRelay([
+      ['EVENT', 'sub', ev('a')],
+      ['EVENT', 'sub', ev('b')],
+      ['EOSE', 'sub'],
+    ]);
+    await expect(queryStrict(relay, [{ ids: ['a'] }], opts())).resolves.toHaveLength(2);
   });
 
-  it('does not throw when the read completed normally', () => {
-    expect(() => assertRelayReadCompleted(live(), live())).not.toThrow();
+  it('returns an empty result for a genuinely empty relay (EOSE, no events)', async () => {
+    const relay = fakeRelay([['EOSE', 'sub']]);
+    await expect(queryStrict(relay, [{ ids: ['a'] }], opts())).resolves.toEqual([]);
   });
 
-  it('stays silent when the query itself was cancelled', () => {
-    // Unmount or key change aborts TanStack's signal; that is not a failure to
-    // report, and throwing would surface a spurious error to the moderator.
-    expect(() => assertRelayReadCompleted(aborted(), aborted())).not.toThrow();
+  it('throws when the relay CLOSES the subscription', async () => {
+    // Funnelcake sends CLOSED with "could not complete query" when its query
+    // layer degrades. NPool.query would swallow this and return [], which is
+    // indistinguishable from an empty account.
+    const relay = fakeRelay([['CLOSED', 'sub', 'error: could not complete query']]);
+    await expect(queryStrict(relay, [{ ids: ['a'] }], opts())).rejects.toBeInstanceOf(RelayReadError);
+  });
+
+  it('throws when the stream ends without EOSE', async () => {
+    // NPool.req returns immediately when no relay is routed to, and an aborted
+    // read simply stops. Neither established what the relay holds.
+    const relay = fakeRelay([]);
+    await expect(queryStrict(relay, [{ ids: ['a'] }], opts())).rejects.toBeInstanceOf(RelayReadError);
+  });
+
+  it('does not treat events received before a CLOSE as a complete read', async () => {
+    const relay = fakeRelay([
+      ['EVENT', 'sub', ev('a')],
+      ['CLOSED', 'sub', 'error: stored replay timed out'],
+    ]);
+    await expect(queryStrict(relay, [{ ids: ['a'] }], opts())).rejects.toBeInstanceOf(RelayReadError);
   });
 });
 
 describe('isDefinitiveRpcNegative', () => {
-  it('accepts the relay answering "not banned" (no HTTP status)', () => {
+  it('accepts the production shape of "not banned" (HTTP 400)', () => {
+    // Verified end to end: the relay answers success:false and the worker
+    // returns it as HTTP 400, so the ApiError DOES carry a status code.
+    expect(isDefinitiveRpcNegative(new ApiError('Event not found or not banned', 400, 'Bad Request'))).toBe(true);
+  });
+
+  it('accepts a statusless RPC-level negative', () => {
     expect(isDefinitiveRpcNegative(new ApiError('Event not found or not banned'))).toBe(true);
   });
 
-  it('rejects a transport or auth failure, which must not read as a negative', () => {
+  it('rejects auth and server failures, which must not read as a negative', () => {
+    expect(isDefinitiveRpcNegative(new ApiError('Unauthorized', 401, 'Unauthorized'))).toBe(false);
     expect(isDefinitiveRpcNegative(new ApiError('Forbidden', 403, 'Forbidden'))).toBe(false);
     expect(isDefinitiveRpcNegative(new ApiError('Internal Server Error', 500, 'ISE'))).toBe(false);
   });
 
   it('rejects an unrecognised relay-side failure rather than assuming a negative', () => {
-    expect(isDefinitiveRpcNegative(new ApiError('database unavailable'))).toBe(false);
+    expect(isDefinitiveRpcNegative(new ApiError('database unavailable', 400, 'Bad Request'))).toBe(false);
   });
 
   it('rejects non-ApiError failures (network, abort)', () => {

--- a/src/lib/relayRead.test.ts
+++ b/src/lib/relayRead.test.ts
@@ -42,6 +42,26 @@ describe('queryStrict', () => {
     await expect(queryStrict(relay, [{ ids: ['a'] }], opts())).rejects.toThrow(/closed the subscription/i);
   });
 
+  it('rejects rather than resolving when the read times out', async () => {
+    // The live failure path. A relay that stops responding (or closes, which
+    // NRelay1 swallows) hangs until our timeout aborts the iterator, and the
+    // abort must surface as a rejection. If it ever resolved instead, an empty
+    // result would be reported to a moderator as "no content found".
+    const hanging: ReqCapable = {
+      async *req(_filters, opts) {
+        await new Promise((_resolve, reject) => {
+          opts?.signal?.addEventListener('abort', () =>
+            reject(new DOMException('The signal has been aborted', 'AbortError')));
+        });
+        yield ['EOSE', 'sub'] as [string, ...unknown[]]; // unreachable
+      },
+    } as ReqCapable;
+
+    await expect(
+      queryStrict(hanging, [{ ids: ['a'] }], { signal: new AbortController().signal, timeoutMs: 50 }),
+    ).rejects.toThrow();
+  });
+
   it('throws when the stream ends without EOSE', async () => {
     // NPool.req returns immediately when no relay is routed to, and an aborted
     // read simply stops. Neither established what the relay holds.

--- a/src/lib/relayRead.ts
+++ b/src/lib/relayRead.ts
@@ -51,6 +51,11 @@ export async function queryStrict(
       complete = true;
       break;
     } else if (msg[0] === 'CLOSED') {
+      // Defensive rather than hot: NRelay1 currently breaks on CLOSED without
+      // forwarding it, so in practice a relay-side close surfaces here as the
+      // timeout below (an AbortError) rather than through this branch. CLOSED is
+      // part of the message contract and the typings advertise it, so handle it
+      // explicitly instead of relying on that implementation detail.
       throw new RelayReadError('Relay closed the subscription before the read completed');
     }
   }

--- a/src/lib/relayRead.ts
+++ b/src/lib/relayRead.ts
@@ -1,0 +1,45 @@
+// ABOUTME: Helpers for telling a completed relay read apart from a failed one.
+// ABOUTME: NPool.query swallows relay errors and resolves with partial results,
+// ABOUTME: so an empty array means "nothing found" AND "the read never worked".
+// ABOUTME: Callers that report absence to a moderator must not conflate those.
+import { ApiError } from './adminApi';
+
+/**
+ * Throws when a relay read was cut short by our own timeout rather than
+ * completing.
+ *
+ * `NPool.query` documents that it "will return partial results instead of
+ * throwing" and wraps its read loop in a bare catch, so a dead or slow relay
+ * resolves to `[]` exactly like a genuinely empty result. Without this check a
+ * failed read is indistinguishable from a verified absence, and any UI that
+ * says "no content found" is making a claim it never established.
+ *
+ * `querySignal` is TanStack Query's own signal: if that aborted, the query was
+ * cancelled (unmount, key change) and there is no failure to report.
+ */
+export function assertRelayReadCompleted(
+  timeoutSignal: AbortSignal,
+  querySignal: AbortSignal,
+): void {
+  if (timeoutSignal.aborted && !querySignal.aborted) {
+    throw new Error('Relay read timed out before completing');
+  }
+}
+
+/**
+ * True when a `callRelayRpc` rejection is the relay definitively answering "no"
+ * rather than us failing to ask.
+ *
+ * `getbannedevent` on an event that is not banned returns
+ * `{"success":false,"error":"Event not found or not banned"}` (verified against
+ * the live relay), which `callRelayRpc` surfaces as an `ApiError` with no HTTP
+ * status. An `ApiError` that *does* carry a status is a transport or auth
+ * failure (expired CF Access, worker 5xx), and any other error is unknown.
+ * Both of those must propagate: reporting them as "not banned" would let a
+ * moderator read an outage as a deletion.
+ */
+export function isDefinitiveRpcNegative(error: unknown): boolean {
+  if (!(error instanceof ApiError)) return false;
+  if (error.statusCode !== undefined) return false;
+  return /not found|not banned/i.test(error.message);
+}

--- a/src/lib/relayRead.ts
+++ b/src/lib/relayRead.ts
@@ -1,45 +1,84 @@
-// ABOUTME: Helpers for telling a completed relay read apart from a failed one.
-// ABOUTME: NPool.query swallows relay errors and resolves with partial results,
-// ABOUTME: so an empty array means "nothing found" AND "the read never worked".
-// ABOUTME: Callers that report absence to a moderator must not conflate those.
+// ABOUTME: Relay reads that fail loudly, for callers that report absence to a
+// ABOUTME: moderator. NPool.query swallows relay errors and resolves with partial
+// ABOUTME: results, so an empty array means both "nothing found" and "the read
+// ABOUTME: never worked". Anything that says "no content" must tell those apart.
+import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
 import { ApiError } from './adminApi';
 
-/**
- * Throws when a relay read was cut short by our own timeout rather than
- * completing.
- *
- * `NPool.query` documents that it "will return partial results instead of
- * throwing" and wraps its read loop in a bare catch, so a dead or slow relay
- * resolves to `[]` exactly like a genuinely empty result. Without this check a
- * failed read is indistinguishable from a verified absence, and any UI that
- * says "no content found" is making a claim it never established.
- *
- * `querySignal` is TanStack Query's own signal: if that aborted, the query was
- * cancelled (unmount, key change) and there is no failure to report.
- */
-export function assertRelayReadCompleted(
-  timeoutSignal: AbortSignal,
-  querySignal: AbortSignal,
-): void {
-  if (timeoutSignal.aborted && !querySignal.aborted) {
-    throw new Error('Relay read timed out before completing');
+/** The slice of NPool that queryStrict needs, kept structural so it is testable. */
+export interface ReqCapable {
+  req(
+    filters: NostrFilter[],
+    opts?: { signal?: AbortSignal },
+  ): AsyncIterable<[string, ...unknown[]]>;
+}
+
+export class RelayReadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RelayReadError';
   }
+}
+
+/**
+ * Reads events and treats anything other than a completed read as an error.
+ *
+ * `NPool.query` is unusable for this: it documents that it "will return partial
+ * results instead of throwing", breaks out of its loop on `CLOSED`, wraps
+ * everything in a bare catch, and returns immediately when no relay routes
+ * match. Every one of those paths yields `[]`, indistinguishable from a genuine
+ * absence. Funnelcake closes subscriptions with "could not complete query" when
+ * its query layer degrades, so this is a live path, not a theoretical one.
+ *
+ * Driving `req` directly lets us insist on the one signal that actually means
+ * "the relay finished answering": EOSE.
+ */
+export async function queryStrict(
+  nostr: ReqCapable,
+  filters: NostrFilter[],
+  opts: { signal: AbortSignal; timeoutMs: number },
+): Promise<NostrEvent[]> {
+  const timeout = AbortSignal.timeout(opts.timeoutMs);
+  const combined = AbortSignal.any([opts.signal, timeout]);
+
+  const events: NostrEvent[] = [];
+  let complete = false;
+
+  for await (const msg of nostr.req(filters, { signal: combined })) {
+    if (msg[0] === 'EVENT') {
+      events.push(msg[2] as NostrEvent);
+    } else if (msg[0] === 'EOSE') {
+      complete = true;
+      break;
+    } else if (msg[0] === 'CLOSED') {
+      throw new RelayReadError('Relay closed the subscription before the read completed');
+    }
+  }
+
+  // No EOSE: timed out, aborted, or no relay was routed to at all. Whatever the
+  // cause, we did not establish what the relay holds, so we must not answer.
+  if (!complete) {
+    throw new RelayReadError('Relay read did not complete');
+  }
+
+  return events;
 }
 
 /**
  * True when a `callRelayRpc` rejection is the relay definitively answering "no"
  * rather than us failing to ask.
  *
- * `getbannedevent` on an event that is not banned returns
- * `{"success":false,"error":"Event not found or not banned"}` (verified against
- * the live relay), which `callRelayRpc` surfaces as an `ApiError` with no HTTP
- * status. An `ApiError` that *does* carry a status is a transport or auth
- * failure (expired CF Access, worker 5xx), and any other error is unknown.
- * Both of those must propagate: reporting them as "not banned" would let a
- * moderator read an outage as a deletion.
+ * `getbannedevent` for an event that is not banned answers
+ * `{"success":false,"error":"Event not found or not banned"}`, which the worker
+ * returns as **HTTP 400** (verified end to end against production, including the
+ * status code). So a 400 means the relay was reached and refused; the message
+ * distinguishes this refusal from some other relay-side failure. A 401/403/5xx,
+ * or any non-ApiError, means we never got an answer, and reporting that as
+ * "not banned" would let a moderator read an outage as a deletion.
  */
 export function isDefinitiveRpcNegative(error: unknown): boolean {
   if (!(error instanceof ApiError)) return false;
-  if (error.statusCode !== undefined) return false;
+  const reachedRelay = error.statusCode === undefined || error.statusCode === 400;
+  if (!reachedRelay) return false;
   return /not found|not banned/i.test(error.message);
 }

--- a/src/lib/relayRead.ts
+++ b/src/lib/relayRead.ts
@@ -55,8 +55,10 @@ export async function queryStrict(
     }
   }
 
-  // No EOSE: timed out, aborted, or no relay was routed to at all. Whatever the
-  // cause, we did not establish what the relay holds, so we must not answer.
+  // No EOSE and no CLOSED. In practice this is the no-route case: an aborted or
+  // timed-out read does not fall through here, it throws AbortError out of the
+  // iterator (NPool's Machina rejects on abort). Either way we never established
+  // what the relay holds, so we must not answer.
   if (!complete) {
     throw new RelayReadError('Relay read did not complete');
   }
@@ -65,20 +67,33 @@ export async function queryStrict(
 }
 
 /**
+ * The relay's verbatim answer when an event exists but is not banned. Source:
+ * funnelcake `crates/clickhouse/src/management.rs` ("Event not found or not
+ * banned"). Anchored deliberately, see below.
+ */
+const RELAY_NOT_BANNED = /^event not found or not banned$/i;
+
+/**
  * True when a `callRelayRpc` rejection is the relay definitively answering "no"
  * rather than us failing to ask.
  *
- * `getbannedevent` for an event that is not banned answers
- * `{"success":false,"error":"Event not found or not banned"}`, which the worker
- * returns as **HTTP 400** (verified end to end against production, including the
- * status code). So a 400 means the relay was reached and refused; the message
- * distinguishes this refusal from some other relay-side failure. A 401/403/5xx,
- * or any non-ApiError, means we never got an answer, and reporting that as
- * "not banned" would let a moderator read an outage as a deletion.
+ * The HTTP status cannot be used to tell those apart. The worker collapses
+ * *every* management-RPC failure into HTTP 400 (`handleRelayRpc`), and turns any
+ * non-ok response from the relay into the prose `Relay error: <status> <text>`
+ * (`callNip86Rpc`). So a misrouted management URL arrives here as
+ * `ApiError("Relay error: 404 Not Found", 400)`: a 400 whose message contains
+ * "not found", indistinguishable by shape from a real negative.
+ *
+ * Hence an exact match on the relay's own sentence and nothing else. The failure
+ * mode matters: if the relay ever rewords it, this returns false, the error
+ * propagates, and the moderator sees "couldn't load" instead of "not
+ * retrievable". That is the safe direction. Loose matching fails the other way,
+ * telling a moderator content was deleted when the relay was simply unreachable.
  */
 export function isDefinitiveRpcNegative(error: unknown): boolean {
   if (!(error instanceof ApiError)) return false;
-  const reachedRelay = error.statusCode === undefined || error.statusCode === 400;
-  if (!reachedRelay) return false;
-  return /not found|not banned/i.test(error.message);
+  // Belt and braces: the relay's negative is delivered as a 400 (or, for a
+  // non-HTTP RPC failure, with no status at all). Anything else is not it.
+  if (error.statusCode !== undefined && error.statusCode !== 400) return false;
+  return RELAY_NOT_BANNED.test(error.message.trim());
 }


### PR DESCRIPTION
## Summary

Moderators reviewing an age case could not see the content they were deciding on. This surfaces it in the case pane using only the admin-authorized read paths that already exist, and when content cannot be shown it says why, from a verified cause rather than a guess.

- **Reported content**: `report_id` holds the kind-1984 report's own id, not the id of what was reported, so resolution is two hops. Fetch the report, read its target from the tags, then fetch that event, falling back to `getbannedevent` so a banned post still shows (badged "removed (banned)").
- **Account's recent posts**: rendered through the existing `MediaPreview` (click-to-reveal; its media-proxy fallback covers Blossom-blocked blobs). The reported event is deduped out of the list.
- **Honest labelling**: every "not visible" message names a verified cause (hidden by suspension, removed by ban, relay error, confirmed absent, or status unknown). A failed or unfinished read is never presented as absence.

## Motivation

Closes #200. A moderator clearing or denying an age case needs to see the reported content and the account's other posts to make the call. The pane previously showed account and enforcement metadata but none of the content itself.

## What this does and does not make visible

Read this before assuming it solves the suspended-account case. It does not.

**Becomes visible:**
- The reported post when it was **banned**, retrieved with `getbannedevent`.
- **Blossom-blocked or restricted media**, through the existing authenticated media-proxy.
- Ordinary relay-visible content for a target not yet under enforcement.

**Stays invisible:**
- A **suspended** account's posts. The relay exposes `suspendpubkey`, `unsuspendpubkey` and `listsuspendedpubkeys`, but nothing that returns a suspended pubkey's events, so there is no server-side path to that content and no client change can surface it. Tracked in funnelcake#680.

Age-review enforcement suspends at the account level rather than banning individual posts, so for a target who is already suspended this shows the labelled reason rather than content. The viewing benefit lands on cases before suspension, and on cases where the specific reported post was banned or its media blocked. That is an improvement over a blank pane, but it is not "moderators can now see suspended content".

## Two correctness properties this had to get right

**Never state an absence you have not established.** `NPool.query` returns partial results instead of throwing: it swallows errors, breaks on a relay `CLOSED`, and returns immediately when no relay is routed to. Every one of those yields an empty array that is indistinguishable from a genuinely empty account, and funnelcake sends `CLOSED` when its query layer degrades. Reads that feed an absence claim therefore go through `queryStrict`, which drives `req` directly and treats anything short of `EOSE` as an error. Separately, `getbannedevent` answers "not banned" as HTTP 400, which is distinguished from a transport or auth failure so an outage is never reported as a deletion.

**Never attribute content to the wrong account.** NIP-56 does not require the reported event to be authored by the reported pubkey, and case creation does not check it, so a mis-filed report can name a third party's post (a report about a repost legitimately names the original). Such a post is still shown, because hiding it would lose evidence, but it carries an explicit "authored by X, not by this case's subject" warning and every content card shows its author, so attribution is never implied by position alone. The same normalized pubkey drives the reads and the enforcement actions, so the account being judged and the account being acted on cannot diverge.

A third property is worth naming because it shapes the copy: **a claim resting on a status we could not refresh says so.** The account status is data-first, matching the panel rendered directly above this one so the two cannot contradict each other, but when a refetch has failed the message adds that the answer could not be refreshed and offers a retry.

## Architecture

- `src/lib/relayRead.ts`: `queryStrict` (an EOSE-or-error relay read) and `isDefinitiveRpcNegative` (tells the relay's "no" apart from our failure to ask).
- `src/lib/contentVisibility.ts`: pure derivation of the visibility reason. No I/O.
- `src/hooks/useReportedEvent.ts`: two-hop resolution with the banned fallback and the author check. The tagged-target list comes from an untrusted event, so it is deduped and bounded, and the lookup stops when the query is cancelled.
- `src/components/AgeReviewContent.tsx`: presentation only.
- Wired into `AgeReviewDetail.tsx` below `AccountTypeIndicator`.

## Where a reviewer's attention is best spent

The risk in this change is concentrated in two places, both about claims made to a moderator rather than about rendering:

- `useReportedEvent` and `relayRead`, where a read failure must never resolve into a statement about what exists.
- `contentVisibility`, where the account status and the relay read are combined into a single "why not visible" claim.

## Validation

- `npx tsc -p tsconfig.app.json --noEmit`: clean. `npx eslint .`: clean.
- `npx vitest run`: 498 passing, 1 skipped.
- Tests cover the pure derivations, the two-hop lookup and its failure modes, and the wiring that feeds them, so a dropped prop surfaces as a wrong claim on screen rather than as silence.
- Guards are mutation-verified: each was broken deliberately, confirmed to turn a test red, and restored.

## Screenshots

Not attached. The states that most need a look (relay error, hidden-by-suspension, foreign-author) cannot be staged against a live environment: the relay has no verb for reading a suspended account's events, and staging rejects the seeded events needed to reproduce the rest. A live capture would only show the happy path. All states are covered by unit and wiring tests instead.
