### PR TITLE
fix(auto-hide): match trusted client names case-insensitively

### DIFF
--- a/worker/src/ReportWatcher.test.ts
+++ b/worker/src/ReportWatcher.test.ts
@@ -802,6 +802,61 @@ describe('ReportWatcher', () => {
       expect(mockDbRun).toHaveBeenCalled();
     });
 
+    // divine-mobile sends `Divine`; TRUSTED_CLIENTS carries the stylized `diVine`.
+    it('should accept a trusted client whose casing differs (divine-mobile sends "Divine")', async () => {
+      for (const clientName of ['Divine', 'DIVINE', ' divine ', 'Divine-Web']) {
+        mockFetch.mockClear();
+        mockFetch.mockResolvedValue({ ok: true, json: async () => ({ result: true }) });
+
+        await watcher.fetch(new Request('https://do/start', { method: 'POST' }));
+        await new Promise(resolve => setTimeout(resolve, 10));
+        const ws = getLastMockWebSocket();
+
+        ws!.simulateMessage(JSON.stringify(['EVENT', 'auto-hide-reports', {
+          id: `case_insensitive_${clientName.trim()}`,
+          pubkey: 'reporter',
+          kind: 1984,
+          content: 'CSAM report',
+          tags: [
+            ['e', `target_${clientName.trim()}`],
+            ['report', 'sexual_minors'],
+            ['client', clientName],
+          ],
+          created_at: Math.floor(Date.now() / 1000),
+        }]));
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        // banevent must have been called: the report was NOT dropped by the gate
+        expect(mockFetch, `client '${clientName}' should be trusted`).toHaveBeenCalled();
+      }
+    });
+
+    it('should still reject a genuinely untrusted client regardless of casing', async () => {
+      for (const clientName of ['Some-Random-App', 'notdivine', 'divine-evil']) {
+        mockFetch.mockClear();
+
+        await watcher.fetch(new Request('https://do/start', { method: 'POST' }));
+        await new Promise(resolve => setTimeout(resolve, 10));
+        const ws = getLastMockWebSocket();
+
+        ws!.simulateMessage(JSON.stringify(['EVENT', 'auto-hide-reports', {
+          id: `reject_${clientName}`,
+          pubkey: 'reporter',
+          kind: 1984,
+          content: 'CSAM report',
+          tags: [
+            ['e', `target_reject_${clientName}`],
+            ['report', 'sexual_minors'],
+            ['client', clientName],
+          ],
+          created_at: Math.floor(Date.now() / 1000),
+        }]));
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        expect(mockFetch, `client '${clientName}' must not be trusted`).not.toHaveBeenCalled();
+      }
+    });
+
     it('should accept reports from all configured trusted clients', async () => {
       for (const clientName of ['diVine', 'divine-web', 'divine-mobile']) {
         // Reset mocks for each iteration

--- a/worker/src/ReportWatcher.ts
+++ b/worker/src/ReportWatcher.ts
@@ -671,12 +671,18 @@ export class ReportWatcher implements DurableObject {
       return;
     }
 
-    // Check trusted-client gate if tier requires it
+    // Check trusted-client gate if tier requires it.
+    //
+    // Matched case-insensitively: per NIP-89 this tag element is a display name, not a
+    // stable identifier, so its casing is each app's choice and shouldn't decide
+    // enforcement. divine-mobile sends `Divine` while TRUSTED_CLIENTS carries the
+    // stylized `diVine`, so an exact match skipped mobile reports.
     if (tier.requireTrustedClient) {
       const clientTag = event.tags.find((t: string[]) => t[0] === 'client');
       const clientName = clientTag?.[1];
+      const normalizedClient = clientName?.trim().toLowerCase();
 
-      if (!clientName || !config.trustedClients.includes(clientName)) {
+      if (!normalizedClient || !config.trustedClients.some(c => c.trim().toLowerCase() === normalizedClient)) {
         console.log(`[ReportWatcher] Report from untrusted client '${clientName || 'none'}', skipping (tier: ${tier.name})`);
         await this.logDecision({
           targetType: 'event',


### PR DESCRIPTION
## What

The client name drifted: `divine-mobile` sends `Divine` while `TRUSTED_CLIENTS` carries the stylized `diVine`. The comparison was exact, so mobile reports stopped matching, and we missed the opportunity to make this case-insensitive when the gate went in.

Per NIP-89 that tag element is a display name rather than a stable identifier, so its casing is each app's choice and shouldn't decide enforcement. Both sides are now trimmed and lowercased.

Preventative fix for interim stability: affected reports were still actioned through other paths, so this restores the fast path rather than fixing an outage.

## Tests

Added coverage for casing variants being accepted (`Divine`, `DIVINE`, ` divine `, `Divine-Web`) and for genuinely untrusted clients still being rejected. Confirmed the new test fails without the change.

## Notes for the reviewer

- Merging doesn't ship this; relay-manager deploys by manual `wrangler`.
- `npm ci` in `worker/` needs `--legacy-peer-deps`, and 8 tests in `age-review.test.ts` / `bulk-moderate.test.ts` fail on `main` independently of this change. Both pre-existing.
- The `client` tag is self-declared and unverifiable: a provenance hint, not a trust boundary. Worth revisiting what this tier should actually gate on.
- Longer term the stable identifier is the NIP-89 handler address (element 3 of the tag, `31990:<pubkey>:<d>`). Matching on that would need a config change, so it's out of scope here.
