### PR TITLE
fix(auth): relay management surfaces no longer require a divine-login session

### DIFF
--- a/src/components/EventsList.tsx
+++ b/src/components/EventsList.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useRef, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNostr } from "@/hooks/useNostr";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useAuthor } from "@/hooks/useAuthor";
 import { useToast } from "@/hooks/useToast";
 import { nip19 } from "nostr-tools";
@@ -346,7 +345,6 @@ function EventCard({
 
 export function EventsList({ relayUrl }: EventsListProps) {
   const { nostr } = useNostr();
-  const { user } = useCurrentUser();
   const { toast } = useToast();
   const { callRelayRpc, banEvent, allowEvent, verifyEventDeleted } = useAdminApi();
   const queryClient = useQueryClient();
@@ -566,14 +564,14 @@ export function EventsList({ relayUrl }: EventsListProps) {
   const { data: bannedEvents } = useQuery({
     queryKey: ['banned-events'],
     queryFn: () => callRelayRpc<Array<{ id: string; reason?: string }>>('listbannedevents'),
-    enabled: !!relayUrl && !!user,
+    enabled: !!relayUrl,
   });
 
   // Query for events needing moderation
   const { data: eventsNeedingModeration } = useQuery({
     queryKey: ['events-needing-moderation', relayUrl],
     queryFn: () => callRelayRpc<Array<{ id: string; reason?: string }>>('listeventsneedingmoderation'),
-    enabled: !!relayUrl && !!user,
+    enabled: !!relayUrl,
   });
 
   // Query for all reports to check which users/events have been reported

--- a/src/components/RelayManager.tsx
+++ b/src/components/RelayManager.tsx
@@ -17,6 +17,7 @@ import { Server, FileText, Users, Settings, Flag, Tag, Bug, GripVertical, Clock 
 import { useAppContext } from "@/hooks/useAppContext";
 import AdminBar from "@/components/AdminBar";
 import { DivineLoginButton } from "@/components/auth/DivineLoginButton";
+import { AttributionNotice } from "@/components/auth/AttributionNotice";
 
 // Tab definitions in default order (Reports first for moderation workflow)
 const TAB_DEFINITIONS = [
@@ -173,6 +174,7 @@ export function RelayManager() {
       </header>
 
       <div className="flex-1 min-h-0 overflow-hidden container mx-auto px-4 py-4">
+        <AttributionNotice />
         <Tabs value={currentTab} onValueChange={handleTabChange} className="h-full flex flex-col">
           <TabsList className="shrink-0 grid w-full grid-cols-7">
             {orderedTabs.map((tab) => {

--- a/src/components/RelayManager.tsx
+++ b/src/components/RelayManager.tsx
@@ -173,9 +173,13 @@ export function RelayManager() {
         </div>
       </header>
 
-      <div className="flex-1 min-h-0 overflow-hidden container mx-auto px-4 py-4">
+      {/* Column layout so anything above the tabs (the attribution notice) takes
+          its height out of the tab area instead of pushing the bottom of every
+          tab past `overflow-hidden`. `h-full` on Tabs would claim the full
+          container height regardless of the notice. */}
+      <div className="flex-1 min-h-0 overflow-hidden container mx-auto px-4 py-4 flex flex-col">
         <AttributionNotice />
-        <Tabs value={currentTab} onValueChange={handleTabChange} className="h-full flex flex-col">
+        <Tabs value={currentTab} onValueChange={handleTabChange} className="flex-1 min-h-0 flex flex-col">
           <TabsList className="shrink-0 grid w-full grid-cols-7">
             {orderedTabs.map((tab) => {
               const Icon = tab.icon;

--- a/src/components/RelaySettings.tsx
+++ b/src/components/RelaySettings.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useAdminApi } from "@/hooks/useAdminApi";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -21,7 +20,6 @@ interface RelaySettingsProps {
 
 
 export function RelaySettings({ relayUrl }: RelaySettingsProps) {
-  const { user } = useCurrentUser();
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const { callRelayRpc } = useAdminApi();
@@ -41,14 +39,14 @@ export function RelaySettings({ relayUrl }: RelaySettingsProps) {
   const { data: allowedKinds, isLoading: loadingKinds, error: kindsError } = useQuery({
     queryKey: ['allowed-kinds', relayUrl],
     queryFn: () => callRelayRpc<number[]>('listallowedkinds'),
-    enabled: !!relayUrl && !!user,
+    enabled: !!relayUrl,
   });
 
   // Query for blocked IPs
   const { data: blockedIps, isLoading: loadingIps, error: ipsError } = useQuery({
     queryKey: ['blocked-ips', relayUrl],
     queryFn: () => callRelayRpc<Array<{ ip: string; reason?: string }>>('listblockedips'),
-    enabled: !!relayUrl && !!user,
+    enabled: !!relayUrl,
   });
 
   // Mutation for changing relay name
@@ -216,16 +214,6 @@ export function RelaySettings({ relayUrl }: RelaySettingsProps) {
     }
     blockIpMutation.mutate({ ip: newIp.trim(), reason: newIpReason.trim() || undefined });
   };
-
-  if (!user) {
-    return (
-      <Alert>
-        <AlertDescription>
-          Please log in to manage relay settings.
-        </AlertDescription>
-      </Alert>
-    );
-  }
 
   return (
     <div className="space-y-6">

--- a/src/components/RelayStats.tsx
+++ b/src/components/RelayStats.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useAdminApi } from "@/hooks/useAdminApi";
 import type { BannedPubkeyEntry } from "@/lib/adminApi";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -31,7 +30,6 @@ async function fetchRelayInfo(relayUrl: string) {
 }
 
 export function RelayStats({ relayUrl }: RelayStatsProps) {
-  const { user } = useCurrentUser();
   const { callRelayRpc } = useAdminApi();
 
   // Query for relay info
@@ -45,35 +43,35 @@ export function RelayStats({ relayUrl }: RelayStatsProps) {
   const { data: bannedUsers, isLoading: loadingBanned } = useQuery({
     queryKey: ['banned-users', relayUrl],
     queryFn: () => callRelayRpc<BannedPubkeyEntry[]>('listbannedpubkeys'),
-    enabled: !!relayUrl && !!user,
+    enabled: !!relayUrl,
   });
 
   // Query for allowed users count
   const { data: allowedUsers, isLoading: loadingAllowed } = useQuery({
     queryKey: ['allowed-users', relayUrl],
     queryFn: () => callRelayRpc<BannedPubkeyEntry[]>('listallowedpubkeys'),
-    enabled: !!relayUrl && !!user,
+    enabled: !!relayUrl,
   });
 
   // Query for banned events count
   const { data: bannedEvents, isLoading: loadingBannedEvents } = useQuery({
     queryKey: ['banned-events'],
     queryFn: () => callRelayRpc<Array<{ id: string; reason?: string }>>('listbannedevents'),
-    enabled: !!relayUrl && !!user,
+    enabled: !!relayUrl,
   });
 
   // Query for events needing moderation
   const { data: eventsNeedingModeration, isLoading: loadingPending } = useQuery({
     queryKey: ['events-needing-moderation', relayUrl],
     queryFn: () => callRelayRpc<Array<{ id: string; reason?: string }>>('listeventsneedingmoderation'),
-    enabled: !!relayUrl && !!user,
+    enabled: !!relayUrl,
   });
 
   // Query for allowed kinds
   const { data: allowedKinds, isLoading: loadingKinds } = useQuery({
     queryKey: ['allowed-kinds', relayUrl],
     queryFn: () => callRelayRpc<number[]>('listallowedkinds'),
-    enabled: !!relayUrl && !!user,
+    enabled: !!relayUrl,
   });
 
   const isLoading = loadingInfo || loadingBanned || loadingAllowed || loadingBannedEvents || loadingPending || loadingKinds;

--- a/src/components/SettingsDashboard.tsx
+++ b/src/components/SettingsDashboard.tsx
@@ -10,7 +10,6 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { CopyableId } from "@/components/CopyableId";
 import { useAppContext } from "@/hooks/useAppContext";
 import { useAdminApi } from "@/hooks/useAdminApi";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { getCurrentEnvironment } from "@/lib/environments";
 import {
   Globe, Shield, Clock, Zap, FileText, ExternalLink,
@@ -166,7 +165,6 @@ export function SettingsDashboard() {
   const { config } = useAppContext();
   const { relayUrl, apiUrl } = config;
   const { callRelayRpc, getWorkerInfo } = useAdminApi();
-  const { user } = useCurrentUser();
 
   const env = getCurrentEnvironment(relayUrl, apiUrl);
 
@@ -192,14 +190,17 @@ export function SettingsDashboard() {
     enabled: !!apiUrl,
   });
 
-  // ── NIP-86 queries (auth-gated) ──
+  // ── NIP-86 queries ──
+  // Not gated on a divine-login session: CF Access is the access gate, and the
+  // worker signs these with the shared admin key (useAdminApi.callRelayRpc takes
+  // no signer). `user` is attribution only (#181).
   const {
     data: allowedKinds,
     isLoading: kindsLoading,
   } = useQuery({
     queryKey: ['allowed-kinds', relayUrl],
     queryFn: () => callRelayRpc<number[]>('listallowedkinds'),
-    enabled: !!user && !!relayUrl,
+    enabled: !!relayUrl,
   });
 
   const {
@@ -208,7 +209,7 @@ export function SettingsDashboard() {
   } = useQuery({
     queryKey: ['blocked-ips', relayUrl],
     queryFn: () => callRelayRpc<Array<{ ip: string; reason?: string }>>('listblockedips'),
-    enabled: !!user && !!relayUrl,
+    enabled: !!relayUrl,
   });
 
   const {
@@ -217,7 +218,7 @@ export function SettingsDashboard() {
   } = useQuery({
     queryKey: ['banned-users', relayUrl],
     queryFn: () => callRelayRpc<Array<string | { pubkey: string; reason?: string }>>('listbannedpubkeys'),
-    enabled: !!user && !!relayUrl,
+    enabled: !!relayUrl,
   });
 
   const {
@@ -226,7 +227,7 @@ export function SettingsDashboard() {
   } = useQuery({
     queryKey: ['allowed-users', relayUrl],
     queryFn: () => callRelayRpc<string[]>('listallowedpubkeys'),
-    enabled: !!user && !!relayUrl,
+    enabled: !!relayUrl,
   });
 
   const {
@@ -235,7 +236,7 @@ export function SettingsDashboard() {
   } = useQuery({
     queryKey: ['banned-events'],
     queryFn: () => callRelayRpc<Array<{ id: string; reason?: string }>>('listbannedevents'),
-    enabled: !!user && !!relayUrl,
+    enabled: !!relayUrl,
   });
 
   const {
@@ -244,7 +245,7 @@ export function SettingsDashboard() {
   } = useQuery({
     queryKey: ['events-needing-moderation', relayUrl],
     queryFn: () => callRelayRpc<unknown[]>('listeventsneedingmoderation'),
-    enabled: !!user && !!relayUrl,
+    enabled: !!relayUrl,
   });
 
   const {
@@ -253,7 +254,7 @@ export function SettingsDashboard() {
   } = useQuery({
     queryKey: ['supported-methods', relayUrl],
     queryFn: () => callRelayRpc<string[]>('supportedmethods'),
-    enabled: !!user && !!relayUrl,
+    enabled: !!relayUrl,
   });
 
   // ── Connection status derived from query states ──
@@ -663,136 +664,126 @@ export function SettingsDashboard() {
           </>
         ) : null}
 
-        {/* ── NIP-86 Sections (auth-gated) ── */}
-        {!user ? (
-          <Card>
-            <CardContent className="py-8 text-center">
-              <p className="text-muted-foreground">Log in to view relay management data</p>
-            </CardContent>
-          </Card>
-        ) : (
-          <>
-            {/* ── 7. Event Kind Configuration ── */}
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-base">
-                  <List className="h-5 w-5" />
-                  Event Kind Configuration
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                {kindsLoading ? (
-                  <div className="space-y-2">
-                    <Skeleton className="h-4 w-48" />
-                    <Skeleton className="h-4 w-32" />
-                  </div>
-                ) : allowedKinds && allowedKinds.length > 0 ? (
-                  <div className="flex flex-wrap gap-2">
-                    {allowedKinds.map((kind) => (
-                      <Badge key={kind} variant="secondary">
-                        Kind {kind}
-                        {KIND_NAMES[kind] ? ` — ${KIND_NAMES[kind]}` : ''}
-                      </Badge>
-                    ))}
-                  </div>
-                ) : (
-                  <p className="text-sm text-muted-foreground">All event kinds are allowed</p>
-                )}
-              </CardContent>
-            </Card>
+        {/* ── NIP-86 Sections ── */}
+        {/* ── 7. Event Kind Configuration ── */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <List className="h-5 w-5" />
+              Event Kind Configuration
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {kindsLoading ? (
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-48" />
+                <Skeleton className="h-4 w-32" />
+              </div>
+            ) : allowedKinds && allowedKinds.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {allowedKinds.map((kind) => (
+                  <Badge key={kind} variant="secondary">
+                    Kind {kind}
+                    {KIND_NAMES[kind] ? ` — ${KIND_NAMES[kind]}` : ''}
+                  </Badge>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">All event kinds are allowed</p>
+            )}
+          </CardContent>
+        </Card>
 
-            {/* ── 8. Blocked IPs ── */}
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-base">
-                  <ShieldBan className="h-5 w-5" />
-                  Blocked IPs
-                  {blockedIps && (
-                    <Badge variant="outline" className="ml-1">{blockedIps.length}</Badge>
-                  )}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                {ipsLoading ? (
-                  <div className="space-y-2">
-                    <Skeleton className="h-4 w-40" />
-                    <Skeleton className="h-4 w-36" />
+        {/* ── 8. Blocked IPs ── */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <ShieldBan className="h-5 w-5" />
+              Blocked IPs
+              {blockedIps && (
+                <Badge variant="outline" className="ml-1">{blockedIps.length}</Badge>
+              )}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {ipsLoading ? (
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-40" />
+                <Skeleton className="h-4 w-36" />
+              </div>
+            ) : blockedIps && blockedIps.length > 0 ? (
+              <div className="space-y-1.5">
+                {blockedIps.map((entry, i) => (
+                  <div key={i} className="flex items-center gap-2 text-sm">
+                    <span className="font-mono">{entry.ip}</span>
+                    {entry.reason && (
+                      <span className="text-muted-foreground">— {entry.reason}</span>
+                    )}
                   </div>
-                ) : blockedIps && blockedIps.length > 0 ? (
-                  <div className="space-y-1.5">
-                    {blockedIps.map((entry, i) => (
-                      <div key={i} className="flex items-center gap-2 text-sm">
-                        <span className="font-mono">{entry.ip}</span>
-                        {entry.reason && (
-                          <span className="text-muted-foreground">— {entry.reason}</span>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <p className="text-sm text-muted-foreground">No blocked IP addresses</p>
-                )}
-              </CardContent>
-            </Card>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">No blocked IP addresses</p>
+            )}
+          </CardContent>
+        </Card>
 
-            {/* ── 9. Moderation Overview ── */}
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-base">
-                  <AlertTriangle className="h-5 w-5" />
-                  Moderation Overview
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                  <div className="text-center">
-                    <p className="text-2xl font-bold">
-                      {bannedUsersLoading ? <Skeleton className="h-8 w-12 mx-auto" /> : (Array.isArray(bannedUsers) ? bannedUsers.length : 0)}
-                    </p>
-                    <p className="text-sm text-muted-foreground">Banned Users</p>
-                  </div>
-                  <div className="text-center">
-                    <p className="text-2xl font-bold">
-                      {allowedUsersLoading ? <Skeleton className="h-8 w-12 mx-auto" /> : (Array.isArray(allowedUsers) ? allowedUsers.length : 0)}
-                    </p>
-                    <p className="text-sm text-muted-foreground">Allowed Users</p>
-                  </div>
-                  <div className="text-center">
-                    <p className="text-2xl font-bold">
-                      {bannedEventsLoading ? <Skeleton className="h-8 w-12 mx-auto" /> : (Array.isArray(bannedEvents) ? bannedEvents.length : 0)}
-                    </p>
-                    <p className="text-sm text-muted-foreground">Banned Events</p>
-                  </div>
-                  <div className="text-center">
-                    <p className={cn(
-                      "text-2xl font-bold",
-                      Array.isArray(pendingModeration) && pendingModeration.length > 0 && "text-orange-500"
-                    )}>
-                      {pendingLoading ? <Skeleton className="h-8 w-12 mx-auto" /> : (Array.isArray(pendingModeration) ? pendingModeration.length : 0)}
-                    </p>
-                    <p className="text-sm text-muted-foreground">Pending Moderation</p>
-                  </div>
+        {/* ── 9. Moderation Overview ── */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <AlertTriangle className="h-5 w-5" />
+              Moderation Overview
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <div className="text-center">
+                <p className="text-2xl font-bold">
+                  {bannedUsersLoading ? <Skeleton className="h-8 w-12 mx-auto" /> : (Array.isArray(bannedUsers) ? bannedUsers.length : 0)}
+                </p>
+                <p className="text-sm text-muted-foreground">Banned Users</p>
+              </div>
+              <div className="text-center">
+                <p className="text-2xl font-bold">
+                  {allowedUsersLoading ? <Skeleton className="h-8 w-12 mx-auto" /> : (Array.isArray(allowedUsers) ? allowedUsers.length : 0)}
+                </p>
+                <p className="text-sm text-muted-foreground">Allowed Users</p>
+              </div>
+              <div className="text-center">
+                <p className="text-2xl font-bold">
+                  {bannedEventsLoading ? <Skeleton className="h-8 w-12 mx-auto" /> : (Array.isArray(bannedEvents) ? bannedEvents.length : 0)}
+                </p>
+                <p className="text-sm text-muted-foreground">Banned Events</p>
+              </div>
+              <div className="text-center">
+                <p className={cn(
+                  "text-2xl font-bold",
+                  Array.isArray(pendingModeration) && pendingModeration.length > 0 && "text-orange-500"
+                )}>
+                  {pendingLoading ? <Skeleton className="h-8 w-12 mx-auto" /> : (Array.isArray(pendingModeration) ? pendingModeration.length : 0)}
+                </p>
+                <p className="text-sm text-muted-foreground">Pending Moderation</p>
+              </div>
+            </div>
+
+            {/* Supported NIP-86 methods */}
+            {methodsLoading ? (
+              <Skeleton className="h-4 w-64" />
+            ) : supportedMethods && supportedMethods.length > 0 ? (
+              <div>
+                <p className="text-sm font-medium mb-2">Supported NIP-86 Methods</p>
+                <div className="flex flex-wrap gap-1.5">
+                  {supportedMethods.map((method) => (
+                    <Badge key={method} variant="outline" className="font-mono text-xs">
+                      {method}
+                    </Badge>
+                  ))}
                 </div>
-
-                {/* Supported NIP-86 methods */}
-                {methodsLoading ? (
-                  <Skeleton className="h-4 w-64" />
-                ) : supportedMethods && supportedMethods.length > 0 ? (
-                  <div>
-                    <p className="text-sm font-medium mb-2">Supported NIP-86 Methods</p>
-                    <div className="flex flex-wrap gap-1.5">
-                      {supportedMethods.map((method) => (
-                        <Badge key={method} variant="outline" className="font-mono text-xs">
-                          {method}
-                        </Badge>
-                      ))}
-                    </div>
-                  </div>
-                ) : null}
-              </CardContent>
-            </Card>
-          </>
-        )}
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
 
       </div>
     </ScrollArea>

--- a/src/components/SettingsDashboard.tsx
+++ b/src/components/SettingsDashboard.tsx
@@ -664,7 +664,6 @@ export function SettingsDashboard() {
           </>
         ) : null}
 
-        {/* ── NIP-86 Sections ── */}
         {/* ── 7. Event Kind Configuration ── */}
         <Card>
           <CardHeader>
@@ -739,30 +738,30 @@ export function SettingsDashboard() {
           <CardContent className="space-y-4">
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
               <div className="text-center">
-                <p className="text-2xl font-bold">
+                <div className="text-2xl font-bold">
                   {bannedUsersLoading ? <Skeleton className="h-8 w-12 mx-auto" /> : (Array.isArray(bannedUsers) ? bannedUsers.length : 0)}
-                </p>
+                </div>
                 <p className="text-sm text-muted-foreground">Banned Users</p>
               </div>
               <div className="text-center">
-                <p className="text-2xl font-bold">
+                <div className="text-2xl font-bold">
                   {allowedUsersLoading ? <Skeleton className="h-8 w-12 mx-auto" /> : (Array.isArray(allowedUsers) ? allowedUsers.length : 0)}
-                </p>
+                </div>
                 <p className="text-sm text-muted-foreground">Allowed Users</p>
               </div>
               <div className="text-center">
-                <p className="text-2xl font-bold">
+                <div className="text-2xl font-bold">
                   {bannedEventsLoading ? <Skeleton className="h-8 w-12 mx-auto" /> : (Array.isArray(bannedEvents) ? bannedEvents.length : 0)}
-                </p>
+                </div>
                 <p className="text-sm text-muted-foreground">Banned Events</p>
               </div>
               <div className="text-center">
-                <p className={cn(
+                <div className={cn(
                   "text-2xl font-bold",
                   Array.isArray(pendingModeration) && pendingModeration.length > 0 && "text-orange-500"
                 )}>
                   {pendingLoading ? <Skeleton className="h-8 w-12 mx-auto" /> : (Array.isArray(pendingModeration) ? pendingModeration.length : 0)}
-                </p>
+                </div>
                 <p className="text-sm text-muted-foreground">Pending Moderation</p>
               </div>
             </div>

--- a/src/components/auth/AttributionNotice.test.tsx
+++ b/src/components/auth/AttributionNotice.test.tsx
@@ -1,0 +1,112 @@
+// ABOUTME: A moderator acting without a resolved identity must be told their
+// ABOUTME: actions are recorded unattributed, and offered the way to fix it.
+//
+// Removing the login walls (this PR) restores access for everyone CF Access
+// admits, but it also removes the loudest cue that you have no divine-login
+// session. Without a replacement, a moderator sees a fully working tool, never
+// signs in, and every decision they write lands moderator_pubkey = null --
+// silently defeating the audit trail #181 exists to build.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { DivineSessionProvider } from '@/components/DivineSessionProvider';
+import { useDivineSession } from '@/hooks/useDivineSession';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { AttributionNotice } from './AttributionNotice';
+
+const PUBKEY = 'a'.repeat(64);
+
+const session = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  startLogin: vi.fn(),
+  logout: vi.fn(),
+}));
+vi.mock('@/lib/divineLogin', () => ({
+  getSession: session.getSession,
+  startLogin: session.startLogin,
+  logout: session.logout,
+  completeLogin: vi.fn(),
+  DIVINE_LOGIN_SERVER_URL: 'https://login.example.test',
+  DIVINE_LOGIN_CLIENT_ID: 'divine-relay-admin',
+}));
+
+const getPublicKey = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/divineSigner', () => ({
+  DivineRpcSigner: class {
+    getPublicKey = getPublicKey;
+    signEvent = vi.fn();
+    getRelays = vi.fn();
+  },
+}));
+
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({ data: undefined, isLoading: false }),
+}));
+
+/**
+ * Reports session state so the negative assertions below can wait for a real
+ * settled state first. Without it, `expect(container).toBeEmptyDOMElement()` is
+ * satisfied by the initial pre-resolve render and proves nothing.
+ */
+function Sentinel() {
+  const { isResolving } = useDivineSession();
+  const { user } = useCurrentUser();
+  return <div data-testid='state'>{isResolving ? 'resolving' : `settled:${!!user}`}</div>;
+}
+
+function renderNotice() {
+  return render(
+    <DivineSessionProvider>
+      <AttributionNotice />
+      <Sentinel />
+    </DivineSessionProvider>,
+  );
+}
+
+beforeEach(() => {
+  session.getSession.mockReset();
+  session.startLogin.mockReset();
+  session.startLogin.mockResolvedValue(undefined);
+  getPublicKey.mockReset();
+});
+
+describe('AttributionNotice', () => {
+  it('warns a signed-out moderator that their actions are unattributed', async () => {
+    session.getSession.mockResolvedValue(null);
+
+    renderNotice();
+
+    expect(await screen.findByText(/without attribution/i)).toBeInTheDocument();
+  });
+
+  it('offers the way to fix it', async () => {
+    session.getSession.mockResolvedValue(null);
+
+    renderNotice();
+
+    fireEvent.click(await screen.findByRole('button', { name: /sign in/i }));
+    expect(session.startLogin).toHaveBeenCalled();
+  });
+
+  it('stays out of the way once the moderator is attributed', async () => {
+    session.getSession.mockResolvedValue({ accessToken: 'tok-abc' });
+    getPublicKey.mockResolvedValue(PUBKEY);
+
+    renderNotice();
+
+    // Wait for a genuinely settled, signed-in session before asserting absence.
+    await waitFor(() => expect(screen.getByTestId('state')).toHaveTextContent('settled:true'));
+    expect(screen.queryByText(/without attribution/i)).toBeNull();
+  });
+
+  it('does not flash while the session is still resolving', async () => {
+    session.getSession.mockResolvedValue({ accessToken: 'tok-abc' });
+    getPublicKey.mockReturnValue(new Promise(() => {}));
+
+    renderNotice();
+
+    await waitFor(() => expect(session.getSession).toHaveBeenCalled());
+    expect(screen.getByTestId('state')).toHaveTextContent('resolving');
+    expect(screen.queryByText(/without attribution/i)).toBeNull();
+  });
+});

--- a/src/components/auth/AttributionNotice.tsx
+++ b/src/components/auth/AttributionNotice.tsx
@@ -32,7 +32,7 @@ export function AttributionNotice() {
   };
 
   return (
-    <Alert className="mb-3">
+    <Alert className="mb-3 shrink-0">
       <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
         <span className="flex items-center gap-2">
           <UserX className="h-4 w-4 shrink-0" aria-hidden />

--- a/src/components/auth/AttributionNotice.tsx
+++ b/src/components/auth/AttributionNotice.tsx
@@ -10,26 +10,16 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useDivineSession } from '@/hooks/useDivineSession';
-import { useToast } from '@/hooks/useToast';
+import { useStartSignIn } from '@/hooks/useStartSignIn';
 
 export function AttributionNotice() {
   const { user } = useCurrentUser();
-  const { isResolving, startLogin } = useDivineSession();
-  const { toast } = useToast();
+  const { isResolving } = useDivineSession();
+  const handleSignIn = useStartSignIn();
 
   // Nothing to say while the session is still resolving: an already-signed-in
   // moderator would otherwise see the warning flash on every load.
   if (isResolving || user) return null;
-
-  const handleSignIn = () => {
-    startLogin(`${window.location.pathname}${window.location.search}`).catch((e) => {
-      toast({
-        title: 'Could not start sign-in',
-        description: e instanceof Error ? e.message : 'Please try again.',
-        variant: 'destructive',
-      });
-    });
-  };
 
   return (
     <Alert className="mb-3 shrink-0">

--- a/src/components/auth/AttributionNotice.tsx
+++ b/src/components/auth/AttributionNotice.tsx
@@ -1,0 +1,48 @@
+// ABOUTME: Tells a moderator with no resolved identity that their moderation
+// ABOUTME: actions are being recorded without attribution, and offers sign-in.
+//
+// CF Access is the access gate, so this never blocks anything -- it is the cue
+// that replaces the login walls this tool used to put in front of the relay
+// management surfaces. Without it a moderator has no reason to sign in and
+// every decision they write lands moderator_pubkey = null (#178, #181).
+import { LogIn, UserX } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { useDivineSession } from '@/hooks/useDivineSession';
+import { useToast } from '@/hooks/useToast';
+
+export function AttributionNotice() {
+  const { user } = useCurrentUser();
+  const { isResolving, startLogin } = useDivineSession();
+  const { toast } = useToast();
+
+  // Nothing to say while the session is still resolving: an already-signed-in
+  // moderator would otherwise see the warning flash on every load.
+  if (isResolving || user) return null;
+
+  const handleSignIn = () => {
+    startLogin(`${window.location.pathname}${window.location.search}`).catch((e) => {
+      toast({
+        title: 'Could not start sign-in',
+        description: e instanceof Error ? e.message : 'Please try again.',
+        variant: 'destructive',
+      });
+    });
+  };
+
+  return (
+    <Alert className="mb-3">
+      <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
+        <span className="flex items-center gap-2">
+          <UserX className="h-4 w-4 shrink-0" aria-hidden />
+          Moderation actions are being recorded without attribution.
+        </span>
+        <Button size="sm" variant="outline" onClick={handleSignIn}>
+          <LogIn className="h-4 w-4 mr-2" />
+          Sign in
+        </Button>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/src/components/auth/DivineLoginButton.tsx
+++ b/src/components/auth/DivineLoginButton.tsx
@@ -5,7 +5,7 @@ import { LogIn, LogOut } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useDivineSession } from '@/hooks/useDivineSession';
-import { useToast } from '@/hooks/useToast';
+import { useStartSignIn } from '@/hooks/useStartSignIn';
 
 function shortPubkey(pubkey: string): string {
   return `${pubkey.slice(0, 8)}...${pubkey.slice(-4)}`;
@@ -13,20 +13,8 @@ function shortPubkey(pubkey: string): string {
 
 export function DivineLoginButton() {
   const { user, metadata } = useCurrentUser();
-  const { startLogin, logout, isResolving } = useDivineSession();
-  const { toast } = useToast();
-
-  // startLogin builds the authorize URL (can reject on a network failure) before
-  // redirecting; surface that instead of silently doing nothing.
-  const handleSignIn = () => {
-    startLogin(`${window.location.pathname}${window.location.search}`).catch((e) => {
-      toast({
-        title: 'Could not start sign-in',
-        description: e instanceof Error ? e.message : 'Please try again.',
-        variant: 'destructive',
-      });
-    });
-  };
+  const { logout, isResolving } = useDivineSession();
+  const handleSignIn = useStartSignIn();
 
   if (isResolving) {
     return <div className="h-9 w-24 animate-pulse rounded-md bg-muted" aria-hidden />;

--- a/src/components/relay-management-access.test.tsx
+++ b/src/components/relay-management-access.test.tsx
@@ -1,0 +1,159 @@
+// ABOUTME: The NIP-86 relay-management surfaces must render and fetch for any
+// ABOUTME: moderator CF Access lets in, with no divine-login session required.
+//
+// Since #181 moved `useCurrentUser` onto divine-login, `user` means "we know who
+// the moderator is" (attribution), NOT "this moderator may act". CF Access is the
+// access gate, and every call below goes to the worker, which signs NIP-86 with
+// the shared admin key (see useAdminApi: callRelayRpc takes only apiUrl, no
+// signer). Gating these reads on `user` locks a fully-authorized moderator out of
+// Settings and blanks the relay stats. These tests render SIGNED OUT and assert
+// the management surfaces still work.
+//
+// Live surfaces: SettingsDashboard (Settings tab) and EventsList (Events tab).
+// RelaySettings and RelayStats carry the identical defect but are currently
+// rendered nowhere in the app; covered here so it can't come back if they are
+// ever wired up.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import { TestApp } from '@/test/TestApp';
+import { RelaySettings } from './RelaySettings';
+import { RelayStats } from './RelayStats';
+import { SettingsDashboard } from './SettingsDashboard';
+import { EventsList } from './EventsList';
+
+// Signed out: no divine-login session. This is the real state for a moderator
+// who has never completed the OAuth flow (and for everyone whose legacy
+// `nostr:login` localStorage entry stopped counting when #181 landed).
+vi.mock('@/lib/divineLogin', () => ({
+  getSession: vi.fn().mockResolvedValue(null),
+  startLogin: vi.fn(),
+  logout: vi.fn(),
+  completeLogin: vi.fn(),
+  DIVINE_LOGIN_SERVER_URL: 'https://login.example.test',
+  DIVINE_LOGIN_CLIENT_ID: 'divine-relay-admin',
+}));
+
+const rpc = vi.hoisted(() => ({ fn: vi.fn() }));
+const workerInfo = vi.hoisted(() => ({ fn: vi.fn() }));
+
+vi.mock('@/hooks/useAdminApi', () => ({
+  useAdminApi: () => ({
+    callRelayRpc: rpc.fn,
+    getWorkerInfo: workerInfo.fn,
+    banEvent: vi.fn(),
+    allowEvent: vi.fn(),
+    verifyEventDeleted: vi.fn(),
+  }),
+  useApiUrl: () => 'https://api.example.test',
+}));
+
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({ data: undefined, isLoading: false }),
+}));
+
+const relayQuery = vi.hoisted(() => ({ fn: vi.fn() }));
+vi.mock('@/hooks/useNostr', () => ({
+  useNostr: () => ({ nostr: { query: relayQuery.fn } }),
+}));
+
+/** Every NIP-86 method the signed-out surfaces should still be allowed to call. */
+function rpcMethodsCalled(): string[] {
+  return rpc.fn.mock.calls.map((c) => c[0] as string);
+}
+
+beforeEach(() => {
+  rpc.fn.mockReset();
+  rpc.fn.mockResolvedValue([]);
+  workerInfo.fn.mockReset();
+  workerInfo.fn.mockResolvedValue({});
+  relayQuery.fn.mockReset();
+  relayQuery.fn.mockResolvedValue([]);
+  localStorage.clear();
+});
+
+describe('relay management surfaces, signed out (CF Access is the gate)', () => {
+  it('RelaySettings renders the settings UI instead of a login wall', async () => {
+    render(
+      <TestApp>
+        <RelaySettings relayUrl='wss://relay.example.test' />
+      </TestApp>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Relay Settings')).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Please log in to manage relay settings/i)).toBeNull();
+  });
+
+  it('RelaySettings fetches allowed kinds and blocked IPs', async () => {
+    render(
+      <TestApp>
+        <RelaySettings relayUrl='wss://relay.example.test' />
+      </TestApp>,
+    );
+
+    await waitFor(() => {
+      expect(rpcMethodsCalled()).toEqual(
+        expect.arrayContaining(['listallowedkinds', 'listblockedips']),
+      );
+    });
+  });
+
+  it('RelayStats fetches the banned/allowed counts', async () => {
+    render(
+      <TestApp>
+        <RelayStats relayUrl='wss://relay.example.test' />
+      </TestApp>,
+    );
+
+    await waitFor(() => {
+      expect(rpcMethodsCalled()).toEqual(
+        expect.arrayContaining(['listbannedpubkeys', 'listallowedpubkeys']),
+      );
+    });
+  });
+
+  it('SettingsDashboard renders the NIP-86 sections instead of a login wall', async () => {
+    render(
+      <TestApp>
+        <SettingsDashboard />
+      </TestApp>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Log in to view relay management data/i)).toBeNull();
+    });
+    expect(
+      await screen.findByText(/Event Kind Configuration/i),
+    ).toBeInTheDocument();
+  });
+
+  it('SettingsDashboard fetches its NIP-86 data', async () => {
+    render(
+      <TestApp>
+        <SettingsDashboard />
+      </TestApp>,
+    );
+
+    await waitFor(() => {
+      expect(rpcMethodsCalled()).toEqual(
+        expect.arrayContaining(['listallowedkinds', 'listbannedpubkeys']),
+      );
+    });
+  });
+
+  it('EventsList fetches the banned/needs-moderation markers', async () => {
+    render(
+      <TestApp>
+        <EventsList relayUrl='wss://relay.example.test' />
+      </TestApp>,
+    );
+
+    await waitFor(() => {
+      expect(rpcMethodsCalled()).toEqual(
+        expect.arrayContaining(['listbannedevents', 'listeventsneedingmoderation']),
+      );
+    });
+  });
+});

--- a/src/hooks/useStartSignIn.ts
+++ b/src/hooks/useStartSignIn.ts
@@ -1,0 +1,23 @@
+// ABOUTME: Starts the divine-login redirect and reports a failed start as a
+// ABOUTME: toast. Shared by every sign-in affordance so they cannot drift.
+import { useCallback } from 'react';
+
+import { useDivineSession } from '@/hooks/useDivineSession';
+import { useToast } from '@/hooks/useToast';
+
+export function useStartSignIn(): () => void {
+  const { startLogin } = useDivineSession();
+  const { toast } = useToast();
+
+  // startLogin builds the authorize URL (can reject on a network failure) before
+  // redirecting; surface that instead of silently doing nothing.
+  return useCallback(() => {
+    startLogin(`${window.location.pathname}${window.location.search}`).catch((e) => {
+      toast({
+        title: 'Could not start sign-in',
+        description: e instanceof Error ? e.message : 'Please try again.',
+        variant: 'destructive',
+      });
+    });
+  }, [startLogin, toast]);
+}


### PR DESCRIPTION
## Summary

Restores relay management for any moderator CF Access admits, with no divine-login session required.

## Motivation

#181 added moderator sign-in for **attribution only** — CF Access stays the access gate (#178). Four components still read `useCurrentUser().user` as an authorization gate, so an admitted moderator got a login wall instead of relay data. Reported from the field: *"I no longer have relay management access."*

The gate was never meaningful: everything behind it goes through `callRelayRpc`, which takes only `apiUrl` and is signed server-side with the shared admin key. No moderator identity was ever involved.

Live impact: the **Settings** tab (NIP-86 section replaced with "Log in to view relay management data") and the **Events** tab (missing banned / needs-moderation markers). `RelaySettings` and `RelayStats` have the same defect but are rendered nowhere; fixed for consistency, not deleted (out of scope).

## Changes

- Removed the `user` gates from `SettingsDashboard`, `EventsList`, `RelaySettings`, `RelayStats`.
- Added `AttributionNotice`: a non-blocking "actions are being recorded without attribution" cue with a sign-in button. Removing the walls also removed the only prompt to sign in; without it every decision silently writes `moderator_pubkey = null`. Hidden for a resolved moderator and during the boot resolve.
- Fixed `<Skeleton>` (a div) nested in `<p>` in the Moderation Overview tiles — latent until this section started rendering by default.

Attribution logic is untouched. `EditProfileForm` keeps its `!user` guard: client-side signing genuinely needs a key.

## Validation

Verified signed-out in a browser against both builds:

| Signed-out page | Before | After |
|---|---|---|
| `/settings` | login wall, **0** relay-rpc calls | sections render, **56** calls |
| `/events` | **0** calls | **16** calls |

New tests confirmed red against `origin/main` before the fix. `tsc -p tsconfig.app.json` clean, `eslint` clean, `vitest run` 52 files / 510 passed, `vite build` succeeds. No worker changes.

**Review tip:** use `git diff -w` on `SettingsDashboard.tsx` — removing the ternary re-indented ~120 lines.

Relates to #178, follows #181.
