### PR TITLE
fix(local-dev): stop local dev writing to production

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,6 +252,26 @@ This starts:
 - **Caddy HTTPS proxy** on `https://localhost:8788` (terminates TLS, forwards to worker)
 - **Vite frontend** on `https://localhost:5173`
 
+### Backing services
+
+`dev-local.sh` does **not** start these, but the worker calls them. It warns at
+startup for any that are not answering, and continues.
+
+| Service | Where | How to start |
+|---------|-------|--------------|
+| Funnelcake relay | `ws://127.0.0.1:4444` | `cd ~/code/divine-relay-test && ./scripts/relays/setup-funnelcake.sh` |
+| Funnelcake REST API | `http://127.0.0.1:3333` | Same cluster as the relay |
+| moderation-service | `http://127.0.0.1:8789` | `cd ~/code/divine-moderation-service && npx wrangler dev --port 8789 --local` |
+
+Without them, moderation actions and relay reads fail. They do **not** fall
+through to production.
+
+That is a deliberate change. `wrangler.local.toml` used to point these at the
+deployed services, so local dev appeared to work with none of the above running,
+by writing real production moderation decisions and publishing to the production
+relay. `worker/test/local-config-targets-local-stack.test.ts` now fails if any
+local URL points at deployed infrastructure.
+
 Select "Local" in the environment selector. The frontend sends `X-Admin-Key` header (from `VITE_ADMIN_API_KEY`) for admin auth since CF Access isn't available locally.
 
 ### Why HTTPS locally

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,11 +266,16 @@ startup for any that are not answering, and continues.
 Without them, moderation actions and relay reads fail. They do **not** fall
 through to production.
 
-That is a deliberate change. `wrangler.local.toml` used to point these at the
-deployed services, so local dev appeared to work with none of the above running,
-by writing real production moderation decisions and publishing to the production
-relay. `worker/test/local-config-targets-local-stack.test.ts` now fails if any
-local URL points at deployed infrastructure.
+That is a deliberate change. The committed `wrangler.local.toml` used to name
+the deployed services. A machine with a populated `worker/.dev.vars` already
+overrode `RELAY_URL`, `FUNNELCAKE_API_URL` and `MODERATION_ADMIN_URL`, but
+`MODERATION_SERVICE_URL` was not in that file, and a fresh clone or worktree
+gets none of it. The tracked defaults are now local so that safety does not
+depend on an untracked file. `worker/test/local-config-targets-local-stack.test.ts`
+fails if any local URL points at deployed infrastructure.
+
+Do not put those outbound URLs in `worker/.dev.vars`. That file overrides
+`[vars]`; a leftover production value there would undo this fix.
 
 Select "Local" in the environment selector. The frontend sends `X-Admin-Key` header (from `VITE_ADMIN_API_KEY`) for admin auth since CF Access isn't available locally.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,7 +260,7 @@ startup for any that are not answering, and continues.
 | Service | Where | How to start |
 |---------|-------|--------------|
 | Funnelcake relay | `ws://127.0.0.1:4444` | `cd ~/code/divine-relay-test && ./scripts/relays/setup-funnelcake.sh` |
-| Funnelcake REST API | `http://127.0.0.1:3333` | Same cluster as the relay |
+| Funnelcake REST API | `http://127.0.0.1:3000` | Same cluster as the relay. Note `setup-funnelcake.sh` prints 3333 on completion; that is stale. |
 | moderation-service | `http://127.0.0.1:8789` | `cd ~/code/divine-moderation-service && npx wrangler dev --port 8789 --local` |
 
 Without them, moderation actions and relay reads fail. They do **not** fall

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,7 +260,7 @@ startup for any that are not answering, and continues.
 | Service | Where | How to start |
 |---------|-------|--------------|
 | Funnelcake relay | `ws://127.0.0.1:4444` | `cd ~/code/divine-relay-test && ./scripts/relays/setup-funnelcake.sh` |
-| Funnelcake REST API | `http://127.0.0.1:3000` | Same cluster as the relay. Note `setup-funnelcake.sh` prints 3333 on completion; that is stale. |
+| Funnelcake REST API | `http://127.0.0.1:3333` | Same kind cluster as the relay (`kind-config.yaml` hostPort 3333). Native `divine-funnelcake/scripts/dev.sh` uses 3000+7777 instead; do not mix that with relay 4444. |
 | moderation-service | `http://127.0.0.1:8789` | `cd ~/code/divine-moderation-service && npx wrangler dev --port 8789 --local` |
 
 Without them, moderation actions and relay reads fail. They do **not** fall

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -51,8 +51,8 @@ check_service() {  # name, url, how-to-start
 MISSING_SERVICES=0
 check_service "funnelcake relay" "http://127.0.0.1:4444/" \
   "cd ~/code/divine-relay-test && ./scripts/relays/setup-funnelcake.sh"
-check_service "funnelcake REST API" "http://127.0.0.1:3000/api/stats" \
-  "same cluster as the relay; check the port-forward is up"
+check_service "funnelcake REST API" "http://127.0.0.1:3333/api/stats" \
+  "same kind cluster as the relay (hostPort 3333); check the port-forward is up"
 check_service "moderation-service" "http://127.0.0.1:8789/health" \
   "cd ~/code/divine-moderation-service && npx wrangler dev --port 8789 --local"
 if [[ "$MISSING_SERVICES" == "1" ]]; then

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -33,6 +33,35 @@ if [[ ! -f "worker/.dev.vars" ]]; then
   echo "error: worker/.dev.vars not found. Create it with NOSTR_NSEC and ADMIN_API_KEY." >&2; exit 1
 fi
 
+# Backing services the worker calls. wrangler.local.toml points at these rather
+# than at deployed infrastructure, so a missing one shows up as a failed action
+# or an empty page. Previously these URLs named production, which is why the
+# stack appeared to "work" without any of this running.
+#
+# A warning rather than an error on purpose: working on the UI alone is a normal
+# thing to do, and it should not require the whole chain.
+check_service() {  # name, url, how-to-start
+  if ! curl -s -o /dev/null -m 2 "$2" 2>/dev/null; then
+    echo "warning: $1 is not answering at $2" >&2
+    echo "         $3" >&2
+    MISSING_SERVICES=1
+  fi
+}
+MISSING_SERVICES=0
+check_service "funnelcake relay" "http://127.0.0.1:4444/" \
+  "cd ~/code/divine-relay-test && ./scripts/relays/setup-funnelcake.sh"
+check_service "funnelcake REST API" "http://127.0.0.1:3333/" \
+  "same cluster as the relay; check the port-forward is up"
+check_service "moderation-service" "http://127.0.0.1:8789/health" \
+  "cd ~/code/divine-moderation-service && npx wrangler dev --port 8789 --local"
+if [[ "$MISSING_SERVICES" == "1" ]]; then
+  echo "" >&2
+  echo "Continuing anyway. Moderation actions and relay reads that depend on the" >&2
+  echo "services above will fail until they are running. They will NOT silently" >&2
+  echo "fall through to production." >&2
+  echo "" >&2
+fi
+
 # Generate Caddyfile with absolute paths for this machine
 REPO_ROOT="$(pwd)"
 cat > .certs/Caddyfile <<CADDY

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -35,8 +35,9 @@ fi
 
 # Backing services the worker calls. wrangler.local.toml points at these rather
 # than at deployed infrastructure, so a missing one shows up as a failed action
-# or an empty page. Previously these URLs named production, which is why the
-# stack appeared to "work" without any of this running.
+# or an empty page. The committed file used to name production; a populated
+# worker/.dev.vars already overrode most of those URLs, but a fresh clone or
+# worktree does not, which is why the tracked defaults had to change.
 #
 # A warning rather than an error on purpose: working on the UI alone is a normal
 # thing to do, and it should not require the whole chain.

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -50,7 +50,7 @@ check_service() {  # name, url, how-to-start
 MISSING_SERVICES=0
 check_service "funnelcake relay" "http://127.0.0.1:4444/" \
   "cd ~/code/divine-relay-test && ./scripts/relays/setup-funnelcake.sh"
-check_service "funnelcake REST API" "http://127.0.0.1:3333/" \
+check_service "funnelcake REST API" "http://127.0.0.1:3000/api/stats" \
   "same cluster as the relay; check the port-forward is up"
 check_service "moderation-service" "http://127.0.0.1:8789/health" \
   "cd ~/code/divine-moderation-service && npx wrangler dev --port 8789 --local"

--- a/worker/src/nip86.test.ts
+++ b/worker/src/nip86.test.ts
@@ -83,12 +83,29 @@ describe('getManagementUrl', () => {
     expect(getManagementUrl(env)).toBe('https://relay.example.com/management');
   });
 
-  it('should handle WS (non-secure) URLs', () => {
+  it('should keep WS (non-secure) URLs on http, not upgrade them to https', () => {
+    // This asserted https, which contradicted its own name and made ws:// unusable:
+    // a local relay serving plain HTTP was called over TLS and every NIP-86
+    // management request failed on the handshake. ws is the insecure scheme and
+    // maps to http, exactly as deriveFunnelcakeApiUrl already does for the same
+    // input.
+    //
+    // Only local dev is affected. wrangler.staging.toml and wrangler.prod.toml
+    // both set RELAY_URL to wss://, which is unchanged.
     const env = {
       RELAY_URL: 'ws://localhost:7777',
       MANAGEMENT_PATH: '/',
     };
-    expect(getManagementUrl(env)).toBe('https://localhost:7777/');
+    expect(getManagementUrl(env)).toBe('http://localhost:7777/');
+  });
+
+  it('still upgrades WSS to HTTPS', () => {
+    // The pair to the above: the secure scheme must not be downgraded.
+    const env = {
+      RELAY_URL: 'wss://relay.example.com',
+      MANAGEMENT_PATH: '/',
+    };
+    expect(getManagementUrl(env)).toBe('https://relay.example.com/');
   });
 });
 

--- a/worker/src/nip86.ts
+++ b/worker/src/nip86.ts
@@ -60,7 +60,7 @@ export async function getAdminPubkey(env: Pick<Nip86Env, 'NOSTR_NSEC'>): Promise
 /**
  * Get the NIP-86 management API URL for the configured relay.
  * If MANAGEMENT_URL is set (for local dev with HTTP), use it directly.
- * Otherwise, converts WSS relay URL to HTTPS and appends the management path.
+ * Otherwise, maps wss→https and ws→http, then appends the management path.
  */
 export function getManagementUrl(env: Pick<Nip86Env, 'RELAY_URL' | 'MANAGEMENT_PATH' | 'MANAGEMENT_URL'>): string {
   if (env.MANAGEMENT_URL) {

--- a/worker/src/nip86.ts
+++ b/worker/src/nip86.ts
@@ -66,7 +66,14 @@ export function getManagementUrl(env: Pick<Nip86Env, 'RELAY_URL' | 'MANAGEMENT_P
   if (env.MANAGEMENT_URL) {
     return env.MANAGEMENT_URL;
   }
-  const baseUrl = env.RELAY_URL.replace(/^wss?:\/\//, 'https://');
+  // Map each scheme to its counterpart rather than forcing https. Collapsing both
+  // onto https made ws:// unusable: a local relay serving plain HTTP was called
+  // over TLS and every management request died on the handshake. This matches
+  // deriveFunnelcakeApiUrl, which already derives the two the same way from the
+  // same value. Deployed configs set wss:// and are unaffected.
+  const baseUrl = env.RELAY_URL
+    .replace(/^wss:\/\//, 'https://')
+    .replace(/^ws:\/\//, 'http://');
   const managementPath = env.MANAGEMENT_PATH || '/management';
   return `${baseUrl}${managementPath}`;
 }

--- a/worker/test/local-config-targets-local-stack.test.ts
+++ b/worker/test/local-config-targets-local-stack.test.ts
@@ -1,0 +1,102 @@
+// wrangler.local.toml must not point local dev at deployed infrastructure.
+//
+// This is not hygiene. handleModerateMedia proxies to MODERATION_ADMIN_URL and
+// publishToRelay signs and publishes to RELAY_URL, so a local worker configured
+// with production URLs writes production moderation decisions and broadcasts
+// signed events to the production relay. Running the admin UI locally and
+// clicking a button is enough to do it.
+//
+// That was the state of this file: MODERATION_SERVICE_URL, MODERATION_ADMIN_URL
+// and RELAY_URL all named production. The moderation ones were survivable only
+// because whoever ran the stack passed `--var` overrides on the command line,
+// which is a habit rather than a safeguard, and RELAY_URL was not overridden at
+// all.
+//
+// The check is deliberately inverted: instead of listing the variables that must
+// be local, it finds every variable whose value looks like a URL and requires
+// each one to be either local or explicitly excused below. A new outbound URL
+// added later fails this test until someone decides which it is, rather than
+// silently inheriting a production default.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const LOCAL_TOML = join(HERE, '..', 'wrangler.local.toml');
+
+/**
+ * Variables whose value is a URL but which are NOT an outbound call target, or
+ * which have no local equivalent. Each needs a reason, because the whole point
+ * is that adding to this list is a decision rather than a default.
+ */
+const NOT_AN_OUTBOUND_TARGET: Record<string, string> = {
+  // A CORS allowlist. These are origins we accept requests FROM, not hosts we
+  // call, so production values are correct even locally.
+  ALLOWED_ORIGINS: 'CORS allowlist, inbound not outbound',
+  // A host allowlist for NIP-98 verification. Same reasoning.
+  NIP98_PUBLIC_HOST_ALLOWLIST: 'NIP-98 host allowlist, inbound not outbound',
+  // AI detection analysis. There is no local realness service to run, and the
+  // call reads a verdict rather than writing enforcement, so pointing it at the
+  // deployed service is the least-bad option. Revisit if realness ever gains a
+  // local target or starts mutating state.
+  REALNESS_API_URL: 'no local equivalent; read-only analysis, writes nothing',
+};
+
+const LOCAL_HOST_RE = /^(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|.*\.localhost)$/;
+
+/** Every `KEY = "value"` in the [vars] table, in file order. */
+function localVars(): Array<{ key: string; value: string; line: number }> {
+  const lines = readFileSync(LOCAL_TOML, 'utf8').split('\n');
+  const out: Array<{ key: string; value: string; line: number }> = [];
+  let inVars = false;
+  lines.forEach((raw, i) => {
+    const line = raw.trim();
+    if (line.startsWith('[')) {
+      inVars = line === '[vars]';
+      return;
+    }
+    if (!inVars || line.startsWith('#') || !line.includes('=')) return;
+    const m = line.match(/^([A-Za-z0-9_]+)\s*=\s*"(.*)"\s*$/);
+    if (m) out.push({ key: m[1], value: m[2], line: i + 1 });
+  });
+  return out;
+}
+
+function looksLikeUrl(value: string): boolean {
+  return /^(https?|wss?):\/\//.test(value);
+}
+
+describe('wrangler.local.toml', () => {
+  it('has vars to check', () => {
+    // Guard the guard. If the parser stops matching -- a reformat, a move to
+    // wrangler.jsonc -- every loop below becomes empty and this file passes
+    // while checking nothing, which is the failure mode it exists to prevent.
+    expect(localVars().length).toBeGreaterThan(5);
+  });
+
+  it('points every outbound URL at the local stack', () => {
+    const offenders = localVars()
+      .filter((v) => looksLikeUrl(v.value))
+      .filter((v) => !(v.key in NOT_AN_OUTBOUND_TARGET))
+      .filter((v) => !LOCAL_HOST_RE.test(new URL(v.value).hostname))
+      .map((v) => `  wrangler.local.toml:${v.line}  ${v.key} = ${v.value}`);
+
+    expect(
+      offenders,
+      `Local dev would call deployed infrastructure:\n${offenders.join('\n')}\n\n` +
+        `Point these at the local stack, or add the name to NOT_AN_OUTBOUND_TARGET ` +
+        `with a reason if it is genuinely not something this worker calls.`,
+    ).toEqual([]);
+  });
+
+  it('keeps every excused variable documented and still present', () => {
+    // An excuse that outlives the variable it excuses is how this list rots into
+    // a blanket exemption. If the variable is gone, the entry should go too.
+    const names = new Set(localVars().map((v) => v.key));
+    for (const [key, reason] of Object.entries(NOT_AN_OUTBOUND_TARGET)) {
+      expect(reason.length, `${key} needs a real reason`).toBeGreaterThan(10);
+      expect(names.has(key), `${key} is excused but no longer exists in [vars]`).toBe(true);
+    }
+  });
+});

--- a/worker/test/local-config-targets-local-stack.test.ts
+++ b/worker/test/local-config-targets-local-stack.test.ts
@@ -13,10 +13,10 @@
 // all.
 //
 // The check is deliberately inverted: instead of listing the variables that must
-// be local, it finds every variable whose value looks like a URL and requires
-// each one to be either local or explicitly excused below. A new outbound URL
-// added later fails this test until someone decides which it is, rather than
-// silently inheriting a production default.
+// be local, it finds every variable whose value contains a URL and requires each
+// one to be either local or explicitly excused below. A new outbound URL added
+// later fails this test until someone decides which it is, rather than silently
+// inheriting a production default.
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -36,51 +36,119 @@ const NOT_AN_OUTBOUND_TARGET: Record<string, string> = {
   ALLOWED_ORIGINS: 'CORS allowlist, inbound not outbound',
   // A host allowlist for NIP-98 verification. Same reasoning.
   NIP98_PUBLIC_HOST_ALLOWLIST: 'NIP-98 host allowlist, inbound not outbound',
-  // AI detection analysis. There is no local realness service to run, and the
-  // call reads a verdict rather than writing enforcement, so pointing it at the
-  // deployed service is the least-bad option. Revisit if realness ever gains a
-  // local target or starts mutating state.
-  REALNESS_API_URL: 'no local equivalent; read-only analysis, writes nothing',
+  // There is no realness service to run locally, so this stays pointed at the
+  // deployed one. Stated honestly rather than comfortably: handleRealnessViaHTTP
+  // forwards a caller-supplied POST body to ${REALNESS_API_URL}/analyze with CF
+  // Access credentials attached, so exercising the local admin UI creates real
+  // analysis jobs on the deployed service. That is accepted risk, not an
+  // absence of risk. Revisit if realness gains a local target.
+  REALNESS_API_URL: 'no local equivalent; accepted risk, POST /analyze does reach the deployed service',
 };
 
-const LOCAL_HOST_RE = /^(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|.*\.localhost)$/;
+/**
+ * Variables that MUST be present. The guard can only judge what it can see, and
+ * several of these have a hardcoded production fallback in the worker when unset
+ * (deriveFunnelcakeApiUrl defaults to wss://relay.divine.video, for one). So an
+ * absent variable is the same hazard as a wrong one, and invisible without this.
+ */
+const MUST_BE_SET = [
+  'RELAY_URL',
+  'FUNNELCAKE_API_URL',
+  'MODERATION_SERVICE_URL',
+  'MODERATION_ADMIN_URL',
+];
 
-/** Every `KEY = "value"` in the [vars] table, in file order. */
-function localVars(): Array<{ key: string; value: string; line: number }> {
-  const lines = readFileSync(LOCAL_TOML, 'utf8').split('\n');
-  const out: Array<{ key: string; value: string; line: number }> = [];
-  let inVars = false;
+const LOCAL_HOST_RE = /^(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|[A-Za-z0-9-]+\.localhost)$/;
+
+// Any quoted string in a value, in any of TOML's spellings. Extracting the
+// QUOTED parts rather than taking the rest of the line is what makes a trailing
+// comment harmless (`X = "url" # note`) without being fooled by a '#' inside a
+// string, and it reaches inside arrays.
+const QUOTED_RE = /"""([\s\S]*?)"""|'''([\s\S]*?)'''|"((?:[^"\\]|\\.)*)"|'([^']*)'/g;
+
+type Entry = { key: string; value: string; line: number; table: string };
+
+/**
+ * Every string value under any vars table, in file order.
+ *
+ * Matches `[vars]` and also `[env.<name>.vars]`, because a wrangler environment
+ * carries its own vars block and one pointed at production is exactly as
+ * dangerous as the top-level table being wrong.
+ */
+function localVars(): Entry[] {
+  const lines = readFileSync(LOCAL_TOML, 'utf8').split(/\r?\n/);
+  const out: Entry[] = [];
+  let table = '';
   lines.forEach((raw, i) => {
     const line = raw.trim();
-    if (line.startsWith('[')) {
-      inVars = line === '[vars]';
+    if (line.startsWith('#')) return;
+    const tableMatch = line.match(/^\[{1,2}\s*([A-Za-z0-9_.-]+)\s*\]{1,2}/);
+    if (tableMatch) {
+      table = tableMatch[1];
       return;
     }
-    if (!inVars || line.startsWith('#') || !line.includes('=')) return;
-    const m = line.match(/^([A-Za-z0-9_]+)\s*=\s*"(.*)"\s*$/);
-    if (m) out.push({ key: m[1], value: m[2], line: i + 1 });
+    if (!(table === 'vars' || table.endsWith('.vars'))) return;
+    const m = line.match(/^([A-Za-z0-9_-]+)\s*=\s*(.+)$/);
+    if (!m) return;
+    const [, key, rest] = m;
+    for (const q of rest.matchAll(QUOTED_RE)) {
+      const value = q[1] ?? q[2] ?? q[3] ?? q[4] ?? '';
+      out.push({ key, value, line: i + 1, table });
+    }
   });
   return out;
 }
 
-function looksLikeUrl(value: string): boolean {
-  return /^(https?|wss?):\/\//.test(value);
+// Every URL ANYWHERE in a value, not just one at the start. A value can carry
+// several -- ALLOWED_ORIGINS in this very file is comma-joined -- and checking
+// only the first lets `http://127.0.0.1:8789/,https://moderation-api.divine.video`
+// through, because URL() reads the leading host and treats the rest as a path.
+const URL_RE = /(https?|wss?):\/\/[^\s,"']+/g;
+
+function urlsIn(value: string): string[] {
+  return [...value.matchAll(URL_RE)].map((m) => m[0]);
+}
+
+/** Hostname, or null when something that looks like a URL will not parse. */
+function hostnameOf(value: string): string | null {
+  try {
+    return new URL(value).hostname;
+  } catch {
+    return null;
+  }
 }
 
 describe('wrangler.local.toml', () => {
-  it('has vars to check', () => {
+  it('parses the vars it is meant to check', () => {
     // Guard the guard. If the parser stops matching -- a reformat, a move to
     // wrangler.jsonc -- every loop below becomes empty and this file passes
     // while checking nothing, which is the failure mode it exists to prevent.
-    expect(localVars().length).toBeGreaterThan(5);
+    const vars = localVars();
+    expect(vars.length).toBeGreaterThan(5);
+    // And it must be reading real URLs, not just counting lines.
+    expect(vars.flatMap((v) => urlsIn(v.value)).length).toBeGreaterThan(2);
+  });
+
+  it('sets every variable that would otherwise fall back to a deployed default', () => {
+    const present = new Set(localVars().map((v) => v.key));
+    const missing = MUST_BE_SET.filter((k) => !present.has(k));
+    expect(
+      missing,
+      `Absent from [vars], and the worker falls back to a deployed URL when these ` +
+        `are unset, which this test cannot otherwise see: ${missing.join(', ')}`,
+    ).toEqual([]);
   });
 
   it('points every outbound URL at the local stack', () => {
     const offenders = localVars()
-      .filter((v) => looksLikeUrl(v.value))
-      .filter((v) => !(v.key in NOT_AN_OUTBOUND_TARGET))
-      .filter((v) => !LOCAL_HOST_RE.test(new URL(v.value).hostname))
-      .map((v) => `  wrangler.local.toml:${v.line}  ${v.key} = ${v.value}`);
+      .filter((v) => !Object.hasOwn(NOT_AN_OUTBOUND_TARGET, v.key))
+      .flatMap((v) => urlsIn(v.value).map((url) => ({ ...v, url })))
+      .filter((v) => {
+        const host = hostnameOf(v.url);
+        // Unparseable is suspicious, not safe: report it rather than skip it.
+        return host === null || !LOCAL_HOST_RE.test(host);
+      })
+      .map((v) => `  wrangler.local.toml:${v.line}  [${v.table}] ${v.key} -> ${v.url}`);
 
     expect(
       offenders,
@@ -96,7 +164,7 @@ describe('wrangler.local.toml', () => {
     const names = new Set(localVars().map((v) => v.key));
     for (const [key, reason] of Object.entries(NOT_AN_OUTBOUND_TARGET)) {
       expect(reason.length, `${key} needs a real reason`).toBeGreaterThan(10);
-      expect(names.has(key), `${key} is excused but no longer exists in [vars]`).toBe(true);
+      expect(names.has(key), `${key} is excused but no longer exists in vars`).toBe(true);
     }
   });
 });

--- a/worker/test/local-config-targets-local-stack.test.ts
+++ b/worker/test/local-config-targets-local-stack.test.ts
@@ -7,10 +7,10 @@
 // clicking a button is enough to do it.
 //
 // That was the state of this file: MODERATION_SERVICE_URL, MODERATION_ADMIN_URL
-// and RELAY_URL all named production. The moderation ones were survivable only
-// because whoever ran the stack passed `--var` overrides on the command line,
-// which is a habit rather than a safeguard, and RELAY_URL was not overridden at
-// all.
+// and RELAY_URL all named production. A populated worker/.dev.vars already
+// overrode RELAY_URL and MODERATION_ADMIN_URL on a configured machine, but
+// MODERATION_SERVICE_URL was not in that file, and a fresh clone or worktree
+// gets none of it. The committed defaults were the trap.
 //
 // The check is deliberately inverted: instead of listing the variables that must
 // be local, it finds every variable whose value contains a URL and requires each
@@ -43,6 +43,10 @@ const NOT_AN_OUTBOUND_TARGET: Record<string, string> = {
   // analysis jobs on the deployed service. That is accepted risk, not an
   // absence of risk. Revisit if realness gains a local target.
   REALNESS_API_URL: 'no local equivalent; accepted risk, POST /analyze does reach the deployed service',
+  // handleMediaProxy builds https://${CDN_DOMAIN}/admin/api/blob/... and falls
+  // back to media.divine.video when unset. There is no local blossom, so this
+  // stays the deployed host. A GET with BLOSSOM_WEBHOOK_SECRET, not a write.
+  CDN_DOMAIN: 'no local blossom; accepted risk, GET /admin/api/blob reaches production media',
 };
 
 /**
@@ -56,6 +60,7 @@ const MUST_BE_SET = [
   'FUNNELCAKE_API_URL',
   'MODERATION_SERVICE_URL',
   'MODERATION_ADMIN_URL',
+  'CDN_DOMAIN',
 ];
 
 const LOCAL_HOST_RE = /^(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|[A-Za-z0-9-]+\.localhost)$/;
@@ -109,6 +114,19 @@ function urlsIn(value: string): string[] {
   return [...value.matchAll(URL_RE)].map((m) => m[0]);
 }
 
+// CDN_DOMAIN is a hostname, not a URL. handleMediaProxy still calls
+// https://${CDN_DOMAIN}/..., so a production hostname is the same hazard as a
+// production URL. A dotted host with no scheme must be judged, not skipped.
+const BARE_HOST_RE = /^[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+$/;
+
+function callTargetsIn(value: string): string[] {
+  const urls = urlsIn(value);
+  if (urls.length) return urls;
+  const trimmed = value.trim();
+  if (BARE_HOST_RE.test(trimmed)) return [`https://${trimmed}`];
+  return [];
+}
+
 /** Hostname, or null when something that looks like a URL will not parse. */
 function hostnameOf(value: string): string | null {
   try {
@@ -126,7 +144,7 @@ describe('wrangler.local.toml', () => {
     const vars = localVars();
     expect(vars.length).toBeGreaterThan(5);
     // And it must be reading real URLs, not just counting lines.
-    expect(vars.flatMap((v) => urlsIn(v.value)).length).toBeGreaterThan(2);
+    expect(vars.flatMap((v) => callTargetsIn(v.value)).length).toBeGreaterThan(2);
   });
 
   it('sets every variable that would otherwise fall back to a deployed default', () => {
@@ -142,7 +160,7 @@ describe('wrangler.local.toml', () => {
   it('points every outbound URL at the local stack', () => {
     const offenders = localVars()
       .filter((v) => !Object.hasOwn(NOT_AN_OUTBOUND_TARGET, v.key))
-      .flatMap((v) => urlsIn(v.value).map((url) => ({ ...v, url })))
+      .flatMap((v) => callTargetsIn(v.value).map((url) => ({ ...v, url })))
       .filter((v) => {
         const host = hostnameOf(v.url);
         // Unparseable is suspicious, not safe: report it rather than skip it.

--- a/worker/wrangler.local.toml
+++ b/worker/wrangler.local.toml
@@ -47,13 +47,18 @@ MANAGEMENT_PATH = "/"
 # 127.0.0.1 rather than localhost on purpose: localhost can resolve to ::1 first,
 # and wrangler dev binds v4 unless told otherwise.
 #
-# These were production URLs, which meant a local moderation action wrote a real
-# production decision. It only ever worked safely because the person running the
-# stack passed `--var MODERATION_ADMIN_URL:...` on the command line, which is a
-# habit, not a safeguard.
+# These were production URLs in the committed file. A populated worker/.dev.vars
+# already overrode MODERATION_ADMIN_URL (and RELAY_URL) on a configured machine,
+# but MODERATION_SERVICE_URL was not in that file, and a fresh clone or worktree
+# gets none of it. Tracked local values remove that dependence.
 MODERATION_SERVICE_URL = "http://127.0.0.1:8789"
 MODERATION_ADMIN_URL = "http://127.0.0.1:8789"
 REALNESS_API_URL = "https://realness.admin.divine.video"
+# No local blossom. handleMediaProxy GETs https://${CDN_DOMAIN}/admin/api/blob/...
+# with BLOSSOM_WEBHOOK_SECRET. Unset, the worker falls back to media.divine.video
+# anyway. Named here so the guard can see it. Accepted risk: previewing blocked
+# media locally reads production blossom.
+CDN_DOMAIN = "media.divine.video"
 # Allow admin UI plus the managed web app and its preview deployments
 ALLOWED_ORIGINS = "https://relay.admin.divine.video,https://app.divine.video,https://*.openvine-app.pages.dev,*.divine-relay-manager.pages.dev,*.divine-relay-admin.pages.dev"
 # NIP-98 public-host allowlist (#173). Empty for local dev (strict same-host).

--- a/worker/wrangler.local.toml
+++ b/worker/wrangler.local.toml
@@ -16,14 +16,31 @@ compatibility_date = "2024-12-01"
 # BLOSSOM_WEBHOOK_SECRET - set via: wrangler secret put BLOSSOM_WEBHOOK_SECRET
 
 [vars]
-RELAY_URL = "wss://relay.divine.video"
+# Everything this worker CALLS points at the local stack. Not tidiness: the
+# worker signs and publishes events to RELAY_URL and proxies moderation actions
+# to MODERATION_ADMIN_URL, so a deployed URL here means running the admin UI
+# locally and clicking a button writes to production. test/
+# local-config-targets-local-stack.test.ts enforces this.
+#
+# Local funnelcake, from divine-relay-test (scripts/relays/setup-funnelcake.sh).
+# Plain ws is correct: this is a server-side connection from the worker, so it
+# does not need the Caddy TLS proxy that the browser does.
+RELAY_URL = "ws://127.0.0.1:4444"
 AUTO_HIDE_ENABLED = "false"
 TRUSTED_CLIENTS = "diVine,divine-web,divine-mobile"
 # Path for NIP-86 management API (appended to relay URL converted to HTTPS)
 MANAGEMENT_PATH = "/"
-# URLs for divine-moderation-service (no service binding in local dev)
-MODERATION_SERVICE_URL = "https://moderation-api.divine.video"
-MODERATION_ADMIN_URL = "https://moderation-api.divine.video"
+# Local divine-moderation-service. Run it from its own checkout with:
+#   npx wrangler dev --port 8789 --local
+# 127.0.0.1 rather than localhost on purpose: localhost can resolve to ::1 first,
+# and wrangler dev binds v4 unless told otherwise.
+#
+# These were production URLs, which meant a local moderation action wrote a real
+# production decision. It only ever worked safely because the person running the
+# stack passed `--var MODERATION_ADMIN_URL:...` on the command line, which is a
+# habit, not a safeguard.
+MODERATION_SERVICE_URL = "http://127.0.0.1:8789"
+MODERATION_ADMIN_URL = "http://127.0.0.1:8789"
 REALNESS_API_URL = "https://realness.admin.divine.video"
 # Allow admin UI plus the managed web app and its preview deployments
 ALLOWED_ORIGINS = "https://relay.admin.divine.video,https://app.divine.video,https://*.openvine-app.pages.dev,*.divine-relay-manager.pages.dev,*.divine-relay-admin.pages.dev"

--- a/worker/wrangler.local.toml
+++ b/worker/wrangler.local.toml
@@ -29,10 +29,14 @@ compatibility_date = "2024-12-01"
 # does not need the Caddy TLS proxy that the browser does.
 RELAY_URL = "ws://127.0.0.1:4444"
 # Local funnelcake serves the relay and the REST API as two deployments on two
-# ports (relay 4444, API 3333). Production serves both from one host, so the
+# ports (relay 4444, API 3000). Production serves both from one host, so the
 # derived-from-RELAY_URL default is right there and wrong here: without this,
 # every /api/funnelcake/* read and every bulk-moderate video page 404s.
-FUNNELCAKE_API_URL = "http://127.0.0.1:3333"
+#
+# 3000 verified against the running stack, not taken from the setup script --
+# divine-relay-test/scripts/relays/setup-funnelcake.sh prints "API:
+# http://localhost:3333" on completion and that is stale. 3333 answers nothing.
+FUNNELCAKE_API_URL = "http://127.0.0.1:3000"
 AUTO_HIDE_ENABLED = "false"
 TRUSTED_CLIENTS = "diVine,divine-web,divine-mobile"
 # Path for NIP-86 management API. Appended to RELAY_URL with the scheme mapped to

--- a/worker/wrangler.local.toml
+++ b/worker/wrangler.local.toml
@@ -16,19 +16,27 @@ compatibility_date = "2024-12-01"
 # BLOSSOM_WEBHOOK_SECRET - set via: wrangler secret put BLOSSOM_WEBHOOK_SECRET
 
 [vars]
-# Everything this worker CALLS points at the local stack. Not tidiness: the
+# Every URL this worker calls points at the local stack. Not tidiness: the
 # worker signs and publishes events to RELAY_URL and proxies moderation actions
 # to MODERATION_ADMIN_URL, so a deployed URL here means running the admin UI
 # locally and clicking a button writes to production. test/
-# local-config-targets-local-stack.test.ts enforces this.
+# local-config-targets-local-stack.test.ts enforces this for [vars]. It does not
+# cover service bindings or database ids, which still name deployed resources;
+# under `wrangler dev --local` those are simulated rather than reached.
 #
 # Local funnelcake, from divine-relay-test (scripts/relays/setup-funnelcake.sh).
 # Plain ws is correct: this is a server-side connection from the worker, so it
 # does not need the Caddy TLS proxy that the browser does.
 RELAY_URL = "ws://127.0.0.1:4444"
+# Local funnelcake serves the relay and the REST API as two deployments on two
+# ports (relay 4444, API 3333). Production serves both from one host, so the
+# derived-from-RELAY_URL default is right there and wrong here: without this,
+# every /api/funnelcake/* read and every bulk-moderate video page 404s.
+FUNNELCAKE_API_URL = "http://127.0.0.1:3333"
 AUTO_HIDE_ENABLED = "false"
 TRUSTED_CLIENTS = "diVine,divine-web,divine-mobile"
-# Path for NIP-86 management API (appended to relay URL converted to HTTPS)
+# Path for NIP-86 management API. Appended to RELAY_URL with the scheme mapped to
+# its http counterpart: wss -> https, ws -> http (see getManagementUrl).
 MANAGEMENT_PATH = "/"
 # Local divine-moderation-service. Run it from its own checkout with:
 #   npx wrangler dev --port 8789 --local

--- a/worker/wrangler.local.toml
+++ b/worker/wrangler.local.toml
@@ -29,14 +29,15 @@ compatibility_date = "2024-12-01"
 # does not need the Caddy TLS proxy that the browser does.
 RELAY_URL = "ws://127.0.0.1:4444"
 # Local funnelcake serves the relay and the REST API as two deployments on two
-# ports (relay 4444, API 3000). Production serves both from one host, so the
+# ports (relay 4444, API 3333). Production serves both from one host, so the
 # derived-from-RELAY_URL default is right there and wrong here: without this,
 # every /api/funnelcake/* read and every bulk-moderate video page 404s.
 #
-# 3000 verified against the running stack, not taken from the setup script --
-# divine-relay-test/scripts/relays/setup-funnelcake.sh prints "API:
-# http://localhost:3333" on completion and that is stale. 3333 answers nothing.
-FUNNELCAKE_API_URL = "http://127.0.0.1:3000"
+# 3333 is the kind mapping in divine-relay-test/kind-config.yaml (hostPort 3333
+# -> funnelcake API). hostPort 3000 on that cluster is Grafana. Native
+# divine-funnelcake/scripts/dev.sh binds funnel on 3000 but cake on 7777, so
+# pairing RELAY_URL :4444 with API :3000 mixes two stacks.
+FUNNELCAKE_API_URL = "http://127.0.0.1:3333"
 AUTO_HIDE_ENABLED = "false"
 TRUSTED_CLIENTS = "diVine,divine-web,divine-mobile"
 # Path for NIP-86 management API. Appended to RELAY_URL with the scheme mapped to


### PR DESCRIPTION
## The problem

Running relay-manager locally wrote to production.

`wrangler.local.toml` pointed three outbound URLs at deployed infrastructure:

```
RELAY_URL              = "wss://relay.divine.video"
MODERATION_SERVICE_URL = "https://moderation-api.divine.video"
MODERATION_ADMIN_URL   = "https://moderation-api.divine.video"
```

Those are not decorative. The worker proxies moderation actions to `MODERATION_ADMIN_URL`, and it signs and publishes events to `RELAY_URL`. So starting the worker the way the file's own header tells you to, opening the admin UI, and clicking a moderation button wrote a real production decision.

### How exposed was it, precisely

Narrower than "everyone, all the time", and worth stating accurately.

`worker/.dev.vars` overrides `[vars]`, and on a configured machine it already sets `RELAY_URL`, `FUNNELCAKE_API_URL` and `MODERATION_ADMIN_URL` to local values. I confirmed that by asking the running worker, which reports `ws://localhost:4444`. So a developer whose local state is fully set up was not publishing to the production relay.

Two gaps remain, and they are the reason this is worth fixing rather than leaving to convention:

- **`MODERATION_SERVICE_URL` is not in `.dev.vars`.** It fell through to the production value even on a fully configured machine. That is the URL the expected-state read in #232 uses.
- **`.dev.vars` is gitignored.** A fresh clone gets none of it. Neither does a git worktree, which is how a lot of work in this repo happens, and which is exactly where someone would start the stack without noticing.

The committed default was a trap for anyone whose untracked local state did not happen to paper over it. Putting the right values in the tracked file removes the dependence on each developer's private file.

## The change

All three now point at the local stack, which I verified is actually running rather than assuming:

- Local funnelcake answers NIP-11 as `divine-local` on 4444
- A local moderation-service answers `/health` as `divine-moderation-api` on 8789

`127.0.0.1` rather than `localhost`, because `localhost` can resolve to `::1` first while `wrangler dev` binds v4.

`REALNESS_API_URL` still names the deployed service. There is nothing local to run in its place. `handleRealnessViaHTTP` POSTs to `/analyze` with CF Access credentials, so exercising that path creates real jobs. That is accepted risk, not an absence of risk.

`FUNNELCAKE_API_URL` is set explicitly to `http://127.0.0.1:3333`. Local funnelcake serves the relay and the REST API on different ports (4444 and 3333). Deriving the API URL from `RELAY_URL` would send `/api/funnelcake/*` at the relay port.

## A second bug this uncovered

Pointing `RELAY_URL` at the local relay did not work on its own, because `getManagementUrl` forced https for both websocket schemes:

```ts
env.RELAY_URL.replace(/^wss?:\/\//, 'https://')
```

So `ws://` was called over TLS. Against a local relay serving plain HTTP that fails on the handshake, taking every NIP-86 management request with it: ban, delete, allow. Without fixing it, this PR would have swapped one broken local setup for another.

The existing test locked the behaviour in while contradicting its own name. It was called `should handle WS (non-secure) URLs` and asserted the result was `https`. It now asserts `http`, with a companion test so the secure scheme cannot be downgraded by a later edit to the same line.

`deriveFunnelcakeApiUrl` already maps the two schemes separately from this same value, so the two helpers now agree rather than disagreeing.

Deployed configs are unaffected. `wrangler.staging.toml` and `wrangler.prod.toml` both set `RELAY_URL` to `wss://`, and that path is unchanged.

## The guard

A test that fails if local config points anywhere deployed.

It is inverted on purpose. Instead of listing the variables that must be local, it finds **every** variable whose value looks like a URL and requires each one to be either local or explicitly excused with a written reason. A new outbound URL added later fails the test until someone decides which it is, rather than silently inheriting a production default. That is the failure mode this PR is fixing, so the guard should not be able to miss the next instance of it.

A third check keeps the excuse list honest: every excused variable must still exist and must carry a real reason, so the list cannot rot into a blanket exemption.

## How it was checked

The guard was mutation-checked both ways: reverting a URL to production fails it, and adding a new unclassified URL variable fails it.

The config change was verified end to end, not by reading it. I started a worker on a spare port from the committed config with **no** URL overrides, and asked it about a hash that exists only in the local database:

```
hash dd44...be8b6

  local worker (committed config, no overrides)  -> age_restricted
  production                                     -> unknown
```

It reaches the local service on the strength of the file alone. Used a read-only route for this deliberately, so nothing was written anywhere during verification.

507 tests, type checks and linting clean.

