### PR TITLE
fix(settings): tolerate object-shaped listallowedkinds from the relay

### DIFF
--- a/src/components/RelaySettings.tsx
+++ b/src/components/RelaySettings.tsx
@@ -13,6 +13,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { useToast } from "@/hooks/useToast";
 import { Globe, FileText, Image, Plus, Trash2, Shield, Network } from "lucide-react";
+import { normalizeAllowedKinds, type AllowedKindEntry } from "@/lib/allowedKinds";
 
 interface RelaySettingsProps {
   relayUrl: string;
@@ -38,7 +39,8 @@ export function RelaySettings({ relayUrl }: RelaySettingsProps) {
   // Query for allowed kinds
   const { data: allowedKinds, isLoading: loadingKinds, error: kindsError } = useQuery({
     queryKey: ['allowed-kinds', relayUrl],
-    queryFn: () => callRelayRpc<number[]>('listallowedkinds'),
+    queryFn: () => callRelayRpc<AllowedKindEntry[]>('listallowedkinds'),
+    select: normalizeAllowedKinds,
     enabled: !!relayUrl,
   });
 

--- a/src/components/RelayStats.tsx
+++ b/src/components/RelayStats.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Progress } from "@/components/ui/progress";
 import { Users, FileText, Shield, Activity, Clock, Globe } from "lucide-react";
+import { normalizeAllowedKinds, type AllowedKindEntry } from "@/lib/allowedKinds";
 
 interface RelayStatsProps {
   relayUrl: string;
@@ -70,7 +71,8 @@ export function RelayStats({ relayUrl }: RelayStatsProps) {
   // Query for allowed kinds
   const { data: allowedKinds, isLoading: loadingKinds } = useQuery({
     queryKey: ['allowed-kinds', relayUrl],
-    queryFn: () => callRelayRpc<number[]>('listallowedkinds'),
+    queryFn: () => callRelayRpc<AllowedKindEntry[]>('listallowedkinds'),
+    select: normalizeAllowedKinds,
     enabled: !!relayUrl,
   });
 

--- a/src/components/SettingsDashboard.tsx
+++ b/src/components/SettingsDashboard.tsx
@@ -11,6 +11,7 @@ import { CopyableId } from "@/components/CopyableId";
 import { useAppContext } from "@/hooks/useAppContext";
 import { useAdminApi } from "@/hooks/useAdminApi";
 import { getCurrentEnvironment } from "@/lib/environments";
+import { normalizeAllowedKinds, type AllowedKindEntry } from "@/lib/allowedKinds";
 import {
   Globe, Shield, Clock, Zap, FileText, ExternalLink,
   Server, Wifi, WifiOff, List, ShieldBan, Users,
@@ -199,7 +200,10 @@ export function SettingsDashboard() {
     isLoading: kindsLoading,
   } = useQuery({
     queryKey: ['allowed-kinds', relayUrl],
-    queryFn: () => callRelayRpc<number[]>('listallowedkinds'),
+    // Funnelcake returns Array<{kind, added_at}>, not the bare number[] the
+    // render assumes; normalize both shapes so an object never reaches JSX.
+    queryFn: () => callRelayRpc<AllowedKindEntry[]>('listallowedkinds'),
+    select: normalizeAllowedKinds,
     enabled: !!relayUrl,
   });
 

--- a/src/components/relay-management-access.test.tsx
+++ b/src/components/relay-management-access.test.tsx
@@ -143,6 +143,23 @@ describe('relay management surfaces, signed out (CF Access is the gate)', () => 
     });
   });
 
+  it('SettingsDashboard renders funnelcake object-shaped kinds without crashing', async () => {
+    rpc.fn.mockImplementation(async (method: string) => {
+      if (method === 'listallowedkinds') {
+        return [{ added_at: '2026-01-27T04:25:39.690Z', kind: 0 }];
+      }
+      return [];
+    });
+
+    render(
+      <TestApp>
+        <SettingsDashboard />
+      </TestApp>,
+    );
+
+    expect(await screen.findByText(/Kind 0 — Metadata/)).toBeInTheDocument();
+  });
+
   it('EventsList fetches the banned/needs-moderation markers', async () => {
     render(
       <TestApp>

--- a/src/lib/allowedKinds.test.ts
+++ b/src/lib/allowedKinds.test.ts
@@ -22,9 +22,18 @@ describe('normalizeAllowedKinds', () => {
     expect(normalizeAllowedKinds([1, { kind: 7 }])).toEqual([1, 7]);
   });
 
-  it('drops entries that carry no numeric kind rather than crashing', () => {
+  it('drops entries that carry no integer kind rather than crashing', () => {
     expect(
-      normalizeAllowedKinds([{ added_at: 'x' }, 'nope', null, { kind: 'no' }]),
+      normalizeAllowedKinds([
+        { added_at: 'x' },
+        'nope',
+        null,
+        { kind: 'no' },
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+        1.5,
+        { kind: 1.5 },
+      ]),
     ).toEqual([]);
   });
 

--- a/src/lib/allowedKinds.test.ts
+++ b/src/lib/allowedKinds.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeAllowedKinds } from './allowedKinds';
+
+describe('normalizeAllowedKinds', () => {
+  it('passes through a bare number[] (the legacy relay contract)', () => {
+    expect(normalizeAllowedKinds([0, 1, 7])).toEqual([0, 1, 7]);
+  });
+
+  it('extracts kind from funnelcake {kind, added_at} objects', () => {
+    // This is the exact shape that crashed the Settings tab with React #31:
+    // rendering the object as a React child throws "Objects are not valid as a
+    // React child (found: object with keys {added_at, kind})".
+    const raw = [
+      { added_at: '2026-01-27T04:25:39.690Z', kind: 0 },
+      { added_at: '2026-03-01T06:02:10.855Z', kind: 8 },
+      { added_at: '2026-03-08T10:25:21.077Z', kind: 1059 },
+    ];
+    expect(normalizeAllowedKinds(raw)).toEqual([0, 8, 1059]);
+  });
+
+  it('handles a mixed array of numbers and objects', () => {
+    expect(normalizeAllowedKinds([1, { kind: 7 }])).toEqual([1, 7]);
+  });
+
+  it('drops entries that carry no numeric kind rather than crashing', () => {
+    expect(
+      normalizeAllowedKinds([{ added_at: 'x' }, 'nope', null, { kind: 'no' }]),
+    ).toEqual([]);
+  });
+
+  it('returns [] for null, undefined, or a non-array', () => {
+    expect(normalizeAllowedKinds(null)).toEqual([]);
+    expect(normalizeAllowedKinds(undefined)).toEqual([]);
+    expect(normalizeAllowedKinds({})).toEqual([]);
+  });
+});

--- a/src/lib/allowedKinds.ts
+++ b/src/lib/allowedKinds.ts
@@ -1,0 +1,30 @@
+// ABOUTME: Normalizes the relay's `listallowedkinds` NIP-86 response into a flat number[].
+// ABOUTME: Funnelcake returns Array<{kind, added_at}>; older relays returned bare number[].
+
+/** A single entry from the relay's `listallowedkinds` response, either shape. */
+export type AllowedKindEntry = number | { kind: number; added_at?: string };
+
+/**
+ * The relay's `listallowedkinds` response drifted from its original contract:
+ * funnelcake returns objects (`{kind, added_at}`), while the code assumed bare
+ * numbers. Rendering an object directly as a React child throws React #31
+ * ("Objects are not valid as a React child") and takes down the whole Settings
+ * tab, so collapse both shapes to a plain number[] and drop anything that does
+ * not carry a finite numeric kind.
+ */
+export function normalizeAllowedKinds(raw: unknown): number[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((entry): number | undefined => {
+      if (typeof entry === 'number') return entry;
+      if (
+        entry &&
+        typeof entry === 'object' &&
+        typeof (entry as { kind?: unknown }).kind === 'number'
+      ) {
+        return (entry as { kind: number }).kind;
+      }
+      return undefined;
+    })
+    .filter((kind): kind is number => typeof kind === 'number' && Number.isFinite(kind));
+}

--- a/src/lib/allowedKinds.ts
+++ b/src/lib/allowedKinds.ts
@@ -26,5 +26,5 @@ export function normalizeAllowedKinds(raw: unknown): number[] {
       }
       return undefined;
     })
-    .filter((kind): kind is number => typeof kind === 'number' && Number.isFinite(kind));
+    .filter((kind): kind is number => Number.isInteger(kind));
 }


### PR DESCRIPTION
## Summary
Stops the Settings tab from crashing the admin UI when the relay returns its allowed event kinds as objects rather than bare numbers. The dashboard now normalizes both shapes before rendering, so an object can never reach JSX. The same normalizer is also wired on RelaySettings and RelayStats, which are not currently mounted.

## Motivation
The Settings dashboard rendered the relay's `listallowedkinds` response assuming `number[]`. Funnelcake returns `Array<{kind, added_at}>`, so rendering an entry threw React #31 and the app-level error boundary took over the whole UI. The render was previously reached only by signed-in moderators; #218 dropped the sign-in gate on this query, so the common signed-out case now hits it reliably. This also closes the latent signed-in crash on current prod.

## Related Issue
- Closes #234

## Validation
- [x] `npx tsc -p tsconfig.app.json --noEmit`
- [x] `npx vitest run src/lib/allowedKinds.test.ts` (5 passing; mutation-verified the object-shape assertion fails on the old behavior)
- [x] `npx vitest run src/components/relay-management-access.test.tsx` (includes a Settings render of the Funnelcake object shape)
- [x] Re-smoked on staging: Settings renders signed-out, no crash, all 40 kind badges correct (`Kind 0 — Metadata` … `Kind 1984 — Reporting`)

## Manual Test Plan / Notes
Deployed the branch to the staging Pages alias against the staging worker; opened Settings while signed out. Before: full-page "Something went wrong". After: Event Kind Configuration renders normally.

## Visuals / API Examples
Visual change (crash → working Settings tab), verified in-browser on staging; screenshots omitted by request.

## Public Artifact Review
- [x] Titles, descriptions, branch names, and screenshots avoid partner, customer, brand, campaign, or other sensitive external names.
