### PR TITLE
fix(age-review): refuse an un-ban on an account under age review

### DIFF
--- a/src/components/EventDetail.tsx
+++ b/src/components/EventDetail.tsx
@@ -2,7 +2,6 @@
 // ABOUTME: Includes raw JSON, linked events, author profile, user stats, related reports, and moderation actions
 
 import { useState, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNostr } from "@/hooks/useNostr";
 import { useAuthor } from "@/hooks/useAuthor";
@@ -11,7 +10,7 @@ import { useModerationStatus } from "@/hooks/useModerationStatus";
 import { useToast } from "@/hooks/useToast";
 import { getKindInfo, getKindCategory } from "@/lib/kindNames";
 import { useAdminApi } from "@/hooks/useAdminApi";
-import { ApiError } from "@/lib/adminApi";
+import { useAgeReviewGuardRedirect } from "@/hooks/useAgeReviewGuardRedirect";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { UserIdentifier } from "@/components/UserIdentifier";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -361,7 +360,7 @@ function TagsTable({ tags }: { tags: string[][] }) {
 export function EventDetail({ event, onSelectEvent, onSelectPubkey, onViewReports }: EventDetailProps) {
   const { nostr } = useNostr();
   const { toast } = useToast();
-  const navigate = useNavigate();
+  const redirectIfGuarded = useAgeReviewGuardRedirect();
   const { banPubkey, deleteEvent, unbanPubkey, allowEvent, verifyPubkeyBanned, verifyPubkeyUnbanned, verifyEventDeleted, logDecision } = useAdminApi();
   const { getModeratorPubkey } = useCurrentUser();
   const queryClient = useQueryClient();
@@ -563,14 +562,7 @@ export function EventDetail({ event, onSelectEvent, onSelectPubkey, onViewReport
       }
     },
     onError: (error: Error, variables: { pubkey: string }) => {
-      // Unban lifts the Keycast hold as well as the ban, so the worker refuses it
-      // on an open age-review case. Route to the case rather than a raw error, so
-      // enforcement cannot drift from the case out of band.
-      if (error instanceof ApiError && error.code === 'age_review_active') {
-        toast({ title: "This account is under age review", description: "Opening it in the Age Review flow." });
-        navigate(`/age-review?pubkey=${encodeURIComponent(variables.pubkey)}`);
-        return;
-      }
+      if (redirectIfGuarded(error, variables.pubkey)) return;
       toast({
         title: "Failed to unban user",
         description: error.message,

--- a/src/components/EventDetail.tsx
+++ b/src/components/EventDetail.tsx
@@ -2,6 +2,7 @@
 // ABOUTME: Includes raw JSON, linked events, author profile, user stats, related reports, and moderation actions
 
 import { useState, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNostr } from "@/hooks/useNostr";
 import { useAuthor } from "@/hooks/useAuthor";
@@ -10,6 +11,7 @@ import { useModerationStatus } from "@/hooks/useModerationStatus";
 import { useToast } from "@/hooks/useToast";
 import { getKindInfo, getKindCategory } from "@/lib/kindNames";
 import { useAdminApi } from "@/hooks/useAdminApi";
+import { ApiError } from "@/lib/adminApi";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { UserIdentifier } from "@/components/UserIdentifier";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -359,6 +361,7 @@ function TagsTable({ tags }: { tags: string[][] }) {
 export function EventDetail({ event, onSelectEvent, onSelectPubkey, onViewReports }: EventDetailProps) {
   const { nostr } = useNostr();
   const { toast } = useToast();
+  const navigate = useNavigate();
   const { banPubkey, deleteEvent, unbanPubkey, allowEvent, verifyPubkeyBanned, verifyPubkeyUnbanned, verifyEventDeleted, logDecision } = useAdminApi();
   const { getModeratorPubkey } = useCurrentUser();
   const queryClient = useQueryClient();
@@ -559,7 +562,15 @@ export function EventDetail({ event, onSelectEvent, onSelectPubkey, onViewReport
         setIsVerifying(false);
       }
     },
-    onError: (error: Error) => {
+    onError: (error: Error, variables: { pubkey: string }) => {
+      // Unban lifts the Keycast hold as well as the ban, so the worker refuses it
+      // on an open age-review case. Route to the case rather than a raw error, so
+      // enforcement cannot drift from the case out of band.
+      if (error instanceof ApiError && error.code === 'age_review_active') {
+        toast({ title: "This account is under age review", description: "Opening it in the Age Review flow." });
+        navigate(`/age-review?pubkey=${encodeURIComponent(variables.pubkey)}`);
+        return;
+      }
       toast({
         title: "Failed to unban user",
         description: error.message,

--- a/src/components/UserActions.test.tsx
+++ b/src/components/UserActions.test.tsx
@@ -140,6 +140,16 @@ describe('UserActions', () => {
     await waitFor(() => expect(navigate).toHaveBeenCalledWith(`/age-review?pubkey=${PUBKEY}`));
   });
 
+  it('routes to Age Review when an unban is guard-blocked (age_review_active)', async () => {
+    // Unban lifts the Keycast hold as well as the ban, so the worker refuses it on
+    // an open case. Without this the moderator gets a raw destructive toast rather
+    // than the case, which is the drift this pattern exists to prevent.
+    api.unbanPubkey.mockRejectedValue(new ApiError('under age review', 409, 'Conflict', 'age_review_active'));
+    renderWithProvider(<UserActions pubkey={PUBKEY} isBanned />);
+    fireEvent.click(screen.getByRole('button', { name: /Unban User/i }));
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith(`/age-review?pubkey=${PUBKEY}`));
+  });
+
   it('attributes the audit write to the logged-in moderator (#178)', async () => {
     renderWithProvider(<UserActions pubkey={PUBKEY} />);
     fireEvent.click(screen.getByRole('button', { name: /Suspend User/i }));

--- a/src/components/UserActions.test.tsx
+++ b/src/components/UserActions.test.tsx
@@ -150,6 +150,16 @@ describe('UserActions', () => {
     await waitFor(() => expect(navigate).toHaveBeenCalledWith(`/age-review?pubkey=${PUBKEY}`));
   });
 
+  it('routes to Age Review when an unsuspend is guard-blocked (age_review_active)', async () => {
+    // The other reversal, and the last unpinned redirect in this file. Suspend
+    // and unban are covered above; without this one, deleting the unsuspend
+    // redirect leaves the whole suite green.
+    api.unsuspendPubkey.mockRejectedValue(new ApiError('under age review', 409, 'Conflict', 'age_review_active'));
+    renderWithProvider(<UserActions pubkey={PUBKEY} isSuspended />);
+    fireEvent.click(screen.getByRole('button', { name: /Unsuspend User/i }));
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith(`/age-review?pubkey=${PUBKEY}`));
+  });
+
   it('attributes the audit write to the logged-in moderator (#178)', async () => {
     renderWithProvider(<UserActions pubkey={PUBKEY} />);
     fireEvent.click(screen.getByRole('button', { name: /Suspend User/i }));

--- a/src/components/UserActions.tsx
+++ b/src/components/UserActions.tsx
@@ -4,8 +4,8 @@ import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useToast } from '@/hooks/useToast';
 import { useAdminApi } from '@/hooks/useAdminApi';
+import { useAgeReviewGuardRedirect } from '@/hooks/useAgeReviewGuardRedirect';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
-import { ApiError } from '@/lib/adminApi';
 import { UNDERAGE_REPORT_CATEGORY } from '@/lib/constants';
 import { useBulkModerateJob } from '@/hooks/useBulkModerateJob';
 import { ConfirmDialog } from './ConfirmDialog';
@@ -49,18 +49,10 @@ export function UserActions({
   // on an open case regardless). Ban stays as the severe-action escape hatch.
   const showBulkActions = context !== 'age-review' && !isUnderageReport;
 
-  // The worker guard refuses a bare suspend/unsuspend/unban on an account under
-  // age review (any context). Route the moderator to the case instead of
-  // surfacing a raw error, so enforcement can't drift from the case out of band.
-  // Unban is included because it lifts the Keycast hold as well as the ban.
-  const routeToAgeReviewIfGuarded = (error: Error): boolean => {
-    if (error instanceof ApiError && error.code === 'age_review_active') {
-      toast({ title: 'This account is under age review', description: 'Opening it in the Age Review flow.' });
-      navigate(`/age-review?pubkey=${encodeURIComponent(pubkey)}`);
-      return true;
-    }
-    return false;
-  };
+  // Shared: the worker refuses suspend/unsuspend/unban on an account under age
+  // review. See useAgeReviewGuardRedirect for why this is not copied per site.
+  const redirectIfGuarded = useAgeReviewGuardRedirect();
+  const routeToAgeReviewIfGuarded = (error: Error): boolean => redirectIfGuarded(error, pubkey);
 
   // Whether this account has an open age-review case, which changes the Ban
   // copy (a ban purges content the review may still need). For an underage

--- a/src/components/UserActions.tsx
+++ b/src/components/UserActions.tsx
@@ -49,9 +49,10 @@ export function UserActions({
   // on an open case regardless). Ban stays as the severe-action escape hatch.
   const showBulkActions = context !== 'age-review' && !isUnderageReport;
 
-  // The worker guard refuses a bare suspend/unsuspend on an account under age
-  // review (any context). Route the moderator to the case instead of surfacing
-  // a raw error, so enforcement can't drift from the case out of band.
+  // The worker guard refuses a bare suspend/unsuspend/unban on an account under
+  // age review (any context). Route the moderator to the case instead of
+  // surfacing a raw error, so enforcement can't drift from the case out of band.
+  // Unban is included because it lifts the Keycast hold as well as the ban.
   const routeToAgeReviewIfGuarded = (error: Error): boolean => {
     if (error instanceof ApiError && error.code === 'age_review_active') {
       toast({ title: 'This account is under age review', description: 'Opening it in the Age Review flow.' });
@@ -186,6 +187,7 @@ export function UserActions({
       onActionComplete?.();
     },
     onError: (error: Error) => {
+      if (routeToAgeReviewIfGuarded(error)) return;
       toast({ title: 'Failed to unban user', description: error.message, variant: 'destructive' });
     },
   });

--- a/src/components/UserManagement.test.tsx
+++ b/src/components/UserManagement.test.tsx
@@ -99,6 +99,22 @@ describe('UserManagement age-review guard wiring', () => {
     await waitFor(() => expect(navigate).toHaveBeenCalledWith(`/age-review?pubkey=${PUBKEY}`));
   });
 
+  it('canonicalises an uppercase hex pubkey before it reaches the relay', async () => {
+    // The input is validated case-insensitively, but every consumer matches
+    // these bytes exactly: the relay's ban list, and the age-review guard's
+    // lookup. Sending uppercase through bans nobody while reporting success,
+    // and makes the guard miss a real open case.
+    renderWithProvider();
+    fireEvent.click(await screen.findByRole('button', { name: /Add User/i }));
+    fireEvent.change(await screen.findByPlaceholderText(/hex pubkey or npub1/i), {
+      target: { value: PUBKEY.toUpperCase() },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Allow$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^Allow User$/i }));
+
+    await waitFor(() => expect(api.callRelayRpc).toHaveBeenCalledWith('unbanpubkey', [PUBKEY, undefined]));
+  });
+
   it('still shows an error toast for a failure that is not a guard refusal', async () => {
     // The redirect must not swallow real errors, or a relay outage would look
     // like an age-review case.

--- a/src/components/UserManagement.test.tsx
+++ b/src/components/UserManagement.test.tsx
@@ -99,6 +99,24 @@ describe('UserManagement age-review guard wiring', () => {
     await waitFor(() => expect(navigate).toHaveBeenCalledWith(`/age-review?pubkey=${PUBKEY}`));
   });
 
+  it('routes an unsuspend refusal to the case', async () => {
+    // The one site this change rewrote from its own inline copy into the shared
+    // hook, so the one a hoist can silently drop -- and the identifier stays in
+    // use by the other two mutations, so eslint would not notice either.
+    api.callRelayRpc.mockImplementation((method: string) => {
+      if (method === 'listsuspendedpubkeys') return Promise.resolve([{ pubkey: PUBKEY, reason: 'age review' }]);
+      return Promise.resolve([]);
+    });
+    api.unsuspendPubkey.mockRejectedValue(guardRefusal());
+
+    renderWithProvider();
+    // Radix tabs activate on mousedown, not click.
+    fireEvent.mouseDown(await screen.findByRole('tab', { name: /Suspended Users/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /^Unsuspend$/i }));
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith(`/age-review?pubkey=${PUBKEY}`));
+  });
+
   it('canonicalises an uppercase hex pubkey before it reaches the relay', async () => {
     // The input is validated case-insensitively, but every consumer matches
     // these bytes exactly: the relay's ban list, and the age-review guard's

--- a/src/components/UserManagement.test.tsx
+++ b/src/components/UserManagement.test.tsx
@@ -1,0 +1,118 @@
+// ABOUTME: Covers the WIRING of the age-review guard redirect in UserManagement.
+// The shared hook's own tests pin the predicate; these pin that each mutation
+// actually calls it, which is the failure mode that shipped once.
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UserManagement } from './UserManagement';
+import { ApiError } from '@/lib/adminApi';
+
+const api = vi.hoisted(() => ({
+  callRelayRpc: vi.fn(),
+  verifyPubkeyBanned: vi.fn(),
+  verifyPubkeyUnbanned: vi.fn(),
+  unbanPubkey: vi.fn(),
+  unsuspendPubkey: vi.fn(),
+  logDecision: vi.fn(),
+}));
+const toast = vi.hoisted(() => vi.fn());
+const navigate = vi.hoisted(() => vi.fn());
+
+vi.mock('react-router-dom', async (orig) => ({
+  ...(await orig<typeof import('react-router-dom')>()),
+  useNavigate: () => navigate,
+}));
+vi.mock('@/hooks/useAdminApi', () => ({ useAdminApi: () => api }));
+vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast }) }));
+const MOD_PUBKEY = 'e'.repeat(64);
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ user: { pubkey: MOD_PUBKEY }, getModeratorPubkey: async () => MOD_PUBKEY }),
+}));
+// UserIdentifier resolves profiles through Nostr; irrelevant to guard wiring.
+vi.mock('@nostrify/react', () => ({
+  useNostr: () => ({ nostr: { query: vi.fn().mockResolvedValue([]) } }),
+}));
+vi.mock('@/hooks/useAppContext', () => ({ useAppContext: () => ({ config: {}, updateConfig: vi.fn() }) }));
+// Children are irrelevant here and drag in their own dependencies.
+vi.mock('@/components/UserActions', () => ({ UserActions: () => null }));
+// Render the action affordances it is handed, so the remove/unsuspend wiring
+// is reachable; everything else about the card is irrelevant here.
+vi.mock('@/components/BannedUserCard', () => ({
+  BannedUserCard: ({ actionButton, onUnban }: { actionButton?: React.ReactNode; onUnban?: () => void }) => (
+    <div>
+      {actionButton}
+      {onUnban ? <button onClick={onUnban}>Unban</button> : null}
+    </div>
+  ),
+}));
+
+const PUBKEY = 'a'.repeat(64);
+
+const guardRefusal = () => new ApiError('under age review', 409, 'Conflict', 'age_review_active');
+
+function renderWithProvider() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <TooltipProvider>
+        <UserManagement selectedPubkey={PUBKEY} />
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('UserManagement age-review guard wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Empty lists: the account is neither banned, allowed, nor suspended, so the
+    // Allow button renders.
+    api.callRelayRpc.mockResolvedValue([]);
+    api.logDecision.mockResolvedValue(undefined);
+  });
+
+  it('routes an allow_user refusal to the case rather than a dead-end toast', async () => {
+    // allow_user calls unbanpubkey, so it hits the guard. This is the call site
+    // the original sweep missed; without the wiring it dead-ends here.
+    api.callRelayRpc.mockImplementation((method: string) => {
+      if (method === 'unbanpubkey') return Promise.reject(guardRefusal());
+      return Promise.resolve([]);
+    });
+
+    renderWithProvider();
+    fireEvent.click(await screen.findByRole('button', { name: /^Allow$/i }));
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith(`/age-review?pubkey=${PUBKEY}`));
+  });
+
+  it('routes an unban refusal to the case', async () => {
+    api.callRelayRpc.mockImplementation((method: string) => {
+      if (method === 'listbannedpubkeys') return Promise.resolve([{ pubkey: PUBKEY, reason: 'spam' }]);
+      return Promise.resolve([]);
+    });
+    api.unbanPubkey.mockRejectedValue(guardRefusal());
+
+    renderWithProvider();
+    fireEvent.click(await screen.findByRole('button', { name: /^Unban$/i }));
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith(`/age-review?pubkey=${PUBKEY}`));
+  });
+
+  it('still shows an error toast for a failure that is not a guard refusal', async () => {
+    // The redirect must not swallow real errors, or a relay outage would look
+    // like an age-review case.
+    api.callRelayRpc.mockImplementation((method: string) => {
+      if (method === 'unbanpubkey') return Promise.reject(new ApiError('relay down', 500, 'Server Error'));
+      return Promise.resolve([]);
+    });
+
+    renderWithProvider();
+    fireEvent.click(await screen.findByRole('button', { name: /^Allow$/i }));
+
+    await waitFor(() =>
+      expect(toast).toHaveBeenCalledWith(expect.objectContaining({ title: 'Failed to allow user' })),
+    );
+    expect(navigate).not.toHaveBeenCalledWith(expect.stringContaining('/age-review'));
+  });
+});

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -214,7 +214,15 @@ export function UserManagement({ selectedPubkey }: UserManagementProps) {
         }
       });
     },
-    onError: (error: Error) => {
+    onError: (error: Error, variables: { pubkey: string }) => {
+      // Unban lifts the Keycast hold as well as the ban, so the worker refuses it
+      // on an open age-review case. Route to the case rather than a raw error,
+      // matching unsuspend below.
+      if (error instanceof ApiError && error.code === 'age_review_active') {
+        toast({ title: "This account is under age review", description: "Opening it in the Age Review flow." });
+        navigate(`/age-review?pubkey=${encodeURIComponent(variables.pubkey)}`);
+        return;
+      }
       toast({
         title: "Failed to unban user",
         description: error.message,

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -183,6 +183,13 @@ export function UserManagement({ selectedPubkey }: UserManagementProps) {
     } else if (!/^[0-9a-f]{64}$/i.test(raw)) {
       toast({ title: "Invalid pubkey", description: "Enter a 64-character hex pubkey or an npub", variant: "destructive" });
       return;
+    } else {
+      // Accepted case-insensitively above (people paste from anywhere), but
+      // canonicalised here: every consumer matches these bytes exactly. The
+      // relay's ban/suspend lists are case-sensitive, so an uppercase value
+      // bans nobody while reporting success, and the age-review guard's lookup
+      // would miss a real open case for the same reason.
+      hexPubkey = raw.toLowerCase();
     }
 
     if (actionType === 'ban') {

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -18,12 +18,12 @@ import { UserX, UserCheck, Plus, Users, Trash2, User, X, Pause, Play } from "luc
 import { BannedUserCard } from "@/components/BannedUserCard";
 import { nip19 } from "nostr-tools";
 import { useAdminApi } from "@/hooks/useAdminApi";
+import { useAgeReviewGuardRedirect } from "@/hooks/useAgeReviewGuardRedirect";
 import { UserActions } from "@/components/UserActions";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { UserDisplayName } from "@/components/UserIdentifier";
 import { CopyableId } from "@/components/CopyableId";
 import type { BannedPubkeyEntry } from "@/lib/adminApi";
-import { ApiError } from "@/lib/adminApi";
 
 interface UserManagementProps {
   selectedPubkey?: string;
@@ -41,6 +41,7 @@ interface AllowedUser {
 
 export function UserManagement({ selectedPubkey }: UserManagementProps) {
   const { toast } = useToast();
+  const redirectIfGuarded = useAgeReviewGuardRedirect();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { callRelayRpc, verifyPubkeyBanned, verifyPubkeyUnbanned, unbanPubkey, unsuspendPubkey, logDecision } = useAdminApi();
@@ -143,7 +144,9 @@ export function UserManagement({ selectedPubkey }: UserManagementProps) {
       setNewPubkey("");
       setNewReason("");
     },
-    onError: (error: Error) => {
+    onError: (error: Error, variables: { pubkey: string; reason?: string }) => {
+      // allow_user calls unbanpubkey, so it hits the same guard as unban below.
+      if (redirectIfGuarded(error, variables.pubkey)) return;
       toast({
         title: "Failed to allow user",
         description: error.message,
@@ -215,14 +218,7 @@ export function UserManagement({ selectedPubkey }: UserManagementProps) {
       });
     },
     onError: (error: Error, variables: { pubkey: string }) => {
-      // Unban lifts the Keycast hold as well as the ban, so the worker refuses it
-      // on an open age-review case. Route to the case rather than a raw error,
-      // matching unsuspend below.
-      if (error instanceof ApiError && error.code === 'age_review_active') {
-        toast({ title: "This account is under age review", description: "Opening it in the Age Review flow." });
-        navigate(`/age-review?pubkey=${encodeURIComponent(variables.pubkey)}`);
-        return;
-      }
+      if (redirectIfGuarded(error, variables.pubkey)) return;
       toast({
         title: "Failed to unban user",
         description: error.message,
@@ -249,11 +245,7 @@ export function UserManagement({ selectedPubkey }: UserManagementProps) {
       toast({ title: "User unsuspended successfully" });
     },
     onError: (error: Error, variables: { pubkey: string }) => {
-      if (error instanceof ApiError && error.code === 'age_review_active') {
-        toast({ title: "This account is under age review", description: "Opening it in the Age Review flow." });
-        navigate(`/age-review?pubkey=${encodeURIComponent(variables.pubkey)}`);
-        return;
-      }
+      if (redirectIfGuarded(error, variables.pubkey)) return;
       toast({
         title: "Failed to unsuspend user",
         description: error.message,

--- a/src/hooks/useAgeReviewGuardRedirect.test.ts
+++ b/src/hooks/useAgeReviewGuardRedirect.test.ts
@@ -1,0 +1,59 @@
+// ABOUTME: Tests the shared age-review guard redirect used by every guarded-RPC call site.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { ApiError } from '@/lib/adminApi';
+import { useAgeReviewGuardRedirect } from './useAgeReviewGuardRedirect';
+
+const navigate = vi.hoisted(() => vi.fn());
+const toast = vi.hoisted(() => vi.fn());
+
+vi.mock('react-router-dom', async (orig) => ({
+  ...(await orig<typeof import('react-router-dom')>()),
+  useNavigate: () => navigate,
+}));
+vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast }) }));
+
+const PUBKEY = 'a'.repeat(64);
+
+const guarded = () => new ApiError('under age review', 409, 'Conflict', 'age_review_active');
+
+describe('useAgeReviewGuardRedirect', () => {
+  beforeEach(() => {
+    navigate.mockReset();
+    toast.mockReset();
+  });
+
+  it('routes to the case and reports handled when the guard refuses', () => {
+    const { result } = renderHook(() => useAgeReviewGuardRedirect());
+    expect(result.current(guarded(), PUBKEY)).toBe(true);
+    expect(navigate).toHaveBeenCalledWith(`/age-review?pubkey=${PUBKEY}`);
+  });
+
+  it('encodes the pubkey into the query string', () => {
+    const { result } = renderHook(() => useAgeReviewGuardRedirect());
+    result.current(guarded(), 'not/a/pubkey');
+    expect(navigate).toHaveBeenCalledWith('/age-review?pubkey=not%2Fa%2Fpubkey');
+  });
+
+  it('leaves an unrelated ApiError to the caller', () => {
+    // A 500 from the same endpoint must still surface as an error toast, not a
+    // silent redirect, or a real failure would look like a guard refusal.
+    const { result } = renderHook(() => useAgeReviewGuardRedirect());
+    expect(result.current(new ApiError('boom', 500, 'Server Error'), PUBKEY)).toBe(false);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('leaves a 409 without the guard code to the caller', () => {
+    // Status alone must not trigger the redirect: other conflicts exist.
+    const { result } = renderHook(() => useAgeReviewGuardRedirect());
+    expect(result.current(new ApiError('conflict', 409, 'Conflict', 'something_else'), PUBKEY)).toBe(false);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('leaves a plain Error to the caller', () => {
+    const { result } = renderHook(() => useAgeReviewGuardRedirect());
+    expect(result.current(new Error('network down'), PUBKEY)).toBe(false);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useAgeReviewGuardRedirect.ts
+++ b/src/hooks/useAgeReviewGuardRedirect.ts
@@ -1,0 +1,42 @@
+// ABOUTME: Routes a moderator to the Age Review case when the worker's age-review
+// guard refuses an enforcement action, instead of surfacing a raw error.
+
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ApiError } from '@/lib/adminApi';
+import { useToast } from '@/hooks/useToast';
+
+/**
+ * The worker refuses `suspendpubkey`, `unsuspendpubkey` and `unbanpubkey` on a
+ * pubkey with an open age-review case, answering with a 409 carrying
+ * `code: 'age_review_active'`. Enforcement must not drift from the case out of
+ * band, so a refused action sends the moderator to the case rather than showing
+ * a dead-end error toast.
+ *
+ * `banpubkey` is deliberately not guarded and so never produces this code: it is
+ * the severe-action escape hatch.
+ *
+ * Returns a predicate. Call it first in a mutation's `onError`; if it returns
+ * true it has already handled the error and the caller should return.
+ *
+ * This is shared rather than copied because it is needed at every call site of a
+ * guarded RPC, and a copied block is easy to omit on a new one. It was, on the
+ * `allow_user` path, which reached `unbanpubkey` and dead-ended.
+ */
+export function useAgeReviewGuardRedirect() {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+
+  return useCallback(
+    (error: unknown, pubkey: string): boolean => {
+      if (!(error instanceof ApiError) || error.code !== 'age_review_active') return false;
+      toast({
+        title: 'This account is under age review',
+        description: 'Opening it in the Age Review flow.',
+      });
+      navigate(`/age-review?pubkey=${encodeURIComponent(pubkey)}`);
+      return true;
+    },
+    [navigate, toast],
+  );
+}

--- a/src/hooks/useAgeReviewGuardRedirect.ts
+++ b/src/hooks/useAgeReviewGuardRedirect.ts
@@ -22,13 +22,21 @@ import { useToast } from '@/hooks/useToast';
  * Shared rather than copied because extending the guard to `unbanpubkey` makes
  * four new call sites able to receive this code — `UserActions` un-ban,
  * `UserManagement` allow_user and un-ban, and `EventDetail` un-ban — on top of
- * the two that already handled it. Six near-identical copies is how one gets
- * missed, so the handling lives here and each site calls it.
+ * the four that already handled it (`UserActions` suspend, unsuspend and bulk;
+ * `UserManagement` unsuspend, which was its own inline copy). Eight
+ * near-identical copies is how one gets missed, so the handling lives here.
  *
- * Not every caller of a guarded RPC needs it: `DebugPanel` issues arbitrary RPC
- * methods and records the error into an action log rather than surfacing a
- * moderator-facing toast, so it deliberately does not use this. The rule is
- * whether a moderator is waiting on the outcome, not whether the RPC is guarded.
+ * Only covers the 409. The same three RPCs also answer 503
+ * `age_review_check_failed` when the check cannot run at all, which is not a
+ * routable case — there is no case id to route to — so this returns false and
+ * each site shows its own error toast. That message is already actionable.
+ *
+ * `DebugPanel` deliberately does not use this. It issues arbitrary RPC methods
+ * as a raw diagnostic and reports whatever came back, rather than running a
+ * moderator workflow with somewhere to be sent. The test is whether a moderator
+ * is waiting on the outcome, not whether the RPC is guarded. (It does toast, and
+ * currently reports a guard refusal as "Partial success", which is misleading
+ * but is a DebugPanel problem rather than one this hook should solve.)
  */
 export function useAgeReviewGuardRedirect() {
   const navigate = useNavigate();

--- a/src/hooks/useAgeReviewGuardRedirect.ts
+++ b/src/hooks/useAgeReviewGuardRedirect.ts
@@ -26,10 +26,12 @@ import { useToast } from '@/hooks/useToast';
  * `UserManagement` unsuspend, which was its own inline copy). Eight
  * near-identical copies is how one gets missed, so the handling lives here.
  *
- * Only covers the 409. The same three RPCs also answer 503
- * `age_review_check_failed` when the check cannot run at all, which is not a
- * routable case — there is no case id to route to — so this returns false and
- * each site shows its own error toast. That message is already actionable.
+ * Only covers the 409. The two REVERSALS, `unsuspendpubkey` and `unbanpubkey`,
+ * also answer 503 `age_review_check_failed` when the check cannot run at all.
+ * `suspendpubkey` never does: fail-closed is passed only for reversals, so a
+ * suspend whose lookup fails proceeds and enforces. The 503 is not a routable
+ * case either way, since there is no case id to route to, so this returns false
+ * and each site shows its own error toast. That message is already actionable.
  *
  * `DebugPanel` deliberately does not use this. It issues arbitrary RPC methods
  * as a raw diagnostic and reports whatever came back, rather than running a

--- a/src/hooks/useAgeReviewGuardRedirect.ts
+++ b/src/hooks/useAgeReviewGuardRedirect.ts
@@ -19,9 +19,16 @@ import { useToast } from '@/hooks/useToast';
  * Returns a predicate. Call it first in a mutation's `onError`; if it returns
  * true it has already handled the error and the caller should return.
  *
- * This is shared rather than copied because it is needed at every call site of a
- * guarded RPC, and a copied block is easy to omit on a new one. It was, on the
- * `allow_user` path, which reached `unbanpubkey` and dead-ended.
+ * Shared rather than copied because extending the guard to `unbanpubkey` makes
+ * four new call sites able to receive this code — `UserActions` un-ban,
+ * `UserManagement` allow_user and un-ban, and `EventDetail` un-ban — on top of
+ * the two that already handled it. Six near-identical copies is how one gets
+ * missed, so the handling lives here and each site calls it.
+ *
+ * Not every caller of a guarded RPC needs it: `DebugPanel` issues arbitrary RPC
+ * methods and records the error into an action log rather than surfacing a
+ * moderator-facing toast, so it deliberately does not use this. The rule is
+ * whether a moderator is waiting on the outcome, not whether the RPC is guarded.
  */
 export function useAgeReviewGuardRedirect() {
   const navigate = useNavigate();

--- a/src/lib/adminApi.test.ts
+++ b/src/lib/adminApi.test.ts
@@ -440,6 +440,54 @@ describe('adminApi', () => {
       );
     });
 
+    it('surfaces a guard 409 as structured ApiError fields, not an opaque message', async () => {
+      // This is the only link that turns the worker's age-review 409 into
+      // something the UI can branch on. Every guarded call goes through here:
+      // unbanPubkey, suspendPubkey, unsuspendPubkey, and UserManagement's
+      // allow_user calling callRelayRpc('unbanpubkey') directly. Drop `code`
+      // and all five silently fall through to a destructive toast instead of
+      // routing to the case, with nothing else failing.
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        statusText: 'Conflict',
+        json: async () => ({
+          success: false,
+          error: 'This account is under age review.',
+          code: 'age_review_active',
+          caseId: 'case-1',
+          state: 'restricted_pending_user_response',
+        }),
+      });
+
+      expect.assertions(4);
+      try {
+        await callRelayRpc(API_URL, 'unbanpubkey', ['a'.repeat(64)]);
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        expect((err as ApiError).code).toBe('age_review_active');
+        expect((err as ApiError).statusCode).toBe(409);
+        expect((err as ApiError).message).toBe('This account is under age review.');
+      }
+    });
+
+    it('falls back to the status line when the error body is not JSON', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        statusText: 'Bad Gateway',
+        json: async () => { throw new Error('not json'); },
+      });
+
+      expect.assertions(2);
+      try {
+        await callRelayRpc(API_URL, 'unbanpubkey', ['a'.repeat(64)]);
+      } catch (err) {
+        expect((err as ApiError).message).toBe('HTTP 502: Bad Gateway');
+        expect((err as ApiError).code).toBeUndefined();
+      }
+    });
+
     it('should throw ApiError on unsuccessful RPC response', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/src/lib/adminApi.test.ts
+++ b/src/lib/adminApi.test.ts
@@ -441,12 +441,15 @@ describe('adminApi', () => {
     });
 
     it('surfaces a guard 409 as structured ApiError fields, not an opaque message', async () => {
-      // This is the only link that turns the worker's age-review 409 into
-      // something the UI can branch on. Every guarded call goes through here:
-      // unbanPubkey, suspendPubkey, unsuspendPubkey, and UserManagement's
-      // allow_user calling callRelayRpc('unbanpubkey') directly. Drop `code`
-      // and all five silently fall through to a destructive toast instead of
-      // routing to the case, with nothing else failing.
+      // Every guarded /api/relay-rpc call goes through here: unbanPubkey,
+      // suspendPubkey, unsuspendPubkey, and UserManagement's allow_user calling
+      // callRelayRpc('unbanpubkey') directly. Drop `code` and all four silently
+      // fall through to a destructive toast instead of routing to the case,
+      // with nothing else failing.
+      //
+      // Not the only such link: /api/bulk-moderate is guarded by the same
+      // predicate, but bulkModerate goes through apiRequest, which parses `code`
+      // separately (pinned above by the 409 version_conflict test).
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 409,

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -2153,21 +2153,20 @@ describe('handleGetAgeReviewFunnel', () => {
 });
 
 describe('ageReviewActiveGuard — non-canonical pubkey', () => {
-  // handleRelayRpc rejects these with a 400 before the guard is reached, so in
-  // practice this branch does not fire. It is kept as defence in depth for any
-  // future caller that skips that check, and tested directly because the
-  // handler now shields it from the route-level tests.
+  // Skipped in BOTH modes, deliberately. A case is keyed to a real lowercase pubkey,
+  // so a non-canonical value cannot have one to skip past -- there is nothing for the
+  // guard to protect. handleRelayRpc rejects these outright on the enforce direction;
+  // the reverse direction is allowed to carry them so a row banned with a bad value
+  // stays removable, and that only works if the guard lets it through.
   const CORS = { 'Access-Control-Allow-Origin': 'https://app.divine.video' };
   const envWithDb = { DB: { prepare: () => ({ bind: () => ({ first: async () => null }) }) } } as unknown as AgeReviewEnv;
 
-  it('refuses under failClosed, because a byte-exact lookup could never match it', async () => {
+  it('proceeds under failClosed, because no case can be keyed to it', async () => {
     const response = await ageReviewActiveGuard('NOT_CANONICAL_HEX', envWithDb, CORS, 'err', { failClosed: true });
-    expect(response?.status).toBe(503);
-    const body = await response?.json() as { code: string };
-    expect(body.code).toBe('age_review_check_failed');
+    expect(response).toBeNull();
   });
 
-  it('proceeds when not failing closed, matching every other unrunnable check', async () => {
+  it('proceeds when not failing closed', async () => {
     const response = await ageReviewActiveGuard('NOT_CANONICAL_HEX', envWithDb, CORS, 'err');
     expect(response).toBeNull();
   });

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -16,6 +16,7 @@ import {
   bucketModerationCounts,
   fetchZendeskTagCount,
   handleGetAgeReviewFunnel,
+  ageReviewActiveGuard,
   type AgeReviewEnv,
 } from './age-review';
 import type { AgeReviewCase } from '../../shared/age-review';
@@ -2148,5 +2149,26 @@ describe('handleGetAgeReviewFunnel', () => {
     for (const query of Object.values(FUNNEL_ZENDESK_QUERIES)) {
       expect(calledUrls.some((u) => u.includes(encodeURIComponent(query)))).toBe(true);
     }
+  });
+});
+
+describe('ageReviewActiveGuard — non-canonical pubkey', () => {
+  // handleRelayRpc rejects these with a 400 before the guard is reached, so in
+  // practice this branch does not fire. It is kept as defence in depth for any
+  // future caller that skips that check, and tested directly because the
+  // handler now shields it from the route-level tests.
+  const CORS = { 'Access-Control-Allow-Origin': 'https://app.divine.video' };
+  const envWithDb = { DB: { prepare: () => ({ bind: () => ({ first: async () => null }) }) } } as unknown as AgeReviewEnv;
+
+  it('refuses under failClosed, because a byte-exact lookup could never match it', async () => {
+    const response = await ageReviewActiveGuard('NOT_CANONICAL_HEX', envWithDb, CORS, 'err', { failClosed: true });
+    expect(response?.status).toBe(503);
+    const body = await response?.json() as { code: string };
+    expect(body.code).toBe('age_review_check_failed');
+  });
+
+  it('proceeds when not failing closed, matching every other unrunnable check', async () => {
+    const response = await ageReviewActiveGuard('NOT_CANONICAL_HEX', envWithDb, CORS, 'err');
+    expect(response).toBeNull();
   });
 });

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -149,20 +149,39 @@ export async function ageReviewActiveGuard(
   error: string,
   opts: { failClosed?: boolean } = {},
 ): Promise<Response | null> {
-  if (!/^[0-9a-f]{64}$/.test(pubkey) || !env.DB) return null;
+  // A malformed pubkey skips the guard in both modes: there is nothing to query,
+  // and the caller's own validation produces the 400.
+  if (!/^[0-9a-f]{64}$/.test(pubkey)) return null;
+
+  // 503, not 409: "could not check" is a different answer from "there is a
+  // case", and 5xx is the retryable class. No caseId/state, since neither is
+  // known.
+  const cannotCheck = () => json({
+    success: false,
+    error: 'Could not check age-review status. Try again.',
+    code: 'age_review_check_failed',
+  }, 503, corsHeaders);
+
+  // A missing binding is the check not happening, so it refuses under
+  // failClosed exactly as a thrown lookup does. Handling only the throw would
+  // leave the PERSISTENT failure lifting holds while the transient one refused,
+  // which is the wrong way round. Every deployment binds DB (wrangler prod,
+  // staging and local), so this costs real traffic nothing.
+  if (!env.DB) {
+    if (opts.failClosed) {
+      console.error('[ageReviewActiveGuard] no DB binding; refusing (fail-closed)');
+      return cannotCheck();
+    }
+    return null;
+  }
+
   let activeCase: AgeReviewCase | null = null;
   try {
     activeCase = await getActiveAgeReviewCase(pubkey, env);
   } catch (err) {
     if (opts.failClosed) {
-      // 503, not 409: this is "could not check", not "there is a case". The
-      // distinction matters to the caller, and 5xx is the retryable class.
       console.error('[ageReviewActiveGuard] lookup failed; refusing (fail-closed):', err);
-      return json({
-        success: false,
-        error: 'Could not check age-review status. Try again.',
-        code: 'age_review_check_failed',
-      }, 503, corsHeaders);
+      return cannotCheck();
     }
     console.error('[ageReviewActiveGuard] lookup failed; proceeding:', err);
   }

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -125,24 +125,45 @@ export async function getActiveAgeReviewCase(
  * (`age_review_active` + caseId/state) that the frontend turns into a redirect
  * to the case; returns null when nothing blocks the action.
  *
- * Fails open: the guard is a safety net (the report hand-off is the primary
- * path), so a transient D1 error must not block core moderation — log and
- * proceed. A malformed pubkey also skips the guard (no point querying; the
+ * Fails open by default: the guard is a safety net (the report hand-off is the
+ * primary path), so a transient D1 error must not block core moderation — log
+ * and proceed. A malformed pubkey also skips the guard (no point querying; the
  * caller's own validation produces the 400). Age-review's own enforcement
  * calls the nip86 helpers / runBulkModeration directly, so it never hits the
  * guarded endpoints.
+ *
+ * `failClosed` inverts that for the REVERSAL direction, where the default is
+ * the wrong trade. Failing open on a suspend over-enforces: visible, and
+ * undone by the moderator who did it. Failing open on an unsuspend or unban
+ * silently LIFTS a minor-safety hold while reporting success, so nobody learns
+ * the check never ran — and those calls now arrive from automation rather than
+ * a human who might notice. The cost is that a real outage blocks reversals
+ * entirely, which is accepted: an outage long enough to matter is not tenable
+ * and has to be fixed rather than papered over. `banpubkey` is unguarded, so
+ * severe enforcement still works throughout.
  */
 export async function ageReviewActiveGuard(
   pubkey: string,
   env: AgeReviewEnv,
   corsHeaders: Record<string, string>,
   error: string,
+  opts: { failClosed?: boolean } = {},
 ): Promise<Response | null> {
   if (!/^[0-9a-f]{64}$/.test(pubkey) || !env.DB) return null;
   let activeCase: AgeReviewCase | null = null;
   try {
     activeCase = await getActiveAgeReviewCase(pubkey, env);
   } catch (err) {
+    if (opts.failClosed) {
+      // 503, not 409: this is "could not check", not "there is a case". The
+      // distinction matters to the caller, and 5xx is the retryable class.
+      console.error('[ageReviewActiveGuard] lookup failed; refusing (fail-closed):', err);
+      return json({
+        success: false,
+        error: 'Could not check age-review status. Try again.',
+        code: 'age_review_check_failed',
+      }, 503, corsHeaders);
+    }
     console.error('[ageReviewActiveGuard] lookup failed; proceeding:', err);
   }
   if (!activeCase) return null;

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -140,11 +140,10 @@ export async function getActiveAgeReviewCase(
  * and has to be fixed rather than papered over. `banpubkey` is unguarded, so
  * severe enforcement still works throughout.
  *
- * Under `failClosed` there are three ways the check "cannot happen", and all
- * three refuse identically: no DB binding, a thrown lookup, and a non-canonical
- * pubkey the byte-exact lookup could never match. The last is defence in depth
- * — relay-rpc answers a malformed pubkey with 400 before reaching here — but
- * the guard does not assume its callers validate.
+ * Under `failClosed` there are two ways the check "cannot happen", and both
+ * refuse identically: no DB binding, and a thrown lookup. A non-canonical pubkey
+ * is NOT one of them: no case can be keyed to a value the lookup could never
+ * match, so there is nothing to refuse on its behalf.
  *
  * `failClosed` is opt-in PER CALL SITE, not a property of the guard. Only
  * relay-rpc's reversals pass it today; bulk-moderate deliberately does not, for
@@ -166,25 +165,17 @@ export async function ageReviewActiveGuard(
     code: 'age_review_check_failed',
   }, 503, corsHeaders);
 
-  // A non-canonical pubkey is also "the check cannot happen": the lookup below
-  // is byte-exact, so it would miss and report "no case" for an account that may
-  // well have one. Under failClosed that refuses like any other unrunnable
-  // check.
+  // A non-canonical pubkey proceeds in both modes, and that is not the same
+  // omission the earlier version made. It skipped on the stated grounds that the
+  // caller validates, which no caller did. The reason now is that there is nothing
+  // here to protect: a case is keyed to a real lowercase pubkey, so a value that
+  // cannot match one cannot be hiding an open case either. Refusing would only
+  // block the reverse direction, which deliberately carries such values so a row
+  // banned with one stays removable (see handleRelayRpc).
   //
-  // Defence in depth, not the primary check: handleRelayRpc rejects these with a
-  // 400 before calling the guard, which is the better answer (a malformed pubkey
-  // never becomes valid on a retry). This stays because the guard must not
-  // depend on its callers validating -- the previous version did, and what
-  // actually stopped the mutation was byte-exact matching in Keycast and
-  // ClickHouse, written for other purposes and free to be relaxed without
-  // anyone connecting the change to this guard.
-  if (!/^[0-9a-f]{64}$/.test(pubkey)) {
-    if (opts.failClosed) {
-      console.error('[ageReviewActiveGuard] non-canonical pubkey; refusing (fail-closed)');
-      return cannotCheck();
-    }
-    return null;
-  }
+  // The enforce direction does not reach this: handleRelayRpc answers those with a
+  // 400 first, since a ban on a value the relay cannot match enforces on nobody.
+  if (!/^[0-9a-f]{64}$/.test(pubkey)) return null;
 
   // A missing binding is the check not happening, so it refuses under
   // failClosed exactly as a thrown lookup does. Handling only the throw would

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -142,7 +142,9 @@ export async function getActiveAgeReviewCase(
  *
  * Under `failClosed` there are three ways the check "cannot happen", and all
  * three refuse identically: no DB binding, a thrown lookup, and a non-canonical
- * pubkey the byte-exact lookup could never match.
+ * pubkey the byte-exact lookup could never match. The last is defence in depth
+ * — relay-rpc answers a malformed pubkey with 400 before reaching here — but
+ * the guard does not assume its callers validate.
  *
  * `failClosed` is opt-in PER CALL SITE, not a property of the guard. Only
  * relay-rpc's reversals pass it today; bulk-moderate deliberately does not, for
@@ -167,10 +169,15 @@ export async function ageReviewActiveGuard(
   // A non-canonical pubkey is also "the check cannot happen": the lookup below
   // is byte-exact, so it would miss and report "no case" for an account that may
   // well have one. Under failClosed that refuses like any other unrunnable
-  // check. Nothing here relies on a downstream format check to stop the
-  // mutation -- the ones that exist (Keycast's HEX_64, ClickHouse's
-  // case-sensitive match) are written for other purposes and could be relaxed
-  // without anyone connecting the change to this guard.
+  // check.
+  //
+  // Defence in depth, not the primary check: handleRelayRpc rejects these with a
+  // 400 before calling the guard, which is the better answer (a malformed pubkey
+  // never becomes valid on a retry). This stays because the guard must not
+  // depend on its callers validating -- the previous version did, and what
+  // actually stopped the mutation was byte-exact matching in Keycast and
+  // ClickHouse, written for other purposes and free to be relaxed without
+  // anyone connecting the change to this guard.
   if (!/^[0-9a-f]{64}$/.test(pubkey)) {
     if (opts.failClosed) {
       console.error('[ageReviewActiveGuard] non-canonical pubkey; refusing (fail-closed)');

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -120,17 +120,15 @@ export async function getActiveAgeReviewCase(
 
 /**
  * Refuse-and-route guard shared by the interactive enforcement endpoints
- * (relay-rpc suspend/unsuspend, bulk-moderate enqueue): if the pubkey has an
- * open (non-terminal) age-review case, returns a structured 409
+ * (relay-rpc suspend/unsuspend/unban, bulk-moderate enqueue): if the pubkey has
+ * an open (non-terminal) age-review case, returns a structured 409
  * (`age_review_active` + caseId/state) that the frontend turns into a redirect
  * to the case; returns null when nothing blocks the action.
  *
  * Fails open by default: the guard is a safety net (the report hand-off is the
  * primary path), so a transient D1 error must not block core moderation — log
- * and proceed. A malformed pubkey also skips the guard (no point querying; the
- * caller's own validation produces the 400). Age-review's own enforcement
- * calls the nip86 helpers / runBulkModeration directly, so it never hits the
- * guarded endpoints.
+ * and proceed. Age-review's own enforcement calls the nip86 helpers /
+ * runBulkModeration directly, so it never hits the guarded endpoints.
  *
  * `failClosed` inverts that for the REVERSAL direction, where the default is
  * the wrong trade. Failing open on a suspend over-enforces: visible, and
@@ -141,6 +139,14 @@ export async function getActiveAgeReviewCase(
  * entirely, which is accepted: an outage long enough to matter is not tenable
  * and has to be fixed rather than papered over. `banpubkey` is unguarded, so
  * severe enforcement still works throughout.
+ *
+ * Under `failClosed` there are three ways the check "cannot happen", and all
+ * three refuse identically: no DB binding, a thrown lookup, and a non-canonical
+ * pubkey the byte-exact lookup could never match.
+ *
+ * `failClosed` is opt-in PER CALL SITE, not a property of the guard. Only
+ * relay-rpc's reversals pass it today; bulk-moderate deliberately does not, for
+ * reasons recorded at its call site in index.ts.
  */
 export async function ageReviewActiveGuard(
   pubkey: string,
@@ -149,10 +155,6 @@ export async function ageReviewActiveGuard(
   error: string,
   opts: { failClosed?: boolean } = {},
 ): Promise<Response | null> {
-  // A malformed pubkey skips the guard in both modes: there is nothing to query,
-  // and the caller's own validation produces the 400.
-  if (!/^[0-9a-f]{64}$/.test(pubkey)) return null;
-
   // 503, not 409: "could not check" is a different answer from "there is a
   // case", and 5xx is the retryable class. No caseId/state, since neither is
   // known.
@@ -161,6 +163,21 @@ export async function ageReviewActiveGuard(
     error: 'Could not check age-review status. Try again.',
     code: 'age_review_check_failed',
   }, 503, corsHeaders);
+
+  // A non-canonical pubkey is also "the check cannot happen": the lookup below
+  // is byte-exact, so it would miss and report "no case" for an account that may
+  // well have one. Under failClosed that refuses like any other unrunnable
+  // check. Nothing here relies on a downstream format check to stop the
+  // mutation -- the ones that exist (Keycast's HEX_64, ClickHouse's
+  // case-sensitive match) are written for other purposes and could be relaxed
+  // without anyone connecting the change to this guard.
+  if (!/^[0-9a-f]{64}$/.test(pubkey)) {
+    if (opts.failClosed) {
+      console.error('[ageReviewActiveGuard] non-canonical pubkey; refusing (fail-closed)');
+      return cannotCheck();
+    }
+    return null;
+  }
 
   // A missing binding is the check not happening, so it refuses under
   // failClosed exactly as a thrown lookup does. Handling only the throw would

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -547,6 +547,39 @@ describe('relay-rpc account-state side effects', () => {
     fetchSpy.mockRestore();
   });
 
+  it('allow_pubkey via /api/moderate forwards the 503 too, not just the 409', async () => {
+    // The other half of the same contract, and the half a caller most needs: a
+    // permanent refusal and an unrunnable check must stay distinguishable across
+    // the hop. Flattening this one to 500 strips `code`, so the caller cannot tell
+    // "there is a case" from "we could not look" from "the relay broke".
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+
+    const response = await worker.fetch(
+      new Request('https://api-relay-prod.divine.video/api/moderate', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Key': 'test-admin-key',
+          Origin: 'https://app.divine.video',
+        },
+        body: JSON.stringify({ action: 'allow_pubkey', pubkey: VALID_PUBKEY }),
+      }),
+      makeAccountStateEnvWithFailingCaseLookup(),
+      testCtx,
+    );
+
+    expect(response.status).toBe(503);
+    const body = await response.json() as { code: string };
+    expect(body.code).toBe('age_review_check_failed');
+
+    await drain(waitUntil);
+    expect(keycastCalls(fetchSpy)).toHaveLength(0);
+
+    fetchSpy.mockRestore();
+  });
+
   it('refuses a reversal when the case lookup itself fails, rather than lifting the hold', async () => {
     // Fail closed on the reversal direction: an unchecked unban silently lifts a
     // minor-safety hold and reports success, so nobody learns the check never

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -412,6 +412,41 @@ describe('relay-rpc account-state side effects', () => {
     fetchSpy.mockRestore();
   });
 
+  it('allow_pubkey via /api/moderate forwards the guard 409 instead of flattening it to 500', async () => {
+    // allow_pubkey re-enters handleRelayRpc with unbanpubkey, so it inherits the
+    // guard. Re-wrapping at 500 would drop code/caseId/state that callers route
+    // on, and would label a permanent refusal as transient, which retrying
+    // clients treat as "try again".
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+    const env = makeAccountStateEnvWithDb({ id: 'case-allow', state: 'restricted_pending_user_response' });
+
+    const response = await worker.fetch(
+      new Request('https://api-relay-prod.divine.video/api/moderate', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Key': 'test-admin-key',
+          Origin: 'https://app.divine.video',
+        },
+        body: JSON.stringify({ action: 'allow_pubkey', pubkey: VALID_PUBKEY }),
+      }),
+      env,
+      testCtx,
+    );
+
+    expect(response.status).toBe(409);
+    const body = await response.json() as { code: string; caseId: string };
+    expect(body.code).toBe('age_review_active');
+    expect(body.caseId).toBe('case-allow');
+
+    await drain(waitUntil);
+    expect(keycastCalls(fetchSpy)).toHaveLength(0);
+
+    fetchSpy.mockRestore();
+  });
+
   it('suspendpubkey is refused when the target has an active age-review case', async () => {
     const fetchSpy = makeFetchSpy();
     const waitUntil = vi.fn();

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -684,13 +684,13 @@ describe('relay-rpc account-state side effects', () => {
     fetchSpy.mockRestore();
   });
 
-  it('refuses a reversal whose pubkey is not canonical hex, rather than skipping the check', async () => {
+  it('rejects a non-canonical pubkey with a 400, before the guard runs', async () => {
     // The guard's lookup is byte-exact, so a non-canonical pubkey cannot match a
     // real case even when one exists -- it would report "no case" for an account
-    // that may well be under review. That is the same "the check cannot happen"
-    // the missing-binding and failed-lookup paths already refuse on, so it
-    // refuses identically instead of relying on a downstream format check in
-    // another module to stop the mutation.
+    // that may well be under review. Answer it here rather than leaving it to
+    // the guard: this is the same 400 handleGetActiveAgeReviewCase already gives
+    // for the same regex, and a malformed pubkey never becomes valid on a retry,
+    // so the retryable 5xx class is the wrong answer for it.
     const fetchSpy = makeFetchSpy();
     const waitUntil = vi.fn();
     const testCtx = { waitUntil } as unknown as ExecutionContext;
@@ -698,17 +698,19 @@ describe('relay-rpc account-state side effects', () => {
     const response = await callRelayRpc(
       'unbanpubkey', [VALID_PUBKEY.toUpperCase()], makeAccountStateEnvWithDb(null), testCtx,
     );
-    expect(response.status).toBe(503);
-    const body = await response.json() as { code: string };
-    expect(body.code).toBe('age_review_check_failed');
+    expect(response.status).toBe(400);
+    const body = await response.json() as { error: string };
+    expect(body.error).toBe('Invalid pubkey');
 
     await drain(waitUntil);
-    expect(keycastCalls(fetchSpy)).toHaveLength(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
 
     fetchSpy.mockRestore();
   });
 
-  it('still lets a suspend through with a non-canonical pubkey (enforce direction stays open)', async () => {
+  it('rejects a non-canonical pubkey on the enforce direction too', async () => {
+    // Not a fail-open/fail-closed question: the value is unusable for suspend as
+    // well, since the relay stores these bytes exactly.
     const fetchSpy = makeFetchSpy();
     const waitUntil = vi.fn();
     const testCtx = { waitUntil } as unknown as ExecutionContext;
@@ -716,7 +718,10 @@ describe('relay-rpc account-state side effects', () => {
     const response = await callRelayRpc(
       'suspendpubkey', [VALID_PUBKEY.toUpperCase(), 'policy'], makeAccountStateEnvWithDb(null), testCtx,
     );
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(400);
+
+    await drain(waitUntil);
+    expect(fetchSpy).not.toHaveBeenCalled();
 
     fetchSpy.mockRestore();
   });

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -248,6 +248,22 @@ describe('relay-rpc account-state side effects', () => {
     } as never;
   }
 
+  // D1 present but throwing, to exercise the guard's fail-open / fail-closed split.
+  function makeAccountStateEnvWithFailingCaseLookup() {
+    return {
+      ...(makeAccountStateEnvWithDb(null) as unknown as Record<string, unknown>),
+      DB: {
+        prepare: () => ({
+          bind: () => ({
+            first: async () => {
+              throw new Error('D1 unavailable');
+            },
+          }),
+        }),
+      },
+    } as never;
+  }
+
   // Routes a mocked fetch by URL so each backend can be asserted independently.
   function makeFetchSpy() {
     return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
@@ -443,6 +459,58 @@ describe('relay-rpc account-state side effects', () => {
 
     await drain(waitUntil);
     expect(keycastCalls(fetchSpy)).toHaveLength(0);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('refuses a reversal when the case lookup itself fails, rather than lifting the hold', async () => {
+    // Fail closed on the reversal direction: an unchecked unban silently lifts a
+    // minor-safety hold and reports success, so nobody learns the check never
+    // ran. 503, not 409 -- "could not check", not "there is a case".
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+    const env = makeAccountStateEnvWithFailingCaseLookup();
+
+    const response = await callRelayRpc('unbanpubkey', [VALID_PUBKEY], env, testCtx);
+    expect(response.status).toBe(503);
+    const body = await response.json() as { code: string };
+    expect(body.code).toBe('age_review_check_failed');
+
+    // Nothing lifted: no Keycast status change on a refused reversal.
+    await drain(waitUntil);
+    expect(keycastCalls(fetchSpy)).toHaveLength(0);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('refuses unsuspendpubkey the same way when the lookup fails', async () => {
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+
+    const response = await callRelayRpc(
+      'unsuspendpubkey', [VALID_PUBKEY], makeAccountStateEnvWithFailingCaseLookup(), testCtx,
+    );
+    expect(response.status).toBe(503);
+    await drain(waitUntil);
+    expect(keycastCalls(fetchSpy)).toHaveLength(0);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('still lets a suspend through when the lookup fails (over-enforcing is the safe side)', async () => {
+    // The enforce direction keeps failing open: a suspend applied without the
+    // check is visible and reversible, and blocking it would stop moderation
+    // during an outage.
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+
+    const response = await callRelayRpc(
+      'suspendpubkey', [VALID_PUBKEY, 'policy'], makeAccountStateEnvWithFailingCaseLookup(), testCtx,
+    );
+    expect(response.status).toBe(200);
 
     fetchSpy.mockRestore();
   });

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -266,6 +266,9 @@ describe('relay-rpc account-state side effects', () => {
   }
 
   // D1 present but throwing, to exercise the guard's fail-open / fail-closed split.
+  // A real outage fails the schema DDL too, not just the lookup: `.run()` is what
+  // ensureSchemaOnce calls, and modelling only `.first()` hid the bootstrap
+  // escaping as an unhandled rejection instead of reaching the guard's decision.
   function makeAccountStateEnvWithFailingCaseLookup() {
     return {
       ...(makeAccountStateEnvWithDb(null) as unknown as Record<string, unknown>),
@@ -275,7 +278,13 @@ describe('relay-rpc account-state side effects', () => {
             first: async () => {
               throw new Error('D1 unavailable');
             },
+            run: async () => {
+              throw new Error('D1 unavailable');
+            },
           }),
+          run: async () => {
+            throw new Error('D1 unavailable');
+          },
         }),
       },
     } as never;
@@ -303,6 +312,35 @@ describe('relay-rpc account-state side effects', () => {
     testCtx: ExecutionContext,
   ): Promise<Response> {
     return worker.fetch(
+      new Request('https://api-relay-prod.divine.video/api/relay-rpc', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Key': 'test-admin-key',
+          Origin: 'https://app.divine.video',
+        },
+        body: JSON.stringify({ method, params }),
+      }),
+      testEnv,
+      testCtx,
+    );
+  }
+
+  // Same request against a COLD isolate. `schemaReady` in index.ts is module-level,
+  // so the first test to reach ensureSchemaOnce makes it a no-op for every test
+  // after it -- which silently stops the bootstrap path from being exercised at
+  // all. Re-importing under vi.resetModules() is the only way to test what a
+  // freshly started worker does on its first request, which is the only time the
+  // DDL actually runs.
+  async function callRelayRpcColdIsolate(
+    method: string,
+    params: string[],
+    testEnv: never,
+    testCtx: ExecutionContext,
+  ): Promise<Response> {
+    vi.resetModules();
+    const freshWorker = (await import('./index')).default;
+    return freshWorker.fetch(
       new Request('https://api-relay-prod.divine.video/api/relay-rpc', {
         method: 'POST',
         headers: {
@@ -461,6 +499,11 @@ describe('relay-rpc account-state side effects', () => {
     // No Keycast status change: the hold must survive the refused unban.
     await drain(waitUntil);
     expect(keycastCalls(fetchSpy)).toHaveLength(0);
+    // And nothing went out at all -- the relay un-ban is the action being
+    // guarded, so the refusal has to land BEFORE it, not merely report 409
+    // afterwards. Asserting only on Keycast would miss a guard that ran late,
+    // since Keycast is a waitUntil side effect skipped on any early return.
+    expect(fetchSpy).not.toHaveBeenCalled();
 
     fetchSpy.mockRestore();
   });
@@ -588,6 +631,106 @@ describe('relay-rpc account-state side effects', () => {
     const kc = keycastCalls(fetchSpy);
     expect(kc).toHaveLength(1);
     expect(kc[0].status).toBe('suspended');
+
+    fetchSpy.mockRestore();
+  });
+
+  // The three below run against a cold isolate, so the schema bootstrap actually
+  // executes rather than being skipped by a flag an earlier test already set.
+  // Bootstrapping is part of the check, not a precondition for it: when D1 is
+  // down the DDL fails too, and that failure must reach the same fail-open /
+  // fail-closed decision as a failed lookup instead of escaping the handler.
+  it('still lets a suspend through on a cold isolate when D1 is down entirely', async () => {
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+
+    const response = await callRelayRpcColdIsolate(
+      'suspendpubkey', [VALID_PUBKEY, 'policy'], makeAccountStateEnvWithFailingCaseLookup(), testCtx,
+    );
+    expect(response.status).toBe(200);
+    // CORS must survive: a bare rejection loses the headers and the UI sees a
+    // network error instead of the documented body.
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://app.divine.video');
+
+    await drain(waitUntil);
+    const kc = keycastCalls(fetchSpy);
+    expect(kc).toHaveLength(1);
+    expect(kc[0].status).toBe('suspended');
+
+    fetchSpy.mockRestore();
+  });
+
+  it('refuses an unban on a cold isolate when D1 is down entirely', async () => {
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+
+    const response = await callRelayRpcColdIsolate(
+      'unbanpubkey', [VALID_PUBKEY], makeAccountStateEnvWithFailingCaseLookup(), testCtx,
+    );
+    expect(response.status).toBe(503);
+    const body = await response.json() as { code: string };
+    expect(body.code).toBe('age_review_check_failed');
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://app.divine.video');
+
+    await drain(waitUntil);
+    expect(keycastCalls(fetchSpy)).toHaveLength(0);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('refuses a reversal whose pubkey is not canonical hex, rather than skipping the check', async () => {
+    // The guard's lookup is byte-exact, so a non-canonical pubkey cannot match a
+    // real case even when one exists -- it would report "no case" for an account
+    // that may well be under review. That is the same "the check cannot happen"
+    // the missing-binding and failed-lookup paths already refuse on, so it
+    // refuses identically instead of relying on a downstream format check in
+    // another module to stop the mutation.
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+
+    const response = await callRelayRpc(
+      'unbanpubkey', [VALID_PUBKEY.toUpperCase()], makeAccountStateEnvWithDb(null), testCtx,
+    );
+    expect(response.status).toBe(503);
+    const body = await response.json() as { code: string };
+    expect(body.code).toBe('age_review_check_failed');
+
+    await drain(waitUntil);
+    expect(keycastCalls(fetchSpy)).toHaveLength(0);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('still lets a suspend through with a non-canonical pubkey (enforce direction stays open)', async () => {
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+
+    const response = await callRelayRpc(
+      'suspendpubkey', [VALID_PUBKEY.toUpperCase(), 'policy'], makeAccountStateEnvWithDb(null), testCtx,
+    );
+    expect(response.status).toBe(200);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('refuses an unsuspend on a cold isolate when D1 is down entirely', async () => {
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+
+    const response = await callRelayRpcColdIsolate(
+      'unsuspendpubkey', [VALID_PUBKEY], makeAccountStateEnvWithFailingCaseLookup(), testCtx,
+    );
+    expect(response.status).toBe(503);
+    const body = await response.json() as { code: string };
+    expect(body.code).toBe('age_review_check_failed');
+
+    await drain(waitUntil);
+    expect(keycastCalls(fetchSpy)).toHaveLength(0);
 
     fetchSpy.mockRestore();
   });

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -390,6 +390,28 @@ describe('relay-rpc account-state side effects', () => {
     fetchSpy.mockRestore();
   });
 
+  it('unbanpubkey is refused when the target has an active age-review case', async () => {
+    // unbanpubkey calls unsuspendUser, which sets Keycast status to active and so
+    // lifts an age-review suspension as well as a ban. Without the guard, a Coop
+    // Unban-User restores login and signing on an account still under review.
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+    const env = makeAccountStateEnvWithDb({ id: 'case-unban', state: 'restricted_pending_user_response' });
+
+    const response = await callRelayRpc('unbanpubkey', [VALID_PUBKEY], env, testCtx);
+    expect(response.status).toBe(409);
+    const body = await response.json() as { code: string; caseId: string };
+    expect(body.code).toBe('age_review_active');
+    expect(body.caseId).toBe('case-unban');
+
+    // No Keycast status change: the hold must survive the refused unban.
+    await drain(waitUntil);
+    expect(keycastCalls(fetchSpy)).toHaveLength(0);
+
+    fetchSpy.mockRestore();
+  });
+
   it('suspendpubkey is refused when the target has an active age-review case', async () => {
     const fetchSpy = makeFetchSpy();
     const waitUntil = vi.fn();

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -431,7 +431,11 @@ describe('relay-rpc account-state side effects', () => {
     const testCtx = { waitUntil } as unknown as ExecutionContext;
     const env = makeAccountStateEnvWithDb(null, { requireSchema: true });
 
-    const response = await callRelayRpc('unbanpubkey', [VALID_PUBKEY], env, testCtx);
+    // Cold isolate, or this asserts nothing: `schemaReady` is module-level, so
+    // once any earlier test has reached ensureSchemaOnce the bootstrap is a
+    // no-op here and the test passes without exercising it. That also made it
+    // the file's last order-dependent test.
+    const response = await callRelayRpcColdIsolate('unbanpubkey', [VALID_PUBKEY], env, testCtx);
     expect(response.status).toBe(200);
 
     await drain(waitUntil);
@@ -747,10 +751,13 @@ describe('relay-rpc account-state side effects', () => {
     expect(body.code).toBe('age_review_active');
     expect(body.caseId).toBe('case-1');
 
-    // The guard short-circuits before any enforcement side effect.
+    // The guard short-circuits before any enforcement side effect. Keycast and
+    // the DM are waitUntil work skipped on any early return, so they cannot show
+    // that the refusal beat the relay call -- assert nothing went out at all.
     await drain(waitUntil);
     expect(keycastCalls(fetchSpy)).toHaveLength(0);
     expect(await notifyBodies(fetchSpy)).toHaveLength(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
 
     fetchSpy.mockRestore();
   });
@@ -766,6 +773,8 @@ describe('relay-rpc account-state side effects', () => {
     const body = await response.json() as { code: string };
     expect(body.code).toBe('age_review_active');
     expect(keycastCalls(fetchSpy)).toHaveLength(0);
+    // As above: the refusal has to land before the relay call, not after it.
+    expect(fetchSpy).not.toHaveBeenCalled();
 
     fetchSpy.mockRestore();
   });

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -372,7 +372,7 @@ describe('relay-rpc account-state side effects', () => {
     const waitUntil = vi.fn();
     const testCtx = { waitUntil } as unknown as ExecutionContext;
 
-    const response = await callRelayRpc('unsuspendpubkey', [VALID_PUBKEY], makeAccountStateEnv(), testCtx);
+    const response = await callRelayRpc('unsuspendpubkey', [VALID_PUBKEY], makeAccountStateEnvWithDb(null), testCtx);
     expect(response.status).toBe(200);
     await drain(waitUntil);
 
@@ -392,7 +392,7 @@ describe('relay-rpc account-state side effects', () => {
     const waitUntil = vi.fn();
     const testCtx = { waitUntil } as unknown as ExecutionContext;
 
-    const response = await callRelayRpc('unbanpubkey', [VALID_PUBKEY], makeAccountStateEnv(), testCtx);
+    const response = await callRelayRpc('unbanpubkey', [VALID_PUBKEY], makeAccountStateEnvWithDb(null), testCtx);
     expect(response.status).toBe(200);
     await drain(waitUntil);
 
@@ -484,6 +484,40 @@ describe('relay-rpc account-state side effects', () => {
     fetchSpy.mockRestore();
   });
 
+  it('refuses a reversal when there is no DB binding at all', async () => {
+    // The persistent version of "the check cannot happen". Handling only the
+    // thrown lookup would leave this case lifting holds while the transient one
+    // refused, which is the wrong way round.
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+
+    const response = await callRelayRpc('unbanpubkey', [VALID_PUBKEY], makeAccountStateEnv(), testCtx);
+    expect(response.status).toBe(503);
+    const body = await response.json() as { code: string };
+    expect(body.code).toBe('age_review_check_failed');
+
+    await drain(waitUntil);
+    expect(keycastCalls(fetchSpy)).toHaveLength(0);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('still lets a suspend through with no DB binding', async () => {
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+
+    const response = await callRelayRpc('suspendpubkey', [VALID_PUBKEY, 'policy'], makeAccountStateEnv(), testCtx);
+    expect(response.status).toBe(200);
+    await drain(waitUntil);
+    const kc = keycastCalls(fetchSpy);
+    expect(kc).toHaveLength(1);
+    expect(kc[0].status).toBe('suspended');
+
+    fetchSpy.mockRestore();
+  });
+
   it('refuses unsuspendpubkey the same way when the lookup fails', async () => {
     const fetchSpy = makeFetchSpy();
     const waitUntil = vi.fn();
@@ -511,6 +545,12 @@ describe('relay-rpc account-state side effects', () => {
       'suspendpubkey', [VALID_PUBKEY, 'policy'], makeAccountStateEnvWithFailingCaseLookup(), testCtx,
     );
     expect(response.status).toBe(200);
+
+    // Failing open must actually let the enforcement through, not just return 200.
+    await drain(waitUntil);
+    const kc = keycastCalls(fetchSpy);
+    expect(kc).toHaveLength(1);
+    expect(kc[0].status).toBe('suspended');
 
     fetchSpy.mockRestore();
   });
@@ -645,7 +685,7 @@ describe('relay-rpc account-state side effects', () => {
         },
         body: JSON.stringify({ action: 'allow_pubkey', pubkey: VALID_PUBKEY }),
       }),
-      makeAccountStateEnv(),
+      makeAccountStateEnvWithDb(null),
       testCtx,
     );
     expect(response.status).toBe(200);

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -231,8 +231,9 @@ describe('relay-rpc account-state side effects', () => {
   // Same env with a DB whose active-case lookup returns `caseRow` only when it
   // is non-terminal, mirroring the guard query's WHERE state NOT IN
   // (cleared, denied_closed). A terminal or null row resolves to null.
-  function makeAccountStateEnvWithDb(caseRow: { id: string; state: string } | null) {
+  function makeAccountStateEnvWithDb(caseRow: { id: string; state: string } | null, opts: { requireSchema?: boolean } = {}) {
     const active = caseRow && !['cleared', 'denied_closed'].includes(caseRow.state) ? caseRow : null;
+    let ageReviewCasesExists = !opts.requireSchema;
     return {
       ALLOWED_ORIGINS: 'https://app.divine.video',
       RELAY_URL: 'wss://relay.divine.video',
@@ -243,7 +244,23 @@ describe('relay-rpc account-state side effects', () => {
       KEYCAST_URL: 'https://login.divine.video',
       KEYCAST_SERVICE_TOKEN: 'keycast-token',
       DB: {
-        prepare: () => ({ bind: () => ({ first: async () => active }) }),
+        prepare: (sql: string) => ({
+          bind: () => ({
+            first: async () => {
+              if (sql.includes('FROM age_review_cases') && !ageReviewCasesExists) {
+                throw new Error('no such table: age_review_cases');
+              }
+              return active;
+            },
+            run: async () => ({ success: true, meta: { changes: 1 } }),
+          }),
+          run: async () => {
+            if (sql.includes('CREATE TABLE IF NOT EXISTS age_review_cases')) {
+              ageReviewCasesExists = true;
+            }
+            return { success: true, meta: { changes: 0 } };
+          },
+        }),
       },
     } as never;
   }
@@ -363,6 +380,26 @@ describe('relay-rpc account-state side effects', () => {
     expect(kc).toHaveLength(1);
     expect(kc[0].url).toContain(`/api/admin/users/${VALID_PUBKEY}/status`);
     expect(kc[0].status).toBe('suspended');
+
+    fetchSpy.mockRestore();
+  });
+
+  it('bootstraps age-review schema before guarding a relay-rpc reversal', async () => {
+    // /api/relay-rpc can be the first request to touch a freshly provisioned D1.
+    // The guard must create age_review_cases before querying it, otherwise
+    // fail-closed turns a missing table into a permanent reversal outage.
+    const fetchSpy = makeFetchSpy();
+    const waitUntil = vi.fn();
+    const testCtx = { waitUntil } as unknown as ExecutionContext;
+    const env = makeAccountStateEnvWithDb(null, { requireSchema: true });
+
+    const response = await callRelayRpc('unbanpubkey', [VALID_PUBKEY], env, testCtx);
+    expect(response.status).toBe(200);
+
+    await drain(waitUntil);
+    const kc = keycastCalls(fetchSpy);
+    expect(kc).toHaveLength(1);
+    expect(kc[0].status).toBe('active');
 
     fetchSpy.mockRestore();
   });

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -185,7 +185,9 @@ describe('notifyModerationService null token', () => {
         },
         body: JSON.stringify({
           method: 'banpubkey',
-          params: ['deadbeef', 'test reason'],
+          // A real 64-hex pubkey: banpubkey rejects a non-canonical one outright,
+          // and this test is about the DM path, not the pubkey format.
+          params: ['abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234', 'test reason'],
         }),
       }),
       testEnv,
@@ -717,23 +719,23 @@ describe('relay-rpc account-state side effects', () => {
     fetchSpy.mockRestore();
   });
 
-  it('rejects a non-canonical pubkey with a 400, before the guard runs', async () => {
-    // The guard's lookup is byte-exact, so a non-canonical pubkey cannot match a
-    // real case even when one exists -- it would report "no case" for an account
-    // that may well be under review. Answer it here rather than leaving it to
-    // the guard: this is the same 400 handleGetActiveAgeReviewCase already gives
-    // for the same regex, and a malformed pubkey never becomes valid on a retry,
-    // so the retryable 5xx class is the wrong answer for it.
+  it('rejects a non-canonical pubkey on the ENFORCE direction', async () => {
+    // A value the relay stores byte-exactly enforces on nobody, so a ban or suspend
+    // carrying one is a no-op that reports success. 400 rather than the guard's 503:
+    // this is the same answer handleGetActiveAgeReviewCase gives for the same regex,
+    // and unlike a D1 outage a malformed pubkey never becomes valid on a retry.
     const fetchSpy = makeFetchSpy();
     const waitUntil = vi.fn();
     const testCtx = { waitUntil } as unknown as ExecutionContext;
 
-    const response = await callRelayRpc(
-      'unbanpubkey', [VALID_PUBKEY.toUpperCase()], makeAccountStateEnvWithDb(null), testCtx,
-    );
-    expect(response.status).toBe(400);
-    const body = await response.json() as { error: string };
-    expect(body.error).toBe('Invalid pubkey');
+    for (const method of ['banpubkey', 'suspendpubkey']) {
+      const response = await callRelayRpc(
+        method, [VALID_PUBKEY.toUpperCase(), 'policy'], makeAccountStateEnvWithDb(null), testCtx,
+      );
+      expect(response.status, `${method} must reject a non-canonical pubkey`).toBe(400);
+      const body = await response.json() as { error: string };
+      expect(body.error).toBe('Invalid pubkey');
+    }
 
     await drain(waitUntil);
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -741,20 +743,21 @@ describe('relay-rpc account-state side effects', () => {
     fetchSpy.mockRestore();
   });
 
-  it('rejects a non-canonical pubkey on the enforce direction too', async () => {
-    // Not a fail-open/fail-closed question: the value is unusable for suspend as
-    // well, since the relay stores these bytes exactly.
+  it('lets the REVERSE direction carry a non-canonical pubkey, so a bad row stays removable', async () => {
+    // Deliberately asymmetric. banpubkey does not go through this check on main and
+    // rows written before it did still exist, stored byte-exactly. If the un-ban
+    // refused what the ban accepted, those rows could never be cleared from the UI --
+    // cleanup would be stricter than the thing that created the mess. Nothing is
+    // risked by allowing it: an age-review case is keyed to a real lowercase pubkey,
+    // so a non-canonical value cannot have one to skip.
     const fetchSpy = makeFetchSpy();
     const waitUntil = vi.fn();
     const testCtx = { waitUntil } as unknown as ExecutionContext;
 
     const response = await callRelayRpc(
-      'suspendpubkey', [VALID_PUBKEY.toUpperCase(), 'policy'], makeAccountStateEnvWithDb(null), testCtx,
+      'unbanpubkey', [VALID_PUBKEY.toUpperCase()], makeAccountStateEnvWithDb(null), testCtx,
     );
-    expect(response.status).toBe(400);
-
-    await drain(waitUntil);
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
 
     fetchSpy.mockRestore();
   });

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1005,13 +1005,30 @@ async function handleRelayRpc(
     return jsonResponse({ success: false, error: 'Missing method' }, 400, corsHeaders);
   }
 
-  // Age-review guard: a bare suspend/unsuspend on a pubkey with an open
+  // Age-review guard: a bare account-state change on a pubkey with an open
   // (non-terminal) age-review case must not half-enforce (Suspend orphans the
   // case) or silently lift the hold (Unsuspend skips verification). Refuse and
   // route the moderator to the case; Restrict/Clear live in the age-review flow.
-  // Age-review's own enforcement calls the nip86 helpers directly, and internal
-  // moderation/bulk callers use ban*/unban* only, so neither reaches this guard.
-  if (body.method === 'suspendpubkey' || body.method === 'unsuspendpubkey') {
+  //
+  // unbanpubkey is included because it calls unsuspendUser, which sets Keycast
+  // status to active and so lifts a suspension as well as a ban. An unban on an
+  // account under age review therefore restores login and signing while skipping
+  // the case, which is exactly what this guard exists to prevent. Nothing reached
+  // it from outside until the Coop enforcement adapter made unbanpubkey callable.
+  //
+  // banpubkey is deliberately NOT included. It is a severe-action escape hatch:
+  // a moderator who finds something like CSAM on an account under review must be
+  // able to act immediately rather than resolve the case first. The distinction
+  // that makes this coherent is that suspend half-enforces and orphans the case,
+  // whereas a ban resolves the matter outright. Pinned by an existing test.
+  //
+  // Age-review's own enforcement calls the nip86 helpers directly, so it does not
+  // reach this guard and can still act on its own cases.
+  if (
+    body.method === 'suspendpubkey' ||
+    body.method === 'unsuspendpubkey' ||
+    body.method === 'unbanpubkey'
+  ) {
     const target = body.params?.[0] ? String(body.params[0]) : '';
     const guarded = await ageReviewActiveGuard(target, env, corsHeaders,
       'This account is under age review. Restrict or clear it from the Age Review flow.');

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1066,25 +1066,35 @@ async function handleRelayRpc(
   //
   // Age-review's own enforcement calls the nip86 helpers directly, so it does not
   // reach this guard and can still act on its own cases.
+  const target = body.params?.[0] ? String(body.params[0]) : '';
+
+  // Canonical hex is required to ENFORCE, but deliberately not to REVERSE.
+  //
+  // The relay stores and matches these bytes exactly, so a ban or suspend carrying a
+  // non-canonical pubkey enforces on nobody while reporting success. 400 rather than
+  // the guard's 503: it is the same answer handleGetActiveAgeReviewCase gives for the
+  // same regex, and unlike a D1 outage a malformed pubkey never becomes valid on a
+  // retry, so the retryable class would be a lie.
+  //
+  // The reverse direction must NOT get the same check. banpubkey did not always have
+  // one, and rows written with a non-canonical value are stored byte-exactly and are
+  // removable only by sending that same value back. Refusing it here would make
+  // cleanup stricter than the thing that created the mess, leaving those rows stuck in
+  // the ban list with no way out of the UI. Nothing is risked by allowing it: an
+  // age-review case is keyed to a real lowercase pubkey, so a non-canonical value has
+  // no case to skip past, which is why the guard also lets it through.
+  if (
+    (body.method === 'banpubkey' || body.method === 'suspendpubkey')
+    && !/^[0-9a-f]{64}$/.test(target)
+  ) {
+    return jsonResponse({ success: false, error: 'Invalid pubkey' }, 400, corsHeaders);
+  }
+
   if (
     body.method === 'suspendpubkey' ||
     body.method === 'unsuspendpubkey' ||
     body.method === 'unbanpubkey'
   ) {
-    const target = body.params?.[0] ? String(body.params[0]) : '';
-
-    // Canonical hex or nothing, decided before the guard. The guard's lookup is
-    // byte-exact, so a non-canonical pubkey could never match a real case, and
-    // the relay stores these bytes exactly, so it could never enforce either.
-    // 400 rather than the guard's 503: this is the same answer
-    // handleGetActiveAgeReviewCase gives for the same regex, and unlike a D1
-    // outage a malformed pubkey never becomes valid on a retry, so the retryable
-    // class would be a lie. The guard keeps its own check for anything that
-    // reaches it by another route.
-    if (!/^[0-9a-f]{64}$/.test(target)) {
-      return jsonResponse({ success: false, error: 'Invalid pubkey' }, 400, corsHeaders);
-    }
-
     if (env.DB) {
       // Bootstrapping is part of the check, not a precondition for it: a DDL
       // failure must reach the same fail-open/fail-closed decision as a failed

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -973,9 +973,11 @@ async function handleModerate(
           // both destroys that contract and mislabels a permanent refusal as
           // transient, which is the shape retrying clients treat as "try again".
           //
-          // Note this is not 409-only. handleRelayRpc has one other reachable
-          // non-ok return: a 400 when the underlying NIP-86 call fails. So a
-          // relay-side failure now surfaces here as 400 rather than 500, which
+          // Note this is not 409-only. handleRelayRpc has three reachable
+          // non-ok returns: the guard's 409, its 503 when the case lookup
+          // cannot run under fail-closed, and a 400 when the underlying NIP-86
+          // call fails. So a relay-side failure now surfaces here as 400 rather
+          // than 500, which
           // makes /api/moderate consistent with /api/relay-rpc (already 400 in
           // that case) but does flip it from retryable to terminal for an
           // automated caller. Deliberate: consistency is worth more than an

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1067,6 +1067,18 @@ async function handleRelayRpc(
     body.method === 'unsuspendpubkey' ||
     body.method === 'unbanpubkey'
   ) {
+    // Canonical hex or nothing, decided before the guard. The guard's lookup is
+    // byte-exact, so a non-canonical pubkey could never match a real case, and
+    // the relay stores these bytes exactly, so it could never enforce either.
+    // 400 rather than the guard's 503: this is the same answer
+    // handleGetActiveAgeReviewCase gives for the same regex, and unlike a D1
+    // outage a malformed pubkey never becomes valid on a retry, so the retryable
+    // class would be a lie. The guard keeps its own check for anything that
+    // reaches it by another route.
+    if (!/^[0-9a-f]{64}$/.test(body.params?.[0] ? String(body.params[0]) : '')) {
+      return jsonResponse({ success: false, error: 'Invalid pubkey' }, 400, corsHeaders);
+    }
+
     if (env.DB) {
       // Bootstrapping is part of the check, not a precondition for it: a DDL
       // failure must reach the same fail-open/fail-closed decision as a failed

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1054,6 +1054,7 @@ async function handleRelayRpc(
     body.method === 'unsuspendpubkey' ||
     body.method === 'unbanpubkey'
   ) {
+    if (env.DB) await ensureSchemaOnce(env.DB);
     const target = body.params?.[0] ? String(body.params[0]) : '';
     // Reversals fail closed: if the case lookup itself fails we refuse rather
     // than lift a hold without having checked. Suspend keeps the default,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -558,6 +558,17 @@ export default {
         // enqueue-time only — a case opened while a chunked job is already
         // draining does not abort it (aborting mid-job would leave
         // half-applied state; the job was legitimate when it started).
+        // No `failClosed` here, deliberately, and NOT because bulk has no
+        // reversal: `un-age-restrict-all` is one, and it lifts restrictions this
+        // very case imposed. The guard's docstring argues fail-closed by
+        // direction, which taken alone would cover it. Bulk is partitioned by
+        // blast radius instead. A refused bulk job is one moderator's click
+        // failing loudly in the UI, with no automated caller behind it, so an
+        // outage that blocks all three actions stops content moderation
+        // wholesale for a human who has no other route -- whereas a refused
+        // reversal only defers restoring an account that stays held meanwhile.
+        // If bulk ever becomes reachable from automation, revisit this: the
+        // reasoning is about who is on the other end, not about the actions.
         let peeked: { pubkey?: string } | undefined;
         try {
           peeked = await request.clone().json() as { pubkey?: string };
@@ -977,11 +988,13 @@ async function handleModerate(
           // non-ok returns: the guard's 409, its 503 when the case lookup
           // cannot run under fail-closed, and a 400 when the underlying NIP-86
           // call fails. So a relay-side failure now surfaces here as 400 rather
-          // than 500, which
-          // makes /api/moderate consistent with /api/relay-rpc (already 400 in
-          // that case) but does flip it from retryable to terminal for an
-          // automated caller. Deliberate: consistency is worth more than an
-          // accidental 500, and no current caller consumes this path.
+          // than 500, which makes /api/moderate consistent with /api/relay-rpc
+          // (already 400 in that case) but does flip it from retryable to
+          // terminal for an automated caller. Deliberate: consistency is worth
+          // more than an accidental 500, and no current caller consumes this
+          // path. Only allow_pubkey forwards: delete_event and ban_pubkey still
+          // flatten to 500, because neither is guarded and so neither can
+          // produce a 409/503 whose code a caller would need.
           return rpcResponse;
         }
         const rpcResult = await rpcResponse.json() as { success: boolean; error?: string };
@@ -1054,7 +1067,21 @@ async function handleRelayRpc(
     body.method === 'unsuspendpubkey' ||
     body.method === 'unbanpubkey'
   ) {
-    if (env.DB) await ensureSchemaOnce(env.DB);
+    if (env.DB) {
+      // Bootstrapping is part of the check, not a precondition for it: a DDL
+      // failure must reach the same fail-open/fail-closed decision as a failed
+      // lookup rather than escape as an unhandled rejection. This route returns
+      // its promise without awaiting (see the /api/relay-rpc case above), so the
+      // top-level catch never sees a rejection from here -- it would leave the
+      // caller with no body and no CORS headers. Swallow and let the guard
+      // decide: the lookup below fails the same way, refusing a reversal and
+      // proceeding for a suspend.
+      try {
+        await ensureSchemaOnce(env.DB);
+      } catch (err) {
+        console.error('[handleRelayRpc] age-review schema bootstrap failed:', err);
+      }
+    }
     const target = body.params?.[0] ? String(body.params[0]) : '';
     // Reversals fail closed: if the case lookup itself fails we refuse rather
     // than lift a hold without having checked. Suspend keeps the default,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -984,10 +984,14 @@ async function handleModerate(
           // both destroys that contract and mislabels a permanent refusal as
           // transient, which is the shape retrying clients treat as "try again".
           //
-          // Note this is not 409-only. handleRelayRpc has three reachable
+          // Note this is not 409-only. handleRelayRpc has four reachable
           // non-ok returns: the guard's 409, its 503 when the case lookup
-          // cannot run under fail-closed, and a 400 when the underlying NIP-86
-          // call fails. So a relay-side failure now surfaces here as 400 rather
+          // cannot run under fail-closed, a 400 when the underlying NIP-86
+          // call fails, and a 400 for a non-canonical pubkey -- reachable from
+          // right here, since allow_pubkey checks only that body.pubkey is
+          // truthy. The two 400s are indistinguishable by status, so a caller
+          // separating malformed input from a relay failure has to read the
+          // body. So a relay-side failure now surfaces here as 400 rather
           // than 500, which makes /api/moderate consistent with /api/relay-rpc
           // (already 400 in that case) but does flip it from retryable to
           // terminal for an automated caller. Deliberate: consistency is worth

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1049,8 +1049,12 @@ async function handleRelayRpc(
   // unbanpubkey is included because it calls unsuspendUser, which sets Keycast
   // status to active and so lifts a suspension as well as a ban. An unban on an
   // account under age review therefore restores login and signing while skipping
-  // the case, which is exactly what this guard exists to prevent. Nothing reached
-  // it from outside until the Coop enforcement adapter made unbanpubkey callable.
+  // the case, which is exactly what this guard exists to prevent. Two callers
+  // outside this repo reach it: divine-moderation-service, which has mapped
+  // allow_pubkey -> unbanpubkey onto /api/relay-rpc since 2026-06-08, and the
+  // Coop enforcement adapter, whose reversal routes followed on 2026-06-17.
+  // Only the adapter surfaces the refusal; divine-moderation-service discards
+  // code/caseId/state (divinevideo/divine-moderation-service#191).
   //
   // banpubkey is deliberately NOT included: it is a severe-action escape hatch, so
   // a moderator who finds something like CSAM on an account under review can act

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -984,14 +984,15 @@ async function handleModerate(
           // both destroys that contract and mislabels a permanent refusal as
           // transient, which is the shape retrying clients treat as "try again".
           //
-          // Note this is not 409-only. handleRelayRpc has four reachable
-          // non-ok returns: the guard's 409, its 503 when the case lookup
-          // cannot run under fail-closed, a 400 when the underlying NIP-86
-          // call fails, and a 400 for a non-canonical pubkey -- reachable from
-          // right here, since allow_pubkey checks only that body.pubkey is
-          // truthy. The two 400s are indistinguishable by status, so a caller
-          // separating malformed input from a relay failure has to read the
-          // body. So a relay-side failure now surfaces here as 400 rather
+          // Note this is not 409-only. Three non-ok returns are reachable from
+          // here: the guard's 409, its 503 when the case lookup cannot run
+          // under fail-closed, and a 400 when the underlying NIP-86 call fails.
+          // The canonical-hex 400 is deliberately NOT one of them: allow_pubkey
+          // issues unbanpubkey, which is exempt from that check so a row banned
+          // with a non-canonical value stays removable, so such a value is
+          // forwarded to the relay and comes back 200.
+          //
+          // So a relay-side failure surfaces here as 400 rather
           // than 500, which makes /api/moderate consistent with /api/relay-rpc
           // (already 400 in that case) but does flip it from retryable to
           // terminal for an automated caller. Deliberate: consistency is worth

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1067,6 +1067,8 @@ async function handleRelayRpc(
     body.method === 'unsuspendpubkey' ||
     body.method === 'unbanpubkey'
   ) {
+    const target = body.params?.[0] ? String(body.params[0]) : '';
+
     // Canonical hex or nothing, decided before the guard. The guard's lookup is
     // byte-exact, so a non-canonical pubkey could never match a real case, and
     // the relay stores these bytes exactly, so it could never enforce either.
@@ -1075,7 +1077,7 @@ async function handleRelayRpc(
     // outage a malformed pubkey never becomes valid on a retry, so the retryable
     // class would be a lie. The guard keeps its own check for anything that
     // reaches it by another route.
-    if (!/^[0-9a-f]{64}$/.test(body.params?.[0] ? String(body.params[0]) : '')) {
+    if (!/^[0-9a-f]{64}$/.test(target)) {
       return jsonResponse({ success: false, error: 'Invalid pubkey' }, 400, corsHeaders);
     }
 
@@ -1094,7 +1096,6 @@ async function handleRelayRpc(
         console.error('[handleRelayRpc] age-review schema bootstrap failed:', err);
       }
     }
-    const target = body.params?.[0] ? String(body.params[0]) : '';
     // Reversals fail closed: if the case lookup itself fails we refuse rather
     // than lift a hold without having checked. Suspend keeps the default,
     // because failing open there over-enforces, which is visible and undoable.

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -972,6 +972,14 @@ async function handleModerate(
           // (code/caseId/state) that callers route on, and flattening it to 500
           // both destroys that contract and mislabels a permanent refusal as
           // transient, which is the shape retrying clients treat as "try again".
+          //
+          // Note this is not 409-only. handleRelayRpc has one other reachable
+          // non-ok return: a 400 when the underlying NIP-86 call fails. So a
+          // relay-side failure now surfaces here as 400 rather than 500, which
+          // makes /api/moderate consistent with /api/relay-rpc (already 400 in
+          // that case) but does flip it from retryable to terminal for an
+          // automated caller. Deliberate: consistency is worth more than an
+          // accidental 500, and no current caller consumes this path.
           return rpcResponse;
         }
         const rpcResult = await rpcResponse.json() as { success: boolean; error?: string };

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1053,8 +1053,13 @@ async function handleRelayRpc(
     body.method === 'unbanpubkey'
   ) {
     const target = body.params?.[0] ? String(body.params[0]) : '';
+    // Reversals fail closed: if the case lookup itself fails we refuse rather
+    // than lift a hold without having checked. Suspend keeps the default,
+    // because failing open there over-enforces, which is visible and undoable.
+    const isReversal = body.method === 'unsuspendpubkey' || body.method === 'unbanpubkey';
     const guarded = await ageReviewActiveGuard(target, env, corsHeaders,
-      'This account is under age review. Restrict or clear it from the Age Review flow.');
+      'This account is under age review. Restrict or clear it from the Age Review flow.',
+      { failClosed: isReversal });
     if (guarded) return guarded;
   }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -966,6 +966,14 @@ async function handleModerate(
         });
         // Pass ctx so the unbanpubkey Keycast restore (non-critical) is kept alive.
         const rpcResponse = await handleRelayRpc(rpcRequest, env, corsHeaders, ctx);
+        if (!rpcResponse.ok) {
+          // Forward the inner response rather than re-wrapping at 500. The
+          // age-review guard answers a refused unban with a structured 409
+          // (code/caseId/state) that callers route on, and flattening it to 500
+          // both destroys that contract and mislabels a permanent refusal as
+          // transient, which is the shape retrying clients treat as "try again".
+          return rpcResponse;
+        }
         const rpcResult = await rpcResponse.json() as { success: boolean; error?: string };
         if (!rpcResult.success) {
           return jsonResponse({ success: false, error: rpcResult.error || 'unbanpubkey RPC failed' }, 500, corsHeaders);
@@ -1016,11 +1024,18 @@ async function handleRelayRpc(
   // the case, which is exactly what this guard exists to prevent. Nothing reached
   // it from outside until the Coop enforcement adapter made unbanpubkey callable.
   //
-  // banpubkey is deliberately NOT included. It is a severe-action escape hatch:
-  // a moderator who finds something like CSAM on an account under review must be
-  // able to act immediately rather than resolve the case first. The distinction
-  // that makes this coherent is that suspend half-enforces and orphans the case,
-  // whereas a ban resolves the matter outright. Pinned by an existing test.
+  // banpubkey is deliberately NOT included: it is a severe-action escape hatch, so
+  // a moderator who finds something like CSAM on an account under review can act
+  // without resolving the case first. Pinned by an existing test.
+  //
+  // What makes guarding one direction but not the other coherent is mechanical,
+  // not a matter of taste. banpubkey performs a destructive content purge that
+  // unbanpubkey cannot reverse (see nip86.ts, where suspendpubkey is documented
+  // as the reversible alternative "without the destructive purge that banpubkey
+  // performs"). So guarding the unban removes no recovery path that ever existed
+  // for content; it defers only restoring login and signing, which is precisely
+  // the hold the case owns. Nor is it a one-way door: once the case reaches a
+  // terminal state getActiveAgeReviewCase returns null and the unban proceeds.
   //
   // Age-review's own enforcement calls the nip86 helpers directly, so it does not
   // reach this guard and can still act on its own cases.


### PR DESCRIPTION
## What

An un-ban of a pubkey with an open age-review case is now refused, the same way an un-suspend already was, and the moderator is routed to the case instead of a dead-end error.

Closes #224.

## Why

`unbanpubkey` calls `unsuspendUser`, which sets Keycast status to `active`. That lifts a *suspension* as well as a ban. So un-banning an account under age review restored login and signing while skipping the case entirely, which is what the guard exists to prevent.

The guard's own comment stated the assumption that made this safe: *"internal moderation/bulk callers use ban*/unban* only, so neither reaches this guard."* That is no longer true. Two internal callers already reach it (the admin UI's un-ban, and `allow_pubkey` via `/api/moderate`, which re-enters `handleRelayRpc`), and two services outside this repo reach it: `divine-moderation-service`, which has mapped `allow_pubkey` -> `unbanpubkey` onto `/api/relay-rpc` since 2026-06-08, and the Coop enforcement adapter, whose reversal routes followed on 2026-06-17.

## What changes for a moderator

Four things they will notice:

1. **Un-ban and Allow are refused on an account under age review**, with a redirect to the case rather than a red error toast. Resolve the case and the un-ban proceeds normally.
2. **If the age-review check itself cannot run, a reversal is refused** rather than going through unchecked. Previously a database problem meant the check silently did not happen and the un-ban succeeded, with nobody learning the hold had been lifted without review. The cost is accepted: during a real outage, reversals are blocked. An outage long enough to matter needs fixing rather than papering over, and `banpubkey` stays unguarded so severe enforcement still works throughout.
3. **`allow_pubkey` via `/api/moderate` now returns the refusal it was given** instead of flattening everything to a 500, so callers can tell a permanent refusal from a transient failure. Only `allow_pubkey`: `delete_event` and `ban_pubkey` still flatten, because neither is guarded and so neither can produce a code a caller would need.
4. **A malformed pubkey is rejected outright on the ENFORCE direction.** `banpubkey` and `suspendpubkey` now answer a non-canonical `params[0]` with `400 Invalid pubkey` before the guard runs, matching what `handleGetActiveAgeReviewCase` already does for the same input. Previously it was forwarded: the relay matches these bytes exactly, so it enforced on nobody while reporting success, and the guard's lookup would have missed a real open case for the same reason. The two REVERSALS deliberately still accept one, so a row banned with a non-canonical value stays removable -- pinned by "lets the REVERSE direction carry a non-canonical pubkey, so a bad row stays removable". The Add User dialog now canonicalises what you paste, so an uppercase pubkey works rather than silently doing nothing.

## Deliberately unchanged

- **`banpubkey` is not guarded.** It is the severe-action escape hatch, pinned by an existing test: a moderator who finds something severe must be able to act without resolving the case first. The reason the asymmetry is coherent is mechanical rather than a matter of taste, and is now written next to the code: `banpubkey` performs a destructive content purge that `unbanpubkey` cannot reverse, so guarding the un-ban removes no recovery path that ever existed for content. It defers only restoring login and signing, which is the hold the case owns.
- **`suspendpubkey` still fails open** when the check cannot run. Failing open there over-enforces, which is visible and undone by the moderator who did it, and blocking it would stop moderation during an outage.
- **Bulk moderation still fails open.** Its own test states that as a deliberate choice. Fail-closed is opt-in per call site rather than a change to the shared guard, so this decision did not silently change a path it was not about.

## Notes for review

The redirect logic had been hand-copied to four call sites across **two** components (`UserActions` suspend/unsuspend/bulk, and `UserManagement` unsuspend as its own inline copy). Extending the guard to `unbanpubkey` gives **four new** sites the ability to receive this code, so rather than copy it a fifth through eighth time it now lives in one hook, `useAgeReviewGuardRedirect`, tested directly. (An earlier version of this note said three components and a missed fifth site; `EventDetail` had no guard handling at all, and the `allow_user` dead-end it cited was not reachable on `main`, since the guard there covered only suspend/unsuspend.)

Two call sites are covered only through that shared hook rather than at component level: `UserManagement`'s un-suspend, whose routing predates this change, and `EventDetail`'s un-ban, which has no test file and pulls in several unrelated hooks. Stated as a conscious drop rather than left implicit. Deleting `EventDetail`'s call alone still survives the suite.

## Test plan

- [x] `tsc -p tsconfig.app.json --noEmit` clean
- [x] `eslint` clean
- [x] UI suite: 514 passing, 1 skipped
- [x] Worker suite: 385 passing, plus 21 D1 tests (`npm run test:d1`)
- [x] Mutation-checked in both directions: removing the guard reds the refusal tests; extending it to `suspendpubkey` reds the fail-open test; neutering the missing-DB refusal reds; dropping the `code` argument from `callRelayRpc` reds the parsing test; reverting the schema-bootstrap catch reds the 3 cold-isolate tests, which are the **only** detectors among 384; deleting the guard-ordering assertion lets a reordered guard survive the entire suite; reverting the pubkey canonicalisation reds the UI test
- [x] Order-independence: `worker/src/index.test.ts` is 59/59 across shuffled seeds, previously 57/1
- [x] **Both refusal paths exercised end to end against a local stack**, with the real Coop enforcement adapter in the loop (recipe: `support-trust-safety/docs/moderation/local-validation-harness.md`)
- [x] `cd worker && npx vitest run src/index.test.ts` - 59 passing
- [x] Takeover validation: `git diff --check`
- [ ] Staging validation

### What the local run showed

The adapter is the consumer that matters here, since it is what makes `unbanpubkey` reachable from Coop in the first place. Both new responses behave correctly downstream:

| This PR returns | Adapter does | Coop sees |
| --- | --- | --- |
| 409 `age_review_active` | passes it through, alert **names the case id and state** and says to clear it from the Age Review flow | terminal |
| 503 `age_review_check_failed` | **502** | terminal, silently (see below) |

**The 503 is not retried, and the row above is why that matters.** The adapter maps it to 502, but Coop drops it there: `publishAction` throws on a non-2xx, and that throw is caught by `publishAction`'s own catch, which logs and returns `false`. `withRetries` wraps `publishAction`, so it only ever sees a resolved value and never re-runs -- the five-attempt budget never engages (coop 1.0.2, `ActionPublisher.ts`: throw `:537`, catch `:731`, return false `:750`).

So the accepted cost, stated accurately: during a D1 outage reversals are refused, and those refusals are dropped silently rather than deferred until the database recovers. The safety direction is unchanged -- a dropped un-ban leaves the hold on -- and `banpubkey` stays unguarded so severe enforcement works throughout.

**One edge worth knowing rather than discovering.** The adapter does not alert on 5xx, which was justified on the assumption that something retries. Since nothing does, a fail-closed reversal during an outage is dropped with no alert at all -- immediately, not after a budget runs out. Tracked in divinevideo/coop-webhook-adapter#6, refiled from #223 into the repo that owns `reversalAlert`, which is where the decision on whether to alert belongs.

**Correction, twice over.** I first recorded 8 worker tests as failing on `main`, then corrected that to a Node version difference. Both were wrong. `worker/` has its own package and lockfile, and in a fresh worktree `worker/node_modules` is empty, so the suite resolves against the root `node_modules` and 8 tests fail spuriously. After `npm ci --legacy-peer-deps` inside `worker/` -- what CI does, for a known peer conflict -- **all 384 worker tests pass on Node 26.5.1**, along with 21 D1 tests. Nothing was ever wrong with `main` or this branch, but neither explanation of why was right.

## Since review

@NotThatKindOfDrLiz took the review blocker and pushed `398a484`, bootstrapping the D1 schema before the relay-rpc guard. Kept: the fresh-D1 gap was real and its regression test is load-bearing.

@realmeylisdev then found that the bootstrap escaped as an unhandled rejection, because this route returns its promise without awaiting, so the top-level catch never saw it. That cost `suspendpubkey` the fail-open behaviour it has on `main`, during exactly the outage it exists for. Their trace is what made it findable, and their fix is what landed. They also found the outage tests were order-dependent: the failing-D1 mock never failed the DDL, and a module-level `schemaReady` meant whichever test reached it first made the bootstrap a no-op for the rest of the file.

Four follow-up commits, all with tests mutation-checked before being kept:

| | |
| --- | --- |
| `99e216f` | A DDL failure reaches the guard's fail-open/fail-closed decision instead of escaping. Cold-isolate tests via `vi.resetModules()` so a freshly started worker is actually exercised. Pins that a refusal lands *before* the relay call -- the previous tests asserted only Keycast, which is `waitUntil` work skipped on any early return, so a guard moved after `callNip86Rpc` reddened nothing. |
| `301130b` | Hook docblock corrected. |
| `e190436` | Pubkeys canonicalised at the Add User dialog, which validates case-insensitively and passed the raw value through. Also pins guard ordering on suspend/unsuspend, and moves the last order-dependent test onto the cold-isolate helper. |
| `73efec2` | A malformed pubkey answered with `400` at the handler rather than the guard's retryable `503`. |
| `53e2279` | Pre-push review of my own diff: dedupe the target expression. |
| `380b733` | Pins the 503 half of the `/api/moderate` contract, which had no detector: swapping `!rpcResponse.ok` for `status === 409` passed all 384 tests while stripping `code` from the 503. Plus two comments that described behaviour the code does not have. |
| `4ce69d8` | Canonical hex required to ENFORCE, not to REVERSE. Validating the reversals but not `banpubkey` made cleanup stricter than the thing that creates the mess: an uppercase ban was accepted and then could not be lifted, leaving a row stuck in the ban list with no way out of the UI. |

## Follow-ups, not in scope here

- divinevideo/coop-webhook-adapter#6: Coop does not retry a 5xx at all, so a fail-closed reversal is dropped silently. Whether the adapter should alert on 5xx is the open decision there.
- divinevideo/divine-moderation-service#191: that service reaches `unbanpubkey` too and throws away `code`/`caseId`/`state`, so a moderator un-banning from its dashboard gets a generic failure with no case to open. A consequence of landing this, not a defect in it.
- The age-review clear path calls `unsuspendPubkey` rather than `unbanPubkey`, so an account banned through the escape hatch and later cleared needs a second manual step.
- `UserActions` closes over the `pubkey` prop rather than mutation variables, so switching selected user mid-flight redirects to the *newly selected* user's case, not merely a stale one: the request went out against the old pubkey, but React Query invokes `onError` from the current render's options. Not a one-line fix either, since those mutationFns take no variables and close over the same prop. Pre-existing, and the refactor confines it to `UserActions` rather than spreading it, since all four new sites pass `variables.pubkey`.



