### PR TITLE
feat(moderate-media): let a caller declare the state it expects to change

### DIFF
--- a/docs/api-webhooks.md
+++ b/docs/api-webhooks.md
@@ -129,7 +129,7 @@ validated upstream.
 
 | Status | `code` | Meaning |
 |--------|--------|---------|
-| 400 | `invalid_from` | `from` was present but empty, whitespace, or not a string. Omit it to skip the check. |
+| 400 | `invalid_from` | `from` was present but empty, whitespace, null, or not a string. Omit it to skip the check. |
 | 400 | `invalid_sha256` | `sha256` is not 64 hex characters. |
 | 409 | `state_mismatch` | Current state is not the declared one. The body carries `from` and `current`. |
 | 503 | `state_unreadable` | Current state could not be read. Retryable, and deliberately not a success. |

--- a/docs/api-webhooks.md
+++ b/docs/api-webhooks.md
@@ -100,9 +100,46 @@ Moderate media content (images/videos) by SHA-256 hash.
 {
   "sha256": "abc123...",
   "action": "SAFE" | "REVIEW" | "QUARANTINE" | "AGE_RESTRICTED" | "PERMANENT_BAN" | "DELETE",
-  "reason": "CSAM content"
+  "reason": "CSAM content",
+  "from": "AGE_RESTRICTED"
 }
 ```
+
+**`from` (optional): declare the state you expect to be changing.**
+
+This endpoint sets state; it does not describe a transition. `SAFE` means "make
+this Active", not "undo the age-restriction I applied", so a caller reversing its
+own action and a caller clearing an age-review quarantine on a minor's content
+send the identical request.
+
+`from` lets a caller declare the state it believes it is changing. The current
+state is read first and the action is refused unless it matches, so a button can
+only reverse the thing it is named for. Omit `from` and nothing changes: no
+extra read, no new failure mode.
+
+It guards a cooperating caller against its own bug. It is not a security
+boundary, since the caller supplies the value and omitting it restores the
+unguarded path.
+
+Sending `from` also requires `sha256` to be 64 hex characters, because it becomes
+part of an upstream URL. Without `from`, `sha256` is forwarded as-is and
+validated upstream.
+
+**Refusals when `from` is present:**
+
+| Status | `code` | Meaning |
+|--------|--------|---------|
+| 400 | `invalid_from` | `from` was present but empty, whitespace, or not a string. Omit it to skip the check. |
+| 400 | `invalid_sha256` | `sha256` is not 64 hex characters. |
+| 409 | `state_mismatch` | Current state is not the declared one. The body carries `from` and `current`. |
+| 503 | `state_unreadable` | Current state could not be read. Retryable, and deliberately not a success. |
+
+A 409 names both states because "refused" alone reads as transient and gets
+retried. `state_unreadable` is 503 rather than 409 because "could not check" is a
+different answer from "no conflict".
+
+What is compared is moderation-service's recorded result. Actions taken directly
+through Blossom's own admin UI do not write there, so they are not reflected.
 
 **Response:**
 ```json

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1849,7 +1849,7 @@ async function handleModerateMedia(
       // `from` pass sha256 in a POST body, which moderation-service validates
       // itself, so widening this would change behaviour for existing callers to
       // no benefit and is left out of this change.
-      if (!/^[0-9a-f]{64}$/i.test(body.sha256)) {
+      if (typeof body.sha256 !== 'string' || !/^[0-9a-f]{64}$/i.test(body.sha256)) {
         return jsonResponse(
           { success: false, error: '`sha256` must be a 64-character hex hash to use `from`', code: 'invalid_sha256' },
           400,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1815,7 +1815,7 @@ async function handleModerateMedia(
     // back the old unguarded behaviour AND a 200, so the caller would believe it
     // asked for the check and was told it succeeded. Refuse instead, and
     // refuse before the upstream read so a malformed request costs no call.
-    if (body.from !== undefined && body.from !== null) {
+    if (body.from !== undefined) {
       const declared = typeof body.from === 'string' ? body.from.trim() : '';
       if (!declared) {
         return jsonResponse(

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -361,6 +361,15 @@ interface ApiResponse {
   author_pubkey?: string | null;
   violation_type?: string | null;
   skipped?: boolean;
+  // Machine-readable refusal reason, so a caller can tell one 4xx/5xx from
+  // another without parsing prose. Matches the `age_review_active` convention
+  // age-review.ts already returns.
+  code?: string;
+  // /api/moderate-media expected-state check: the state the caller declared it
+  // expected, and the one actually found. Both are returned because an operator
+  // seeing only "conflict" cannot tell this from any other refusal.
+  from?: string;
+  current?: string;
 }
 
 // Verify that the request is authorized for admin API access.
@@ -1731,11 +1740,22 @@ async function handleModerateMedia(
       sha256: string;
       action: 'SAFE' | 'REVIEW' | 'QUARANTINE' | 'AGE_RESTRICTED' | 'PERMANENT_BAN' | 'DELETE';
       reason?: string;
+      // Optional expected-state check. The state the caller believes it is changing.
+      // Typed `unknown` rather than `string` because this object is a cast over
+      // `request.json()`, so the annotation is a claim about a stranger's input,
+      // not a fact. `unknown` makes the compiler insist on the narrowing below
+      // instead of letting a declared type stand in for a check.
+      from?: unknown;
     };
 
     if (!body.sha256) {
       return jsonResponse({ success: false, error: 'Missing sha256' }, 400, corsHeaders);
     }
+
+    // The hash used for the upstream write. Left exactly as sent unless the
+    // expected-state path canonicalises it below, so callers that send no
+    // `from` see no change in what reaches moderation-service.
+    let sha256 = body.sha256;
 
     if (!body.action) {
       return jsonResponse({ success: false, error: 'Missing action' }, 400, corsHeaders);
@@ -1761,11 +1781,175 @@ async function handleModerateMedia(
       headers['CF-Access-Client-Secret'] = cfAccess.clientSecret;
     }
 
+    // The expected-state check, when the caller declares what it believes it is
+    // changing.
+    //
+    // This endpoint is a state SETTER, not a transition: `SAFE` means "make this
+    // blob Active", not "undo the age-restriction I applied". So the intent is
+    // lost, and nothing distinguishes a moderator reversing their own
+    // age-restrict from one clearing the QUARANTINE that hides a minor's content
+    // under age review (see bulk-moderate.ts, whose own comment explains why
+    // AGE_RESTRICTED must never be used for a minor). Both are the same request.
+    //
+    // ageReviewActiveGuard refuses that class of reversal for unbanpubkey and
+    // unsuspendpubkey, but it is pubkey-keyed and this endpoint is hash-keyed, so
+    // it was never wired here. `from` closes the gap for callers that opt in,
+    // without a breaking change for the ones that do not.
+    //
+    // The check and the write are two separate steps, not one. Reading the state
+    // is a request to moderation-service and changing it is another, with no lock
+    // and nothing conditional available upstream, so a change landing between them
+    // is not caught. That window is one round trip and the result is no worse than
+    // the unguarded behaviour it replaces, but do not build anything on this that
+    // needs the two to happen together.
+    //
+    // It is also a mistake-guard, not a security boundary. The caller supplies
+    // `from` and omitting it restores the old behaviour, so this protects a
+    // cooperating caller from its own bug -- which is the actual threat here,
+    // since the endpoint already sits behind admin auth.
+    //
+    // Omitting `from` means "no check" and is the supported default.
+    // Sending it present-but-unusable means the caller tried to declare a state
+    // and failed to -- an unmapped action name, a template that rendered empty,
+    // the wrong type off a JSON payload. Treating that as "absent" would hand
+    // back the old unguarded behaviour AND a 200, so the caller would believe it
+    // asked for the check and was told it succeeded. Refuse instead, and
+    // refuse before the upstream read so a malformed request costs no call.
+    if (body.from !== undefined && body.from !== null) {
+      const declared = typeof body.from === 'string' ? body.from.trim() : '';
+      if (!declared) {
+        return jsonResponse(
+          {
+            success: false,
+            error: '`from` must be a non-empty string naming the state being changed; omit it to skip the check',
+            code: 'invalid_from',
+          },
+          400,
+          corsHeaders
+        );
+      }
+      const expected = declared.toUpperCase();
+
+      // `sha256` becomes a path segment below, and the URL constructor resolves
+      // `..` before the request goes out. Unchecked, a caller can point the state
+      // read at any path on moderation-service -- with relay-manager's service
+      // token attached -- and satisfy the comparison against the `status` of an
+      // endpoint that has nothing to do with the blob.
+      //
+      // Not a bypass: `from` is optional, so anyone wanting no check just omits
+      // it. What this actually costs is a credentialed GET to an arbitrary
+      // upstream path, and a caller that believes it verified something when it
+      // read an unrelated endpoint.
+      //
+      // Same shape as the check moderation-service applies to this value
+      // (handlePublicCheckResult, src/index.mjs:1494), so nothing that survives
+      // here is something the upstream would have rejected.
+      //
+      // Deliberately scoped to the expected-state path. Callers that send no
+      // `from` pass sha256 in a POST body, which moderation-service validates
+      // itself, so widening this would change behaviour for existing callers to
+      // no benefit and is left out of this change.
+      if (!/^[0-9a-f]{64}$/i.test(body.sha256)) {
+        return jsonResponse(
+          { success: false, error: '`sha256` must be a 64-character hex hash to use `from`', code: 'invalid_sha256' },
+          400,
+          corsHeaders
+        );
+      }
+
+      // Canonicalise the hash so the row that is verified is the row that gets
+      // written. moderation-service lowercases before its SELECT
+      // (handlePublicCheckResult, src/index.mjs:1497) but /api/v1/moderate binds
+      // sha256 raw into `INSERT ... ON CONFLICT(sha256)`, and the column is
+      // `sha256 TEXT PRIMARY KEY` with no COLLATE NOCASE. BINARY collation makes
+      // an uppercase hash a DIFFERENT key, so unnormalised this reads dd44... and
+      // writes DD44... while reporting that it checked first.
+      //
+      // Only the expected-state path is normalised, matching how the validation
+      // above is scoped. That an uppercase hash can open a second row at all is a
+      // pre-existing hazard of this endpoint, not something introduced here, and
+      // fixing it for every caller belongs in its own change.
+      sha256 = body.sha256.toLowerCase();
+
+      // NOTE: the read goes to MODERATION_SERVICE_URL and the write below goes to
+      // MODERATION_ADMIN_URL. Today those are the same host in local, staging and
+      // prod, which is what makes comparing one against the other meaningful. If
+      // they are ever pointed at different deployments, this reads state from one
+      // service and acts on another, and the guard keeps returning 200 while
+      // checking nothing. Split them and this has to move to the admin URL.
+      //
+      // What `current` reflects is moderation-service's `moderation_results` row,
+      // which is NOT the blob's live state everywhere: Blossom's own admin UI
+      // (divine-blossom, handle_admin_moderate_action) changes blob status without
+      // calling back here, so an action taken there leaves this row stale. The
+      // age-review path that motivates this guard does go through /api/v1/moderate
+      // (bulk-moderate.ts), so it IS reflected -- but do not read this as covering
+      // every way media gets restricted.
+      let current: string;
+      try {
+        // Built inside the try on purpose: getModerationServiceUrl throws when the
+        // binding is missing, and a misconfiguration is the same "could not check"
+        // case as an upstream failure. Outside, it exited as a 500 naming an
+        // internal binding instead of the retryable 503 this block commits to.
+        const checkRequest = new Request(`${getModerationServiceUrl(env)}/check-result/${encodeURIComponent(sha256)}`, {
+          method: 'GET',
+          headers,
+        });
+        const checkResponse = env.MODERATION_API
+          ? await env.MODERATION_API.fetch(checkRequest)
+          : await fetch(checkRequest);
+        if (!checkResponse.ok) throw new Error(`check-result ${checkResponse.status}`);
+        const state = await checkResponse.json() as { status?: string; moderated?: boolean };
+        // `status` is the stored action lowercased, or the literal 'unknown' when
+        // there is no row -- handlePublicCheckResult emits one or the other on
+        // every 200 (src/index.mjs:1508, :1520). Its absence therefore does not
+        // mean the blob is in an unknown state; it means this is not a response
+        // this code understands, so the state is unreadable and belongs in the
+        // 503 class below.
+        //
+        // Defaulting it to 'unknown' instead would answer 409 "expected
+        // AGE_RESTRICTED, found UNKNOWN", asserting a fact about the blob that
+        // was never established. An explicit 'unknown' FROM the service is a real
+        // answer and still refuses; a missing field is not.
+        if (typeof state?.status !== 'string' || !state.status) {
+          throw new Error('check-result carried no status');
+        }
+        current = state.status.toUpperCase();
+      } catch (err) {
+        // 503, not 409, and never success: "could not check" is a different answer
+        // from "no conflict", and the retryable class is the honest one. Same
+        // reasoning as ageReviewActiveGuard's failClosed.
+        console.error('[handleModerateMedia] expected-state read failed:', err);
+        return jsonResponse(
+          { success: false, error: 'Could not read current media state; refusing to act', code: 'state_unreadable' },
+          503,
+          corsHeaders
+        );
+      }
+
+      if (current !== expected) {
+        // Names both states: an operator seeing only "conflict" cannot tell this
+        // from any other 409 and will retry it. Echoes the NORMALISED value, so
+        // what is reported is what was actually compared.
+        return jsonResponse(
+          {
+            success: false,
+            error: `Refusing ${body.action}: expected current state ${expected}, found ${current}`,
+            code: 'state_mismatch',
+            from: expected,
+            current,
+          },
+          409,
+          corsHeaders
+        );
+      }
+    }
+
     const moderationRequest = new Request(`${getModerationAdminUrl(env)}/api/v1/moderate`, {
       method: 'POST',
       headers,
       body: JSON.stringify({
-        sha256: body.sha256,
+        sha256,
         action: body.action,
         reason: body.reason || 'Moderated via Divine Relay Admin',
         source: 'relay-manager',

--- a/worker/test/moderate-media-expected-state.test.ts
+++ b/worker/test/moderate-media-expected-state.test.ts
@@ -280,6 +280,10 @@ describe('/api/moderate-media expected-state check', () => {
       SHA + '/../../api/v1/decisions',
       SHA.slice(0, 63),
       SHA + 'f',
+      // RegExp.test stringifies its argument, so [SHA] looks like a hash and
+      // then body.sha256.toLowerCase throws. Must be 400, not a 500 TypeError.
+      [SHA],
+      123,
     ];
     for (const sha256 of traversals) {
       calls = [];

--- a/worker/test/moderate-media-expected-state.test.ts
+++ b/worker/test/moderate-media-expected-state.test.ts
@@ -1,0 +1,430 @@
+// The expected-state check on /api/moderate-media.
+//
+// The endpoint is a state SETTER, not a transition: `SAFE` means "make this blob
+// Active", not "undo the age-restriction I applied". So any caller can move any
+// blob from any state to any other one, and the intent is lost -- nothing
+// distinguishes a moderator reversing their own age-restrict from one clearing an
+// age-review quarantine on a minor's content. They are the same request.
+//
+// That is not theoretical. Age review hides a minor's media with QUARANTINE and
+// clears it with SAFE (worker/src/bulk-moderate.ts), and its own comment says
+// AGE_RESTRICTED must NOT be used for a minor because it serves full bytes to any
+// signed-in viewer. COOP's Un-Restrict-Media button also sends SAFE. relay-manager
+// refuses this class of reversal elsewhere -- ageReviewActiveGuard returns 409
+// age_review_active for unbanpubkey/unsuspendpubkey -- but that guard is
+// pubkey-keyed and this endpoint is hash-keyed, so it was never wired here.
+//
+// `from` lets a caller declare what it believes it is undoing. A mismatch is
+// refused, so the button can only reverse the thing it is named for.
+//
+// Status codes follow the convention age-review.ts already sets: 409 when there IS
+// a conflicting state, 503 when we could not determine one, because "could not
+// check" is a different answer from "no conflict" and must not read as success.
+import { describe, it, expect, beforeEach } from 'vitest';
+import worker from '../src/index';
+
+const SHA = 'dd44' + '0'.repeat(59) + '4';
+
+type Call = { url: string; method: string; body: unknown };
+
+let calls: Call[];
+
+/**
+ * Stands in for moderation-service. `status` is what check-result reports.
+ *
+ * The two failure options are deliberately different shapes, because the real
+ * handler produces both and only one of them exercises the status check.
+ * `checkFails` returns a non-JSON body, so `.json()` throws on its own;
+ * `checkRejects` returns a well-formed JSON error, which parses fine and is
+ * caught only by an explicit look at `response.ok`. See the test below.
+ */
+function moderationApi(
+  status: string | null,
+  opts: { checkFails?: boolean; checkRejects?: boolean; checkOmitsStatus?: boolean } = {},
+) {
+  return {
+    async fetch(request: Request): Promise<Response> {
+      const url = new URL(request.url);
+      let body: unknown = null;
+      if (request.method === 'POST') {
+        try {
+          body = await request.clone().json();
+        } catch {
+          body = null;
+        }
+      }
+      calls.push({ url: url.pathname, method: request.method, body });
+
+      if (url.pathname.startsWith('/check-result/')) {
+        if (opts.checkFails) return new Response('upstream down', { status: 500 });
+        // Copied from handlePublicCheckResult in divine-moderation-service
+        // (src/index.mjs:1494) -- a rejected sha256 answers 400 with this exact
+        // body. A fake that only ever fails with unparseable text would let a
+        // regression through; see the test that uses this.
+        if (opts.checkRejects) return Response.json({ error: 'Invalid sha256' }, { status: 400 });
+        // A 200 that carries no `status` at all. handlePublicCheckResult never
+        // does this, which is the point: it models the contract having moved.
+        if (opts.checkOmitsStatus) return Response.json({ sha256: SHA, moderated: true });
+
+        // Answer for the REQUESTED hash, not unconditionally. A fake that
+        // returns the same state for every path lets the read target the wrong
+        // blob -- or a constant -- with the suite still green, which is the one
+        // mutation that matters most here.
+        //
+        // Lowercased on the way in because that is what moderation-service does
+        // before its SELECT (src/index.mjs:1497), so this models a case-folding
+        // read over a case-SENSITIVE table.
+        const requested = decodeURIComponent(url.pathname.slice('/check-result/'.length)).toLowerCase();
+        if (requested !== SHA) {
+          return Response.json({ sha256: requested, status: 'unknown', moderated: false });
+        }
+        if (status === null) {
+          return Response.json({ sha256: SHA, status: 'unknown', moderated: false });
+        }
+        return Response.json({ sha256: SHA, status, moderated: true });
+      }
+      if (url.pathname === '/api/v1/moderate') {
+        return Response.json({ success: true, sha256: SHA, action: 'SAFE' });
+      }
+      return new Response('not found', { status: 404 });
+    },
+  };
+}
+
+function env(api: ReturnType<typeof moderationApi>) {
+  return {
+    ADMIN_API_KEY: 'k',
+    // handleModerateMedia requires one of SERVICE_API_TOKEN or CF Access creds
+    // before it will proxy anything; without it every case 500s on auth and the
+    // assertions below would be measuring the harness, not the feature.
+    SERVICE_API_TOKEN: 'service-token',
+    MODERATION_API: api,
+    MODERATION_SERVICE_URL: 'https://moderation.example',
+    MODERATION_ADMIN_URL: 'https://moderation.example',
+  } as unknown as Parameters<typeof worker.fetch>[1];
+}
+
+function post(body: Record<string, unknown>) {
+  return new Request('https://relay.example/api/moderate-media', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-Admin-Key': 'k' },
+    body: JSON.stringify(body),
+  });
+}
+
+const moderateCalls = () => calls.filter((c) => c.url === '/api/v1/moderate');
+
+beforeEach(() => {
+  calls = [];
+});
+
+describe('/api/moderate-media expected-state check', () => {
+  it('refuses to clear a state the caller did not expect, and does not act', async () => {
+    // The scenario that matters: media is QUARANTINE because its owner is under
+    // age review. COOP's Un-Restrict-Media expects to be undoing an age-restrict.
+    const res = await worker.fetch(
+      post({ sha256: SHA, action: 'SAFE', from: 'AGE_RESTRICTED' }),
+      env(moderationApi('quarantine')),
+      {} as ExecutionContext,
+    );
+
+    expect(res.status).toBe(409);
+    const payload = (await res.json()) as { success: boolean; error: string; from?: string; current?: string };
+    expect(payload.success).toBe(false);
+    // The error has to name BOTH states, or an operator cannot tell this apart
+    // from any other 409 and will retry it.
+    expect(payload.current).toBe('QUARANTINE');
+    expect(payload.from).toBe('AGE_RESTRICTED');
+    // The whole point: nothing was changed.
+    expect(moderateCalls()).toHaveLength(0);
+  });
+
+  it('proceeds when the current state is the one the caller expected', async () => {
+    const res = await worker.fetch(
+      post({ sha256: SHA, action: 'SAFE', from: 'AGE_RESTRICTED' }),
+      env(moderationApi('age_restricted')),
+      {} as ExecutionContext,
+    );
+
+    expect(res.status).toBe(200);
+    expect(moderateCalls()).toHaveLength(1);
+    expect((moderateCalls()[0].body as { action: string }).action).toBe('SAFE');
+  });
+
+  it('refuses when nothing has been moderated at all', async () => {
+    // `from` says "undo the age-restrict"; there is no moderation to undo. Letting
+    // this through would set Active on a blob no one had acted on.
+    const res = await worker.fetch(
+      post({ sha256: SHA, action: 'SAFE', from: 'AGE_RESTRICTED' }),
+      env(moderationApi(null)),
+      {} as ExecutionContext,
+    );
+
+    expect(res.status).toBe(409);
+    expect(moderateCalls()).toHaveLength(0);
+  });
+
+  it('fails closed when the current state cannot be read', async () => {
+    // 503, not 409, and not success: "could not check" is a different answer from
+    // "no conflict". Same reasoning as ageReviewActiveGuard's failClosed.
+    const res = await worker.fetch(
+      post({ sha256: SHA, action: 'SAFE', from: 'AGE_RESTRICTED' }),
+      env(moderationApi('age_restricted', { checkFails: true })),
+      {} as ExecutionContext,
+    );
+
+    expect(res.status).toBe(503);
+    expect(moderateCalls()).toHaveLength(0);
+  });
+
+  it('treats a non-ok check-result as unreadable even when its body is valid JSON', async () => {
+    // The sibling test above fails closed for the wrong reason: its 500 carries
+    // unparseable text, so `.json()` throws whether or not the code inspects the
+    // status. Deleting the `!checkResponse.ok` guard leaves that test green.
+    //
+    // moderation-service answers a rejected sha256 with 400 AND a well-formed
+    // JSON body (handlePublicCheckResult, src/index.mjs:1494). That parses
+    // cleanly, `status` comes back undefined, and the state would read as
+    // 'UNKNOWN' -- so the caller would be told "nothing has been moderated"
+    // when what actually happened is the request was refused. Same class of
+    // mistake as answering 409 for an unreadable state: an operator reads it as
+    // information about the blob rather than about the failure.
+    const res = await worker.fetch(
+      post({ sha256: SHA, action: 'SAFE', from: 'AGE_RESTRICTED' }),
+      env(moderationApi('age_restricted', { checkRejects: true })),
+      {} as ExecutionContext,
+    );
+
+    expect(res.status).toBe(503);
+    const payload = (await res.json()) as { code?: string; current?: string };
+    expect(payload.code).toBe('state_unreadable');
+    // Must NOT report a current state: there isn't one, and naming a fictional
+    // 'UNKNOWN' here is the exact confusion this test exists to prevent.
+    expect(payload.current).toBeUndefined();
+    expect(moderateCalls()).toHaveLength(0);
+  });
+
+  it('refuses an empty `from` rather than silently skipping the check', async () => {
+    // `if (body.from)` treats '' as absent, so a caller whose `from` came out
+    // empty -- an unmapped action name, a template that rendered nothing -- gets
+    // the OLD unguarded behaviour and a 200. Silently downgrading a guard is the
+    // worst available outcome on this path: the caller believes it asked for
+    // the check and is told it succeeded.
+    //
+    // Omitting the field means "no check" and stays supported.
+    // Sending it empty means the caller tried to declare a state and failed to,
+    // which is a bug in the caller and must be visible to it.
+    // Whitespace-only counts as empty for the same reason: it is what a caller
+    // produces by accident, never on purpose.
+    for (const empty of ['', '   ', '\t\n']) {
+      calls = [];
+      const res = await worker.fetch(
+        post({ sha256: SHA, action: 'SAFE', from: empty }),
+        env(moderationApi('quarantine')),
+        {} as ExecutionContext,
+      );
+
+      expect(res.status, `from=${JSON.stringify(empty)}`).toBe(400);
+      expect(((await res.json()) as { code?: string }).code).toBe('invalid_from');
+      expect(moderateCalls(), `from=${JSON.stringify(empty)}`).toHaveLength(0);
+    }
+  });
+
+  it('refuses a non-string `from` with 400 rather than a 500', async () => {
+    // A number/array/object reaches `body.from.toUpperCase()` and throws, which
+    // the outer handler turns into a 500 carrying the raw TypeError text
+    // ("body.from.toUpperCase is not a function"). It does fail closed, so this
+    // is about the answer being wrong and useless rather than unsafe: 500 tells
+    // the caller to retry an identical request that cannot ever succeed, and
+    // leaks an internal detail while doing it.
+    for (const bad of [123, ['AGE_RESTRICTED'], { state: 'AGE_RESTRICTED' }, true]) {
+      calls = [];
+      const res = await worker.fetch(
+        post({ sha256: SHA, action: 'SAFE', from: bad }),
+        env(moderationApi('quarantine')),
+        {} as ExecutionContext,
+      );
+
+      expect(res.status, `from=${JSON.stringify(bad)}`).toBe(400);
+      const payload = (await res.json()) as { code?: string; error?: string };
+      expect(payload.code, `from=${JSON.stringify(bad)}`).toBe('invalid_from');
+      expect(payload.error).not.toContain('toUpperCase');
+      expect(moderateCalls(), `from=${JSON.stringify(bad)}`).toHaveLength(0);
+    }
+  });
+
+  it('refuses a sha256 that is not a hash, rather than reading whatever path it names', async () => {
+    // `sha256` is interpolated into the state-read URL, and the URL constructor
+    // resolves `..` before the request is sent. So a sha256 of
+    // '../../api/v1/decisions' does not read /check-result/ at all -- it reads
+    // moderation-service's admin decisions endpoint, carrying relay-manager's
+    // service token, and whatever `status` that response happens to have is what
+    // the guard compares against.
+    //
+    // Two things go wrong at once: a GET to an arbitrary upstream path with our
+    // credentials, and a comparison satisfied by an endpoint that has nothing to
+    // do with the blob.
+    //
+    // Neither is a bypass -- `from` is optional, so a caller wanting no check
+    // omits it. The cost is the credentialed GET, and a caller being told it
+    // verified state when it read something unrelated.
+    //
+    // Checked only on this path. The POST body's sha256 is forwarded to
+    // moderation-service, which validates it itself (handlePublicCheckResult and
+    // its siblings), so callers that send no `from` keep working exactly as
+    // before and nothing here narrows what they may send.
+    const traversals = [
+      '../../api/v1/decisions',
+      '..%2F..%2Fapi%2Fv1%2Fdecisions',
+      'not-a-hash',
+      SHA + '/../../api/v1/decisions',
+      SHA.slice(0, 63),
+      SHA + 'f',
+    ];
+    for (const sha256 of traversals) {
+      calls = [];
+      const res = await worker.fetch(
+        post({ sha256, action: 'SAFE', from: 'AGE_RESTRICTED' }),
+        env(moderationApi('age_restricted')),
+        {} as ExecutionContext,
+      );
+
+      expect(res.status, `sha256=${sha256}`).toBe(400);
+      expect(((await res.json()) as { code?: string }).code).toBe('invalid_sha256');
+      // Nothing upstream was contacted at all: not the state read, not the write.
+      expect(calls, `sha256=${sha256}`).toHaveLength(0);
+    }
+  });
+
+  it('reads the state of the blob it is about to write, not some other one', async () => {
+    // Without this, replacing the interpolated hash with a constant leaves every
+    // other test green: nothing else looks at which path the read went to. A
+    // refactor that threads the wrong variable in here would compare an
+    // unrelated blob's state and the guard would still report success.
+    const res = await worker.fetch(
+      post({ sha256: SHA, action: 'SAFE', from: 'AGE_RESTRICTED' }),
+      env(moderationApi('age_restricted')),
+      {} as ExecutionContext,
+    );
+
+    expect(res.status).toBe(200);
+    const reads = calls.filter((c) => c.url.startsWith('/check-result/'));
+    expect(reads).toHaveLength(1);
+    expect(reads[0].url).toBe(`/check-result/${SHA}`);
+  });
+
+  it('verifies and writes the same row when the hash arrives uppercased', async () => {
+    // moderation-service lowercases before its SELECT (src/index.mjs:1497) but
+    // /api/v1/moderate binds sha256 RAW into `INSERT ... ON CONFLICT(sha256)`,
+    // and the column is `sha256 TEXT PRIMARY KEY` with no COLLATE NOCASE, so
+    // BINARY collation makes an uppercase hash a different key.
+    //
+    // Unnormalised, the guard reads row dd44... and the write lands on row
+    // DD44... -- it reports "verified" for a record it did not touch. Concretely:
+    // a QUARANTINE written with an uppercase hash leaves the lowercase row still
+    // saying AGE_RESTRICTED, so Un-Restrict-Media passes its check against the
+    // stale row and clears the restriction anyway. That is the reversal this
+    // whole change exists to refuse.
+    const res = await worker.fetch(
+      post({ sha256: SHA.toUpperCase(), action: 'SAFE', from: 'AGE_RESTRICTED' }),
+      env(moderationApi('age_restricted')),
+      {} as ExecutionContext,
+    );
+
+    expect(res.status).toBe(200);
+    // Both hops must name the same, canonical row.
+    const reads = calls.filter((c) => c.url.startsWith('/check-result/'));
+    expect(reads[0].url).toBe(`/check-result/${SHA}`);
+    expect((moderateCalls()[0].body as { sha256: string }).sha256).toBe(SHA);
+  });
+
+  it('answers 503 when the moderation URL is unconfigured, not 500', async () => {
+    // getModerationServiceUrl throws when MODERATION_SERVICE_URL is missing. If
+    // that throw happens outside the guard's try, the caller gets a 500 naming an
+    // internal binding instead of the 503 this block otherwise commits to -- and
+    // "misconfigured" is exactly the "could not check" case the fail-closed
+    // reasoning says must be retryable and must not read as success.
+    const broken = env(moderationApi('age_restricted')) as unknown as Record<string, unknown>;
+    delete broken.MODERATION_SERVICE_URL;
+
+    const res = await worker.fetch(
+      post({ sha256: SHA, action: 'SAFE', from: 'AGE_RESTRICTED' }),
+      broken as Parameters<typeof worker.fetch>[1],
+      {} as ExecutionContext,
+    );
+
+    expect(res.status).toBe(503);
+    const payload = (await res.json()) as { code?: string; error?: string };
+    expect(payload.code).toBe('state_unreadable');
+    // Must not name the binding: that is internal detail, and it tells the caller
+    // nothing it can act on.
+    expect(payload.error).not.toContain('MODERATION_SERVICE_URL');
+    expect(moderateCalls()).toHaveLength(0);
+  });
+
+  it('treats a response with no `status` as unreadable, not as "nothing moderated"', async () => {
+    // handlePublicCheckResult always emits `status` -- 'unknown' when there is no
+    // row, the lowercased action when there is (src/index.mjs:1508, :1520). So a
+    // 200 that omits the field is not a blob in an unknown state; it is a
+    // response this code does not understand, which means the contract moved or
+    // something else answered.
+    //
+    // Folding that into 'unknown' would answer 409 "expected AGE_RESTRICTED,
+    // found UNKNOWN" -- telling an operator a fact about the blob that was never
+    // established. 503 says the true thing: the state could not be read.
+    const res = await worker.fetch(
+      post({ sha256: SHA, action: 'SAFE', from: 'AGE_RESTRICTED' }),
+      env(moderationApi(null, { checkOmitsStatus: true })),
+      {} as ExecutionContext,
+    );
+
+    expect(res.status).toBe(503);
+    expect(((await res.json()) as { code?: string }).code).toBe('state_unreadable');
+    expect(moderateCalls()).toHaveLength(0);
+  });
+
+  it('is backwards compatible: no `from` means no check and no behaviour change', async () => {
+    // Every existing caller omits it. They must keep working, and must not pay for
+    // a read they did not ask for.
+    const res = await worker.fetch(
+      post({ sha256: SHA, action: 'SAFE' }),
+      env(moderationApi('quarantine')),
+      {} as ExecutionContext,
+    );
+
+    expect(res.status).toBe(200);
+    expect(moderateCalls()).toHaveLength(1);
+    expect(calls.filter((c) => c.url.startsWith('/check-result/'))).toHaveLength(0);
+  });
+
+  it('compares case-insensitively and ignores surrounding whitespace', async () => {
+    // check-result reports the action lowercased, so case must not decide
+    // whether a reversal is allowed. The padding is here because `from` is
+    // normalised with trim() before the comparison, and without this the trim
+    // could be deleted with the suite still green.
+    const res = await worker.fetch(
+      post({ sha256: SHA, action: 'SAFE', from: '  age_restricted \n' }),
+      env(moderationApi('AGE_RESTRICTED')),
+      {} as ExecutionContext,
+    );
+
+    expect(res.status).toBe(200);
+    expect(moderateCalls()).toHaveLength(1);
+  });
+
+  it('reports the normalised `from` on a mismatch, not the raw one', async () => {
+    // The error string and the `from` field are what an operator reads to work
+    // out what happened. Echoing the raw value shows padding they cannot see and
+    // a case that differs from the state that was actually compared.
+    const res = await worker.fetch(
+      post({ sha256: SHA, action: 'SAFE', from: '  age_restricted  ' }),
+      env(moderationApi('quarantine')),
+      {} as ExecutionContext,
+    );
+
+    expect(res.status).toBe(409);
+    const payload = (await res.json()) as { from?: string; error?: string };
+    expect(payload.from).toBe('AGE_RESTRICTED');
+    expect(payload.error).toContain('expected current state AGE_RESTRICTED, found QUARANTINE');
+  });
+});

--- a/worker/test/moderate-media-expected-state.test.ts
+++ b/worker/test/moderate-media-expected-state.test.ts
@@ -212,11 +212,11 @@ describe('/api/moderate-media expected-state check', () => {
     // the check and is told it succeeded.
     //
     // Omitting the field means "no check" and stays supported.
-    // Sending it empty means the caller tried to declare a state and failed to,
-    // which is a bug in the caller and must be visible to it.
+    // Sending it empty or JSON null means the caller tried to declare a state
+    // and failed to, which is a bug in the caller and must be visible to it.
     // Whitespace-only counts as empty for the same reason: it is what a caller
     // produces by accident, never on purpose.
-    for (const empty of ['', '   ', '\t\n']) {
+    for (const empty of ['', '   ', '\t\n', null]) {
       calls = [];
       const res = await worker.fetch(
         post({ sha256: SHA, action: 'SAFE', from: empty }),


### PR DESCRIPTION
## What is wrong today

This endpoint sets the moderation state of a piece of media. It does not record what you meant by the change.

So "make this visible again" and "clear the hold on a minor's video" are the same request. There is no way for the endpoint to tell them apart, because both arrive as `action: SAFE` and nothing else.

That matters because of how age review works. When we hold a minor's video, we hide it with `QUARANTINE` and later clear it with `SAFE`. COOP's "Un-Restrict-Media" button also sends `SAFE`. A moderator clicking that button on a reported video could therefore clear an age-review hold without meaning to, and without anything warning them.

We already refuse this kind of accidental reversal for accounts. The existing guard covers un-banning and un-suspending a person. It works off the account key, and this endpoint works off a file hash, so it never applied here.

## What this adds

A caller can now say what state it expects to be changing. If the media is in some other state, the request is refused and nothing happens.

The COOP un-restrict button says it expects to be undoing an age restriction. If the video is actually on an age-review hold, the request is refused, the hold stays, and the response says both what the caller expected and what is really there.

Refusals are:

| Status | Meaning |
|--------|---------|
| 409 | The media is in a different state than you said. Says which. |
| 503 | We could not read the current state. Try again. |
| 400 | The request itself was malformed. |

The 503 is deliberate. If we cannot check, we refuse rather than proceed, because "I could not look" must never come back as "done".

## What this does not change

Nothing, for anyone not using it. The field is optional. Every caller that exists today omits it, behaves exactly as before, and does not pay for the extra lookup.

## What this does not do

It protects a caller from its own mistake. It is not a security control. The caller supplies the expected state, and leaving it out gets the old behaviour, so it does not stop anyone determined to skip it. The endpoint is already behind admin authentication, and an honest caller getting it wrong is the real risk here.

There is a small gap between reading the current state and changing it. If something else changes the media in that instant, we will not catch it. Closing that properly needs a change in moderation-service, which is not in this PR. The gap is one round trip, and this is still better than today, where there is no check at all.

What we compare against is moderation-service's record. Actions taken directly in Blossom's own admin screens do not write there, so those are not visible to this check. The age-review path that motivates the change does write there, so that one is covered.

## What review turned up

The first version of this had four real problems, three of which passed all tests. Worth listing, because they are the reason this took more than one pass:

**It could check one record and change a different one.** Hashes are matched case-sensitively when written but lowercased when read. So a hash sent in capitals looked at one record and wrote to another. In practice: a hold placed using a capitalised hash would leave the original record still saying "age restricted", so the un-restrict button would check that stale record, see what it expected, and lift the hold anyway. The file would become visible again while our age-review screens kept showing it as hidden. Two reviewers found this separately.

**An unchecked hash could redirect the lookup.** A caller sending path characters instead of a hash could point the state lookup at a different internal endpoint, and that endpoint's response could satisfy the check. It required admin access already, so this was not an open door, but it meant a caller could be told its state was verified when nothing relevant had been read.

**An empty expected-state was ignored instead of refused.** If a caller sent the field but it came out blank, the check was skipped silently and the caller got a success. That is the worst possible outcome: it asked for the protection and was told it got it.

**A malformed response was read as "nothing has been moderated".** That reported a fact about the file that had never been established. It now reports that the state could not be read, which is what actually happened.

## How it was checked

Fifteen tests. Each was verified by breaking the code on purpose and confirming a test caught it, fifteen different ways. That is how three of the four problems above were found: the tests passed, but they would still have passed with the protection removed.

Also run against the local stack end to end:

```
put a video on an age-review hold           -> held
click un-restrict (expects age-restricted)  -> refused, 409, both states named
check the video afterwards                  -> still held
```

504 tests, type checks and linting clean.

## Sequencing

`divinevideo/coop-webhook-adapter#8` is the first caller and should land after this. Against an older relay-manager it would simply not get the protection, rather than break.
