### PR TITLE
feat(age-review): lead the parent outreach email with what we need

### DIFF
--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -2220,16 +2220,41 @@ describe('buildParentOutreachBody', () => {
   });
 
   it('drops a NIP-05 that is not actually a NIP-05', () => {
+    // The issuing domain must be supplied, or this asserts nothing: without it
+    // displayNip05 returns early and the shape check never runs.
     const html = buildParentOutreachBody({
       pubkey: 'a'.repeat(64),
       account_nip05: 'http://not-divine.example/claim',
-    });
+    }, 'divine.video');
     expect(html).not.toContain('Username:');
     expect(html).not.toContain('not-divine.example');
   });
 
+  it('drops a NIP-05 smuggling a URL in front of a domain we do issue', () => {
+    // The host really is divine.video, so the domain gate passes it. Only the
+    // shape check stands between this and a live link to evil.example in mail
+    // sent under Divine branding.
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_nip05: 'http://evil.example/claim@divine.video',
+    }, 'divine.video');
+    expect(html).not.toContain('Username:');
+    expect(html).not.toContain('evil.example');
+  });
+
+  it('drops a NIP-05 carrying markup in front of a domain we do issue', () => {
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_nip05: '<script>alert(1)</script>@divine.video',
+    }, 'divine.video');
+    expect(html).not.toContain('Username:');
+    expect(html).not.toContain('script');
+  });
+
   it('prints no empty row for a NIP-05 that is only the root prefix', () => {
-    const html = buildParentOutreachBody({ pubkey: 'a'.repeat(64), account_nip05: '_@' });
+    const html = buildParentOutreachBody(
+      { pubkey: 'a'.repeat(64), account_nip05: '_@' }, 'divine.video',
+    );
     expect(html).not.toContain('Username:');
   });
 
@@ -2251,6 +2276,16 @@ describe('buildParentOutreachBody', () => {
     });
     expect(html).toContain(`${'x'.repeat(79)}\u{1F600}\u2026`);
     expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(html)).toBe(false);
+  });
+
+  it('drops a display name carrying a bare IP address', () => {
+    // No letters after the final dot, so the hostname rule alone does not see
+    // this one.
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_name: 'Star Girl go to 93.184.216.34/claim',
+    });
+    expect(html).not.toContain('Display name:');
   });
 
   it('drops a display name using a unicode dot to hide a hostname', () => {

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -2143,7 +2143,7 @@ describe('buildParentOutreachBody', () => {
       pubkey: 'a'.repeat(64),
       account_name: 'Star Girl',
       account_nip05: '_@stargirl.divine.video',
-    });
+    }, 'divine.video');
     expect(html).toContain('The account under review:');
     expect(html).toContain('Display name: Star Girl');
     // NIP-05 root identifiers display as the bare domain, so the stored
@@ -2156,9 +2156,42 @@ describe('buildParentOutreachBody', () => {
   it('leaves a non-root NIP-05 local part alone', () => {
     const html = buildParentOutreachBody({
       pubkey: 'a'.repeat(64),
-      account_nip05: 'alice@example.com',
+      account_nip05: 'alice@divine.video',
+    }, 'divine.video');
+    expect(html).toContain('Username: alice@divine.video');
+  });
+
+  it('drops a NIP-05 on a domain we do not issue', () => {
+    // A NIP-05 is a bare hostname, so looksLinkish cannot screen it without
+    // rejecting every real one. The issuing domain is the screen instead: this
+    // value is unverified kind-0, and rendering it would mail an
+    // attacker-chosen, highly linkifiable hostname under Divine branding.
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_nip05: '_@claim-your-teen-account.example',
+    }, 'divine.video');
+    expect(html).not.toContain('Username:');
+    expect(html).not.toContain('claim-your-teen-account');
+  });
+
+  it('renders no username at all when no issuing domain is configured', () => {
+    // Staging deliberately leaves NIP05_DOMAIN unset. No username beats one we
+    // cannot vouch for.
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_nip05: '_@stargirl.divine.video',
     });
-    expect(html).toContain('Username: alice@example.com');
+    expect(html).not.toContain('Username:');
+  });
+
+  it('accepts a subdomain of the issuing domain but not a lookalike', () => {
+    expect(buildParentOutreachBody(
+      { pubkey: 'a'.repeat(64), account_nip05: '_@kid.divine.video' }, 'divine.video',
+    )).toContain('Username: kid.divine.video');
+    // `notdivine.video` ends with the domain as a substring but is not ours.
+    expect(buildParentOutreachBody(
+      { pubkey: 'a'.repeat(64), account_nip05: '_@notdivine.video' }, 'divine.video',
+    )).not.toContain('Username:');
   });
 
   it('escapes an ID that could not be encoded as an npub', () => {
@@ -2178,7 +2211,7 @@ describe('buildParentOutreachBody', () => {
       pubkey: 'a'.repeat(64),
       account_name: 'Star Girl verify at http://not-divine.example/claim',
       account_nip05: '_@stargirl.divine.video',
-    });
+    }, 'divine.video');
     expect(html).not.toContain('Display name:');
     expect(html).not.toContain('not-divine.example');
     // Failing safe still leaves the parent able to identify the account.
@@ -2200,13 +2233,42 @@ describe('buildParentOutreachBody', () => {
     expect(html).not.toContain('Username:');
   });
 
-  it('caps an overlong display name rather than mailing it whole', () => {
+  it('caps an overlong display name and marks it as cut', () => {
     const html = buildParentOutreachBody({
       pubkey: 'a'.repeat(64),
       account_name: 'Q'.repeat(300),
     });
-    expect(html).toContain(`Display name: ${'Q'.repeat(80)}<`);
+    expect(html).toContain(`Display name: ${'Q'.repeat(80)}\u2026`);
     expect(html).not.toContain('Q'.repeat(81));
+  });
+
+  it('truncates by code point, so an emoji is never cut in half', () => {
+    // A lone surrogate in html_body is malformed and Zendesk may reject the
+    // whole comment, which would drop the outreach entirely.
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_name: `${'x'.repeat(79)}\u{1F600}extra`,
+    });
+    expect(html).toContain(`${'x'.repeat(79)}\u{1F600}\u2026`);
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(html)).toBe(false);
+  });
+
+  it('drops a display name using a unicode dot to hide a hostname', () => {
+    // UTS-46 maps U+3002 to '.', so a mail client resolves this as a hostname
+    // even though an ASCII-only check does not see one.
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_name: 'Star Girl go to evil\u3002example',
+    });
+    expect(html).not.toContain('Display name:');
+  });
+
+  it('drops a display name hiding a dot behind a zero-width character', () => {
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_name: 'Star Girl evil\u200b.example',
+    });
+    expect(html).not.toContain('Display name:');
   });
 
   it('omits the rows it has no value for rather than printing empties', () => {

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -1593,8 +1593,8 @@ describe('parent contact record', () => {
     expect(payload.ticket.requester.name).toBe('parent@example.com');
     expect(payload.ticket.requester.name).not.toContain('Claimed parent');
     expect(payload.ticket.requester.name).not.toBe('Parent/Guardian');
-    // The outreach is sent as html_body; assert on the field that actually ships,
-    // or this passes vacuously against an undefined `body`.
+    // The outreach ships as html_body now; asserted against `body` this errors
+    // on an undefined receiver rather than checking anything.
     expect(payload.ticket.comment.html_body).not.toContain('Some One');
   });
 
@@ -2037,6 +2037,11 @@ describe('handleParentContact Zendesk integration', () => {
 
     // Nor may the message body carry it: same unverified address.
     expect(ticketPut.ticket.comment.html_body).not.toContain('Some One');
+
+    // Zendesk sends `body` when both are present, so a plain body reappearing
+    // here would silently revert the message to text. This is the branch a
+    // moderator-restricted case takes, so it needs the guard as much as create.
+    expect(ticketPut.ticket.comment.body).toBeUndefined();
 
     // Agent-only: the block reached the contact, with the right case.
     const contactPut = mockFetch.mock.calls.find(

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -1593,9 +1593,10 @@ describe('parent contact record', () => {
     expect(payload.ticket.requester.name).toBe('parent@example.com');
     expect(payload.ticket.requester.name).not.toContain('Claimed parent');
     expect(payload.ticket.requester.name).not.toBe('Parent/Guardian');
-    // The outreach ships as html_body now; asserted against `body` this errors
-    // on an undefined receiver rather than checking anything.
-    expect(payload.ticket.comment.html_body).not.toContain('Some One');
+    // The To: header stays address-only. The message body now does name the
+    // account -- a deliberate reversal of #222 for the body alone -- so this
+    // asserts the split rather than a blanket ban on the handle.
+    expect(payload.ticket.comment.html_body).toContain('Some One');
   });
 
   it('writes the identity block to the contact notes', async () => {
@@ -2035,8 +2036,10 @@ describe('handleParentContact Zendesk integration', () => {
     expect(ticketPut.ticket.requester.name).toBe('parent@example.com');
     expect(ticketPut.ticket.requester.name).not.toContain('Some One');
 
-    // Nor may the message body carry it: same unverified address.
-    expect(ticketPut.ticket.comment.html_body).not.toContain('Some One');
+    // The body does name the account, on this path too -- the parent cannot act
+    // on the review without knowing which account it is. Only the To: header is
+    // held back until a reply proves the address.
+    expect(ticketPut.ticket.comment.html_body).toContain('Some One');
 
     // Zendesk sends `body` when both are present, so a plain body reappearing
     // here would silently revert the message to text. This is the branch a
@@ -2135,13 +2138,42 @@ describe('buildParentOutreachBody', () => {
     expect(html).toContain('<a href="https://divine.video/kids">how accounts work for kids on Divine</a>');
   });
 
-  it('names no account and takes nothing that could name one', () => {
-    // #222 keeps the pre-reply message handle-free: it goes to an address the
-    // teen supplied that nobody has verified. The builder therefore takes no
-    // identity at all, so there is nothing for a caller to thread in by
-    // accident.
-    expect(buildParentOutreachBody.length).toBe(0);
-    expect(buildParentOutreachBody()).not.toContain('The account under review');
+  it('names the account so the parent knows which one this is about', () => {
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_name: 'Star Girl',
+      account_nip05: '_@stargirl.divine.video',
+    });
+    expect(html).toContain('The account under review:');
+    expect(html).toContain('Display name: Star Girl');
+    expect(html).toContain('Username: _@stargirl.divine.video');
+    expect(html).toMatch(/ID: npub1[a-z0-9]+/);
+  });
+
+  it('omits the rows it has no value for rather than printing empties', () => {
+    // Capture is best effort: an account whose profile was already hidden by
+    // enforcement yields no name and no NIP-05. The npub always resolves.
+    const html = buildParentOutreachBody({ pubkey: 'a'.repeat(64) });
+    expect(html).toContain('The account under review:');
+    expect(html).not.toContain('Display name:');
+    expect(html).not.toContain('Username:');
+    expect(html).toMatch(/ID: npub1[a-z0-9]+/);
+  });
+
+  it('drops the block entirely when nothing was captured', () => {
+    expect(buildParentOutreachBody({})).not.toContain('The account under review');
+  });
+
+  it('escapes an account-controlled display name', () => {
+    // account_name is stored raw from the account's own kind-0 (#222 stores raw
+    // on purpose, so each render surface sanitizes for its own medium). This is
+    // the only thing between it and a parent's inbox.
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_name: '<script>alert(1)</script> & "friends"',
+    });
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt; &amp; &quot;friends&quot;');
   });
 });
 

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -2146,8 +2146,19 @@ describe('buildParentOutreachBody', () => {
     });
     expect(html).toContain('The account under review:');
     expect(html).toContain('Display name: Star Girl');
-    expect(html).toContain('Username: _@stargirl.divine.video');
+    // NIP-05 root identifiers display as the bare domain, so the stored
+    // `_@stargirl.divine.video` must not reach a parent with its prefix.
+    expect(html).toContain('Username: stargirl.divine.video');
+    expect(html).not.toContain('_@');
     expect(html).toMatch(/ID: npub1[a-z0-9]+/);
+  });
+
+  it('leaves a non-root NIP-05 local part alone', () => {
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_nip05: 'alice@example.com',
+    });
+    expect(html).toContain('Username: alice@example.com');
   });
 
   it('omits the rows it has no value for rather than printing empties', () => {

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -2119,6 +2119,10 @@ describe('buildParentOutreachBody', () => {
   it('states the video requirements, the deadline, and the 16+ path', () => {
     const html = buildParentOutreachBody();
     expect(html).toContain('a parent or guardian speaking on camera');
+    // divine.video/kids and /age-review both require the age statement. This
+    // email is the primary instruction channel now, so dropping it here sends
+    // families back for a second video -- the round trip this copy exists to end.
+    expect(html).toContain('that the teen is between 13 and 15');
     expect(html).toContain('the country or countries where you live');
     expect(html).toContain('Please do NOT send government IDs');
     expect(html).toContain('Please reply within 15 days');

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -2161,6 +2161,57 @@ describe('buildParentOutreachBody', () => {
     expect(html).toContain('Username: alice@example.com');
   });
 
+  it('escapes the NIP-05 and the ID, not just the display name', () => {
+    // account_nip05 is as attacker-controlled as account_name -- both are raw
+    // kind-0 -- and toNpub hands back its input unchanged when the pubkey will
+    // not encode, so neither may reach the parent unescaped.
+    const html = buildParentOutreachBody({
+      pubkey: '<img src=x onerror=alert(1)>',
+      account_nip05: '"><script>alert(1)</script>@evil-domain.test',
+    });
+    expect(html).not.toContain('<script>');
+    expect(html).not.toContain('<img');
+  });
+
+  it('drops a display name that is trying to look like a link', () => {
+    // The account picks this string AND supplies the address we mail it to, so
+    // a name carrying a URL turns this message into attacker-chosen delivery.
+    // Escaping does not help: mail clients auto-link bare URLs in text.
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_name: 'Star Girl verify at http://not-divine.example/claim',
+      account_nip05: '_@stargirl.divine.video',
+    });
+    expect(html).not.toContain('Display name:');
+    expect(html).not.toContain('not-divine.example');
+    // Failing safe still leaves the parent able to identify the account.
+    expect(html).toContain('Username: stargirl.divine.video');
+    expect(html).toMatch(/ID: npub1[a-z0-9]+/);
+  });
+
+  it('drops a NIP-05 that is not actually a NIP-05', () => {
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_nip05: 'http://not-divine.example/claim',
+    });
+    expect(html).not.toContain('Username:');
+    expect(html).not.toContain('not-divine.example');
+  });
+
+  it('prints no empty row for a NIP-05 that is only the root prefix', () => {
+    const html = buildParentOutreachBody({ pubkey: 'a'.repeat(64), account_nip05: '_@' });
+    expect(html).not.toContain('Username:');
+  });
+
+  it('caps an overlong display name rather than mailing it whole', () => {
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_name: 'Q'.repeat(300),
+    });
+    expect(html).toContain(`Display name: ${'Q'.repeat(80)}<`);
+    expect(html).not.toContain('Q'.repeat(81));
+  });
+
   it('omits the rows it has no value for rather than printing empties', () => {
     // Capture is best effort: an account whose profile was already hidden by
     // enforcement yields no name and no NIP-05. The npub always resolves.

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -18,6 +18,7 @@ import {
   handleGetAgeReviewFunnel,
   ageReviewActiveGuard,
   composeContactNotes,
+  buildParentOutreachBody,
   type AgeReviewEnv,
 } from './age-review';
 import type { AgeReviewCase } from '../../shared/age-review';
@@ -1592,7 +1593,9 @@ describe('parent contact record', () => {
     expect(payload.ticket.requester.name).toBe('parent@example.com');
     expect(payload.ticket.requester.name).not.toContain('Claimed parent');
     expect(payload.ticket.requester.name).not.toBe('Parent/Guardian');
-    expect(payload.ticket.comment.body).not.toContain('Some One');
+    // The outreach is sent as html_body; assert on the field that actually ships,
+    // or this passes vacuously against an undefined `body`.
+    expect(payload.ticket.comment.html_body).not.toContain('Some One');
   });
 
   it('writes the identity block to the contact notes', async () => {
@@ -2032,6 +2035,9 @@ describe('handleParentContact Zendesk integration', () => {
     expect(ticketPut.ticket.requester.name).toBe('parent@example.com');
     expect(ticketPut.ticket.requester.name).not.toContain('Some One');
 
+    // Nor may the message body carry it: same unverified address.
+    expect(ticketPut.ticket.comment.html_body).not.toContain('Some One');
+
     // Agent-only: the block reached the contact, with the right case.
     const contactPut = mockFetch.mock.calls.find(
       (call: unknown[]) => (call[0] as string).includes('/users/') && (call[1] as { method?: string })?.method === 'PUT',
@@ -2042,6 +2048,91 @@ describe('handleParentContact Zendesk integration', () => {
     expect(notes).toContain('Some One');
 
     vi.unstubAllGlobals();
+  });
+
+  it('sends the outreach as html_body so Zendesk renders it as rich mail', async () => {
+    const c = makeCase({ state: 'restricted_pending_user_response' });
+    const db = {
+      prepare: vi.fn().mockImplementation((sql: string) => ({
+        bind: vi.fn().mockReturnValue({
+          first: vi.fn().mockResolvedValue(
+            sql.includes('WHERE id = ? AND pubkey = ?') ? c : null
+          ),
+          run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+        }),
+      })),
+    };
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ ticket: { id: 42 } }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const req = new Request('https://api.test/v1/minor-review-cases/case-1/parent-contact', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'parent@example.com' }),
+    });
+    await handleParentContact(req, 'case-1', c.pubkey, makeEnv(db, {
+      ZENDESK_SUBDOMAIN: 'test',
+      ZENDESK_API_TOKEN: 'tok',
+      ZENDESK_EMAIL: 'agent@test.com',
+    }), corsHeaders);
+
+    const zendeskCall = mockFetch.mock.calls.find(
+      (call: unknown[]) => (call[0] as string).includes('zendesk.com/api/v2/tickets')
+    );
+    const { comment } = JSON.parse(zendeskCall![1].body).ticket;
+    // A plain `body` alongside html_body would be the one Zendesk sent, so the
+    // markup has to be the only thing supplied.
+    expect(comment.body).toBeUndefined();
+    expect(comment.html_body).toContain('<a href="https://divine.video/family">');
+
+    vi.unstubAllGlobals();
+  });
+});
+
+// -- parent outreach copy -----------------------------------------------------
+
+describe('buildParentOutreachBody', () => {
+  it('leads with what we need rather than asking who they are', () => {
+    const html = buildParentOutreachBody();
+    expect(html).toContain('reply to this email with a short private video');
+    // The message this replaces asked only for a confirmation, which parents
+    // answered with "yes" -- worthless as consent. That ask must not survive.
+    expect(html).not.toContain('confirm you are the parent or legal guardian');
+  });
+
+  it('carries no age-band label, so one template serves both bands', () => {
+    const html = buildParentOutreachBody();
+    for (const label of ['13-15', '16+ (claimed)', 'Under 13', 'age range']) {
+      expect(html).not.toContain(label);
+    }
+    expect(html).toContain('possibly belonging to someone under 16');
+  });
+
+  it('states the video requirements, the deadline, and the 16+ path', () => {
+    const html = buildParentOutreachBody();
+    expect(html).toContain('a parent or guardian speaking on camera');
+    expect(html).toContain('the country or countries where you live');
+    expect(html).toContain('Please do NOT send government IDs');
+    expect(html).toContain('Please reply within 15 days');
+    expect(html).toContain('you are 16 or older');
+  });
+
+  it('links the family and kids pages as anchors, not bare URLs', () => {
+    const html = buildParentOutreachBody();
+    expect(html).toContain('<a href="https://divine.video/family">For Families page</a>');
+    expect(html).toContain('<a href="https://divine.video/kids">how accounts work for kids on Divine</a>');
+  });
+
+  it('names no account and takes nothing that could name one', () => {
+    // #222 keeps the pre-reply message handle-free: it goes to an address the
+    // teen supplied that nobody has verified. The builder therefore takes no
+    // identity at all, so there is nothing for a caller to thread in by
+    // accident.
+    expect(buildParentOutreachBody.length).toBe(0);
+    expect(buildParentOutreachBody()).not.toContain('The account under review');
   });
 });
 

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -2161,6 +2161,18 @@ describe('buildParentOutreachBody', () => {
     expect(html).toContain('Username: alice@divine.video');
   });
 
+  it('drops a NIP-05 whose local part is hostname-shaped, even on a domain we issue', () => {
+    // The host gate constrains only the domain. NIP-05 permits `.` in the local
+    // part, so an unverified kind-0 value can smuggle a hostname there and still
+    // pass the gate on our own domain. looksLinkish screens the local part.
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_nip05: 'www.evil.example@divine.video',
+    }, 'divine.video');
+    expect(html).not.toContain('Username:');
+    expect(html).not.toContain('www.evil.example');
+  });
+
   it('drops a NIP-05 on a domain we do not issue', () => {
     // A NIP-05 is a bare hostname, so looksLinkish cannot screen it without
     // rejecting every real one. The issuing domain is the screen instead: this
@@ -2304,6 +2316,28 @@ describe('buildParentOutreachBody', () => {
       account_name: 'Star Girl evil\u200b.example',
     });
     expect(html).not.toContain('Display name:');
+  });
+
+  it('drops a name hiding a dot behind an invisible format character outside the zero-width block', () => {
+    // U+2062 (INVISIBLE TIMES) is a Cf character the enumerated strip missed:
+    // looksLinkish cannot match across it, but a mail client ignores it and
+    // parses `evil.example`.
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_name: 'Star Girl evil\u2062.example',
+    });
+    expect(html).not.toContain('Display name:');
+  });
+
+  it('drops a name carrying a bidi override and never emits one into the body', () => {
+    // U+202E (RIGHT-TO-LEFT OVERRIDE), left unterminated, reorders the rest of
+    // the paragraph it lands in -- and the npub row shares that paragraph.
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_name: 'Star Girl evil\u202e.example',
+    });
+    expect(html).not.toContain('Display name:');
+    expect(html).not.toContain('\u202e');
   });
 
   it('omits the rows it has no value for rather than printing empties', () => {

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -2340,6 +2340,50 @@ describe('buildParentOutreachBody', () => {
     expect(html).not.toContain('\u202e');
   });
 
+  it('drops a name hiding a dot behind a variation selector', () => {
+    // U+FE0F is Default_Ignorable but not Cf, so the \p{Cf} half of the strip
+    // never reaches it -- and it is the ordinary emoji presentation selector, so
+    // it turns up in real display names rather than only in crafted ones. ICU
+    // resolves `evil️.example` to `evil.example`, so without
+    // \p{Default_Ignorable_Code_Point} this renders a live hostname.
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_name: 'Star Girl evil️.example',
+    });
+    expect(html).not.toContain('Display name:');
+  });
+
+  it('drops a display name whose IP address is written in fullwidth digits', () => {
+    // The IPv4 rule matches ASCII \d only, and the explicit dot replacement does
+    // not touch the digits. NFKC is the only thing that folds this to
+    // `93.184.216.34` -- which is exactly what a UTS-46 resolver sees.
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_name: 'Star Girl go to ９３．１８４．２１６．３４',
+    });
+    expect(html).not.toContain('Display name:');
+  });
+
+  it('drops a display name carrying a scheme even when the host has no dot', () => {
+    // The hostname rule needs a dot after the label, so an intranet or localhost
+    // target is caught by the scheme check alone.
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_name: 'Star Girl go to http://localhost/claim',
+    });
+    expect(html).not.toContain('Display name:');
+  });
+
+  it('accepts a NIP-05 that arrived with surrounding whitespace', () => {
+    // Capture stores kind-0 verbatim and never trims, so a padded value reaches
+    // the anchored shape check as-is and would be dropped without the trim.
+    const html = buildParentOutreachBody({
+      pubkey: 'a'.repeat(64),
+      account_nip05: '  _@stargirl.divine.video\n',
+    }, 'divine.video');
+    expect(html).toContain('Username: stargirl.divine.video');
+  });
+
   it('omits the rows it has no value for rather than printing empties', () => {
     // Capture is best effort: an account whose profile was already hidden by
     // enforcement yields no name and no NIP-05. The npub always resolves.

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -2161,16 +2161,13 @@ describe('buildParentOutreachBody', () => {
     expect(html).toContain('Username: alice@example.com');
   });
 
-  it('escapes the NIP-05 and the ID, not just the display name', () => {
-    // account_nip05 is as attacker-controlled as account_name -- both are raw
-    // kind-0 -- and toNpub hands back its input unchanged when the pubkey will
-    // not encode, so neither may reach the parent unescaped.
-    const html = buildParentOutreachBody({
-      pubkey: '<img src=x onerror=alert(1)>',
-      account_nip05: '"><script>alert(1)</script>@evil-domain.test',
-    });
-    expect(html).not.toContain('<script>');
+  it('escapes an ID that could not be encoded as an npub', () => {
+    // toNpub hands back its input unchanged rather than throwing when the
+    // pubkey will not encode, so the ID row is not automatically safe just
+    // because npubs are alphanumeric.
+    const html = buildParentOutreachBody({ pubkey: '<img src=x onerror=alert(1)>' });
     expect(html).not.toContain('<img');
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
   });
 
   it('drops a display name that is trying to look like a link', () => {

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -908,8 +908,7 @@ export function buildParentOutreachBody(): string {
     '<p><strong>Please do NOT send government IDs, payment details, school or medical records, ' +
       'or passwords.</strong> We only need the short video.</p>',
     '',
-    `<p>Please reply within ${DEADLINE_DAYS} days. If we do not hear from you, ` +
-      'your child&#39;s account will be deleted.</p>',
+    '<p>Please reply within 15 days. If we do not hear from you, your child&#39;s account will be deleted.</p>',
     '',
     '<p>If you are the account holder and you are 16 or older, reply and tell us that. ' +
       'No video needed, and we will take another look.</p>',

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -944,6 +944,11 @@ function buildAccountIdentityHtml(identity: AgeReviewCaseIdentity & { pubkey?: s
   const nip05 = identity.account_nip05 ? displayNip05(identity.account_nip05.trim()) : undefined;
 
   if (name && !looksLinkish(name)) rows.push(`Display name: ${escapeHtml(name)}`);
+  // The escape here cannot fire: displayNip05's charset already excludes every
+  // HTML-special character, so a markup-bearing value is dropped before it
+  // arrives. Kept so the row does not become the one that forgot, if that
+  // validation is ever loosened. Deliberately not covered by a test -- there is
+  // no input that would reach it.
   if (nip05) rows.push(`Username: ${escapeHtml(nip05)}`);
   if (identity.pubkey) rows.push(`ID: ${escapeHtml(toNpub(identity.pubkey))}`);
   if (rows.length === 0) return '';

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -933,6 +933,11 @@ function displayNip05(nip05: string): string | undefined {
  * deeplink, the band, and the claimed-and-unverified qualifier. A parent needs
  * only enough to recognise their child's account.
  *
+ * `account_vine_username` is captured and is the agent block's third fallback,
+ * but is deliberately not shown here. It may have informed what became the
+ * Divine username, but by the time a case exists the original Vine name that
+ * happened to be carried over is not what a parent would recognise.
+ *
  * Every row is conditional except the npub. Capture is best effort -- an account
  * whose profile was already hidden by enforcement yields no name and no NIP-05
  * -- but the pubkey is on the case row and always resolves.

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -882,6 +882,16 @@ function escapeHtml(value: string): string {
 }
 
 /**
+ * NIP-05 calls `_@domain` the "root" identifier and says to display it as the
+ * bare domain (nips/05.md, "Showing just the domain as an identifier"). Divine
+ * issues `_@<username>.divine.video`, so the prefix is noise to a parent. Any
+ * other local part is a real name and is left alone.
+ */
+function displayNip05(nip05: string): string {
+  return nip05.startsWith('_@') ? nip05.slice(2) : nip05;
+}
+
+/**
  * Tells the parent which account this is about.
  *
  * A narrower set than agents get: the contact-notes block also carries the case
@@ -898,7 +908,7 @@ function buildAccountIdentityHtml(identity: AgeReviewCaseIdentity & { pubkey?: s
   const nip05 = identity.account_nip05?.trim();
 
   if (name) rows.push(`Display name: ${escapeHtml(name)}`);
-  if (nip05) rows.push(`Username: ${escapeHtml(nip05)}`);
+  if (nip05) rows.push(`Username: ${escapeHtml(displayNip05(nip05))}`);
   if (identity.pubkey) rows.push(`ID: ${escapeHtml(toNpub(identity.pubkey))}`);
   if (rows.length === 0) return '';
 

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -22,7 +22,7 @@ import { resolveZendeskCreds } from './zendesk-sync';
 import type { BulkAction } from '../../shared/bulk-moderation';
 import { suspendUser, unsuspendUser, banUser, clearVerifiedMinor, createMinorAccount, type KeycastEnv } from './keycast-client';
 import { suspendPubkey, unsuspendPubkey, banPubkey, type SecretStoreSecret } from './nip86';
-import { buildAgeReviewIdentityBlock, buildClaimedParentName } from './report-note';
+import { buildAgeReviewIdentityBlock, buildClaimedParentName, toNpub } from './report-note';
 
 /**
  * The identity a case captured at creation, as stored on `age_review_cases`.
@@ -868,6 +868,44 @@ async function getZendeskClientConfig(env: AgeReviewEnv): Promise<ZendeskClientC
 }
 
 /**
+ * Escape text for interpolation into the HTML outreach body. The display name
+ * and NIP-05 come from the account's own kind-0 and are stored raw, so every
+ * render surface has to neutralize them itself.
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Tells the parent which account this is about.
+ *
+ * A narrower set than agents get: the contact-notes block also carries the case
+ * deeplink and band, and qualifies the handle as claimed and unverified. A
+ * parent needs only enough to recognise their child's account.
+ *
+ * Every row is conditional except the npub. Capture is best effort -- an account
+ * whose profile was already hidden by enforcement yields no name and no NIP-05
+ * -- but the pubkey is on the case row and always resolves.
+ */
+function buildAccountIdentityHtml(identity: AgeReviewCaseIdentity & { pubkey?: string }): string {
+  const rows: string[] = [];
+  const name = identity.account_name?.trim();
+  const nip05 = identity.account_nip05?.trim();
+
+  if (name) rows.push(`Display name: ${escapeHtml(name)}`);
+  if (nip05) rows.push(`Username: ${escapeHtml(nip05)}`);
+  if (identity.pubkey) rows.push(`ID: ${escapeHtml(toNpub(identity.pubkey))}`);
+  if (rows.length === 0) return '';
+
+  return `<p>The account under review:<br>\n${rows.join('<br>\n')}</p>`;
+}
+
+/**
  * The first message a parent or guardian receives. It leads with what we need
  * from them rather than asking them to confirm who they are: a reply that only
  * says "yes" tells us nothing, and anyone who is not the parent cannot produce
@@ -877,20 +915,29 @@ async function getZendeskClientConfig(env: AgeReviewEnv): Promise<ZendeskClientC
  * label because the same message is sent to a 13-15 case and to someone
  * claiming to be 16 or older, and "possibly under 16" is true of both.
  *
- * It names no account, for the same reason the requester carries no handle: it
- * goes to an address the teen supplied that nobody has verified. The captured
- * identity reaches agents through the contact notes instead.
+ * It names the account. That is a deliberate reversal of the position #222 took
+ * for this message, taken by the T&S lead: a parent cannot act on a review
+ * without knowing which account it concerns. The risk #222 named is real and
+ * unchanged -- the address is supplied by the account under review and is
+ * unverified until someone replies from it -- so the requester name stays
+ * address-only and this is the only surface where the handle reaches an
+ * unverified recipient.
  *
  * Sent as HTML: Zendesk renders `html_body` through the account's mail template
  * and derives the plain-text alternative itself.
  */
-export function buildParentOutreachBody(): string {
+export function buildParentOutreachBody(
+  identity: AgeReviewCaseIdentity & { pubkey?: string } = {},
+): string {
+  const identityHtml = buildAccountIdentityHtml(identity);
+
   return [
     '<p>Hello,</p>',
     '',
     '<p>An account on Divine was flagged as possibly belonging to someone under 16. ' +
       'Where permitted by law, teens aged 13 to 15 can use Divine through Divine Greenlight, ' +
       'with a parent or guardian who is aware and involved.</p>',
+    ...(identityHtml ? ['', identityHtml] : []),
     '',
     '<p>To keep the account open, reply to this email with a short private video that shows:</p>',
     '',
@@ -1069,7 +1116,7 @@ async function createAgeReviewTicket(
   if (!env.DB) return;
 
   const subject = `Age review: parental verification needed [${caseId}]`;
-  const outreachBody = buildParentOutreachBody();
+  const outreachBody = buildParentOutreachBody(identity);
   const customFields = buildAgeReviewCustomFields(env, deadlineAt);
 
   const res = await fetch(`${zendesk.baseUrl}/tickets`, {
@@ -1184,7 +1231,7 @@ async function updateTicketWithParentContact(
   const zendesk = await getZendeskClientConfig(env);
   if (!zendesk) return;
 
-  const outreachBody = buildParentOutreachBody();
+  const outreachBody = buildParentOutreachBody(identity);
 
   const res = await fetch(`${zendesk.baseUrl}/tickets/${ticketId}`, {
     method: 'PUT',

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -867,20 +867,59 @@ async function getZendeskClientConfig(env: AgeReviewEnv): Promise<ZendeskClientC
   };
 }
 
-function buildParentOutreachBody(ageBand: AgeBand): string {
+/**
+ * The first message a parent or guardian receives. It leads with what we need
+ * from them rather than asking them to confirm who they are: a reply that only
+ * says "yes" tells us nothing, and anyone who is not the parent cannot produce
+ * the video regardless.
+ *
+ * One template covers both bands this path can reach. It carries no age-band
+ * label because the same message is sent to a 13-15 case and to someone
+ * claiming to be 16 or older, and "possibly under 16" is true of both.
+ *
+ * It names no account, for the same reason the requester carries no handle: it
+ * goes to an address the teen supplied that nobody has verified. The captured
+ * identity reaches agents through the contact notes instead.
+ *
+ * Sent as HTML: Zendesk renders `html_body` through the account's mail template
+ * and derives the plain-text alternative itself.
+ */
+export function buildParentOutreachBody(): string {
   return [
-    'Hello,',
+    '<p>Hello,</p>',
     '',
-    'We received a report that an account on Divine may belong to a minor in the ' +
-      `${BAND_DISPLAY[ageBand]} age range. As part of our safety process, we need a ` +
-      'parent or guardian to verify they are aware of and approve this account.',
+    '<p>An account on Divine was flagged as possibly belonging to someone under 16. ' +
+      'Where permitted by law, teens aged 13 to 15 can use Divine through Divine Greenlight, ' +
+      'with a parent or guardian who is aware and involved.</p>',
     '',
-    'Please reply to this email to confirm you are the parent or legal guardian of the account holder.',
+    '<p>To keep the account open, reply to this email with a short private video that shows:</p>',
     '',
-    'If you have questions, you can reply directly to this email or contact us at contact@divine.video.',
+    '<ul>',
+    '  <li>the teen</li>',
+    '  <li>a parent or guardian speaking on camera</li>',
+    '  <li>that the teen has permission to use Divine</li>',
+    '  <li>that the parent or guardian knows about the account and will supervise its use</li>',
+    '  <li>the country or countries where you live</li>',
+    '</ul>',
     '',
-    'Thank you,',
-    'Divine Trust & Safety',
+    '<p>You can attach the video or include a private link to it.</p>',
+    '',
+    '<p><strong>Please do NOT send government IDs, payment details, school or medical records, ' +
+      'or passwords.</strong> We only need the short video.</p>',
+    '',
+    '<p>Please reply within 15 days. If we do not hear from you, your child&#39;s account will be deleted.</p>',
+    '',
+    '<p>If you are the account holder and you are 16 or older, reply and tell us that. ' +
+      'No video needed, and we will take another look.</p>',
+    '',
+    '<p>If you have questions about this request, or want tips on supporting your family&#39;s ' +
+      'healthy use of social media, visit our <a href="https://divine.video/family">For Families page</a>. ' +
+      'Read <a href="https://divine.video/kids">how accounts work for kids on Divine</a>.</p>',
+    '',
+    '<p>You can also reply directly to this email with any questions.</p>',
+    '',
+    '<p>Thank you,<br>',
+    'Divine Trust &amp; Safety</p>',
   ].join('\n');
 }
 
@@ -1029,7 +1068,7 @@ async function createAgeReviewTicket(
   if (!env.DB) return;
 
   const subject = `Age review: parental verification needed [${caseId}]`;
-  const outreachBody = buildParentOutreachBody(ageBand);
+  const outreachBody = buildParentOutreachBody();
   const customFields = buildAgeReviewCustomFields(env, deadlineAt);
 
   const res = await fetch(`${zendesk.baseUrl}/tickets`, {
@@ -1041,7 +1080,7 @@ async function createAgeReviewTicket(
     body: JSON.stringify({
       ticket: {
         subject,
-        comment: { body: outreachBody, public: true },
+        comment: { html_body: outreachBody, public: true },
         // The address alone. Zendesk renders this into the To: header of every
         // outbound mail, and this ticket's first message goes to an address the
         // teen supplied that nobody has verified -- so it must not carry the
@@ -1144,7 +1183,7 @@ async function updateTicketWithParentContact(
   const zendesk = await getZendeskClientConfig(env);
   if (!zendesk) return;
 
-  const outreachBody = buildParentOutreachBody(ageBand);
+  const outreachBody = buildParentOutreachBody();
 
   const res = await fetch(`${zendesk.baseUrl}/tickets/${ticketId}`, {
     method: 'PUT',
@@ -1158,7 +1197,7 @@ async function updateTicketWithParentContact(
         // riskier still: it reassigns the requester on a ticket that already
         // exists, so the name lands on a contact an agent may already see.
         requester: { email: parentEmail, name: parentEmail },
-        comment: { body: outreachBody, public: true },
+        comment: { html_body: outreachBody, public: true },
       },
     }),
   });

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -881,8 +881,42 @@ function escapeHtml(value: string): string {
     .replace(/'/g, '&#39;');
 }
 
-/** Matches the same 80 characters `sanitizeInline` allows a rendered handle. */
+/** The same 80 characters `sanitizeInline` allows a rendered handle. */
 const IDENTITY_MAX_LEN = 80;
+
+/**
+ * Strip what has no business in a rendered identity and truncate to the cap.
+ *
+ * Control characters and zero-width joiners are removed rather than escaped:
+ * they cannot help a parent recognise an account, and a zero-width character
+ * inside a hostname is a way to hide one from `looksLinkish` while a mail
+ * client's own parser still sees the link.
+ *
+ * Truncation is by code point, not code unit -- emoji in display names are
+ * ordinary, and slicing one in half emits a lone surrogate into the mail body.
+ * The ellipsis matches `sanitizeInline`, so a cut name is not presented to a
+ * parent as if it were whole.
+ */
+function cleanIdentityText(value: string): string {
+  // Control characters and the zero-width / format range, tested by code point
+  // rather than a regex: this repo sets noInlineConfig, so a control-character
+  // class cannot be exempted from no-control-regex inline. report-note.ts walks
+  // the string the same way.
+  const stripped = Array.from(value)
+    .filter((ch) => {
+      const c = ch.codePointAt(0) ?? 0;
+      return !(
+        c <= 0x1f || c === 0x7f || c === 0xad ||
+        (c >= 0x200b && c <= 0x200f) || c === 0x2060 || c === 0xfeff
+      );
+    })
+    .join('')
+    .trim();
+  const points = Array.from(stripped);
+  return points.length > IDENTITY_MAX_LEN
+    ? `${points.slice(0, IDENTITY_MAX_LEN).join('')}…`
+    : stripped;
+}
 
 /**
  * True when a display name is trying to look like a link.
@@ -899,29 +933,54 @@ const IDENTITY_MAX_LEN = 80;
  * attacker chose. Dropping the row is the safe failure: the parent still gets
  * the username and the ID.
  *
- * Deliberately blunt. A dotted token with an alphabetic suffix is enough to
- * trip it, so a legitimate name like "Anna.Marie" is dropped too. Losing a
- * display name costs recognisability; shipping a live link costs more.
+ * Compared on a normalized copy, because a linkifier resolves hostnames under
+ * UTS-46: U+3002, U+FF0E and U+FF61 all map to `.`, so `evil。example` is a
+ * hostname to the client and was not to an ASCII-only check. NFKC alone does
+ * not cover it -- it folds U+FF0E and leaves the other two -- so they are
+ * replaced outright.
+ *
+ * Deliberately blunt. A dotted token with a letter suffix is enough to trip it,
+ * so a legitimate name like "Anna.Marie" is dropped too. Losing a display name
+ * costs recognisability; shipping a live link costs more.
  */
 function looksLinkish(value: string): boolean {
-  return /:\/\/|\bwww\./i.test(value) || /[a-z0-9-]+\.[a-z]{2,}/i.test(value);
+  const normalized = value.normalize('NFKC').replace(/[。．｡]/g, '.');
+  return /:\/\/|\bwww\./iu.test(normalized) || /[\p{L}\p{N}-]+\.[\p{L}]{2,}/u.test(normalized);
 }
 
 /**
- * The display form of a NIP-05, or undefined when the stored value is not one.
+ * The display form of a NIP-05, or undefined when we will not vouch for it.
  *
- * A NIP-05 is inherently domain-shaped, so `looksLinkish` cannot be applied to
- * it. Shape validation does the same job from the other direction: anything
- * carrying a scheme, a path, whitespace or another `@` is not a NIP-05 and is
- * not rendered.
+ * Two gates. Shape first: anything carrying a scheme, a path, whitespace or a
+ * second `@` is not a NIP-05.
+ *
+ * Then the issuing domain, which is the gate that matters. A NIP-05 is a bare
+ * hostname by construction, so `looksLinkish` cannot be applied to it -- it
+ * would reject every legitimate value. That leaves the same hole this row was
+ * supposed to be exempt from: `account_nip05` is unverified kind-0 the account
+ * chose, so `_@claim-your-teen-account.example` would render as a clean, highly
+ * linkifiable hostname, mailed under Divine branding to an address the same
+ * account supplied. We can only vouch for domains we issue, so anything else is
+ * dropped.
+ *
+ * Unset `NIP05_DOMAIN` therefore renders no username at all. That is the same
+ * call #222 made for the capture side: staging accounts come from a different
+ * Keycast instance, and no username beats a wrong or unvouched one.
  *
  * NIP-05 calls `_@domain` the "root" identifier and says to display it as the
  * bare domain (nips/05.md, "Showing just the domain as an identifier"). Divine
- * issues `_@<username>.divine.video`, so the prefix is noise to a parent. Any
+ * issues `_@<username>.<NIP05_DOMAIN>`, so the prefix is noise to a parent. Any
  * other local part is a real name and is left intact.
  */
-function displayNip05(nip05: string): string | undefined {
+function displayNip05(nip05: string, issuingDomain?: string): string | undefined {
+  if (!issuingDomain) return undefined;
   if (!/^[a-z0-9._-]+@[a-z0-9-]+(\.[a-z0-9-]+)+$/i.test(nip05)) return undefined;
+
+  const host = nip05.split('@').pop() ?? '';
+  const domain = issuingDomain.toLowerCase();
+  const lowerHost = host.toLowerCase();
+  if (lowerHost !== domain && !lowerHost.endsWith(`.${domain}`)) return undefined;
+
   const display = nip05.startsWith('_@') ? nip05.slice(2) : nip05;
   return display.length > 0 && display.length <= IDENTITY_MAX_LEN ? display : undefined;
 }
@@ -942,11 +1001,19 @@ function displayNip05(nip05: string): string | undefined {
  * whose profile was already hidden by enforcement yields no name and no NIP-05
  * -- but the pubkey is on the case row and always resolves.
  */
-function buildAccountIdentityHtml(identity: AgeReviewCaseIdentity & { pubkey?: string }): string {
+function buildAccountIdentityHtml(
+  identity: AgeReviewCaseIdentity & { pubkey?: string },
+  issuingDomain?: string,
+): string {
   const rows: string[] = [];
 
-  const name = identity.account_name?.trim().slice(0, IDENTITY_MAX_LEN);
-  const nip05 = identity.account_nip05 ? displayNip05(identity.account_nip05.trim()) : undefined;
+  // Cleaned and capped before the link check, never after: the check has to run
+  // on exactly the string that gets rendered, or truncation could cut a URL out
+  // of view of the check while leaving one in the mail.
+  const name = identity.account_name ? cleanIdentityText(identity.account_name) : undefined;
+  const nip05 = identity.account_nip05
+    ? displayNip05(identity.account_nip05.trim(), issuingDomain)
+    : undefined;
 
   if (name && !looksLinkish(name)) rows.push(`Display name: ${escapeHtml(name)}`);
   // The escape here cannot fire: displayNip05's charset already excludes every
@@ -984,8 +1051,9 @@ function buildAccountIdentityHtml(identity: AgeReviewCaseIdentity & { pubkey?: s
  */
 export function buildParentOutreachBody(
   identity: AgeReviewCaseIdentity & { pubkey?: string } = {},
+  issuingDomain?: string,
 ): string {
-  const identityHtml = buildAccountIdentityHtml(identity);
+  const identityHtml = buildAccountIdentityHtml(identity, issuingDomain);
 
   return [
     '<p>Hello,</p>',
@@ -1172,7 +1240,7 @@ async function createAgeReviewTicket(
   if (!env.DB) return;
 
   const subject = `Age review: parental verification needed [${caseId}]`;
-  const outreachBody = buildParentOutreachBody(identity);
+  const outreachBody = buildParentOutreachBody(identity, env.NIP05_DOMAIN);
   const customFields = buildAgeReviewCustomFields(env, deadlineAt);
 
   const res = await fetch(`${zendesk.baseUrl}/tickets`, {
@@ -1287,7 +1355,7 @@ async function updateTicketWithParentContact(
   const zendesk = await getZendeskClientConfig(env);
   if (!zendesk) return;
 
-  const outreachBody = buildParentOutreachBody(identity);
+  const outreachBody = buildParentOutreachBody(identity, env.NIP05_DOMAIN);
 
   const res = await fetch(`${zendesk.baseUrl}/tickets/${ticketId}`, {
     method: 'PUT',

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -881,22 +881,57 @@ function escapeHtml(value: string): string {
     .replace(/'/g, '&#39;');
 }
 
+/** Matches the same 80 characters `sanitizeInline` allows a rendered handle. */
+const IDENTITY_MAX_LEN = 80;
+
 /**
+ * True when a display name is trying to look like a link.
+ *
+ * Escaping stops markup, not linkification: mail clients auto-link bare URLs in
+ * text, and `report-note.ts` wraps these same values in a code span for exactly
+ * this reason. That defence does not carry over here, because this render goes
+ * out as mail rather than into an agent-facing note.
+ *
+ * The threat is specific. The account under review picks its own kind-0 display
+ * name AND supplies the address this mail is sent to, so a name of
+ * "verify at http://not-divine.example/claim" would have Divine Trust & Safety
+ * deliver an attacker's link, under Divine's branding, to an address the
+ * attacker chose. Dropping the row is the safe failure: the parent still gets
+ * the username and the ID.
+ *
+ * Deliberately blunt. A dotted token with an alphabetic suffix is enough to
+ * trip it, so a legitimate name like "Anna.Marie" is dropped too. Losing a
+ * display name costs recognisability; shipping a live link costs more.
+ */
+function looksLinkish(value: string): boolean {
+  return /:\/\/|\bwww\./i.test(value) || /[a-z0-9-]+\.[a-z]{2,}/i.test(value);
+}
+
+/**
+ * The display form of a NIP-05, or undefined when the stored value is not one.
+ *
+ * A NIP-05 is inherently domain-shaped, so `looksLinkish` cannot be applied to
+ * it. Shape validation does the same job from the other direction: anything
+ * carrying a scheme, a path, whitespace or another `@` is not a NIP-05 and is
+ * not rendered.
+ *
  * NIP-05 calls `_@domain` the "root" identifier and says to display it as the
  * bare domain (nips/05.md, "Showing just the domain as an identifier"). Divine
  * issues `_@<username>.divine.video`, so the prefix is noise to a parent. Any
- * other local part is a real name and is left alone.
+ * other local part is a real name and is left intact.
  */
-function displayNip05(nip05: string): string {
-  return nip05.startsWith('_@') ? nip05.slice(2) : nip05;
+function displayNip05(nip05: string): string | undefined {
+  if (!/^[a-z0-9._-]+@[a-z0-9-]+(\.[a-z0-9-]+)+$/i.test(nip05)) return undefined;
+  const display = nip05.startsWith('_@') ? nip05.slice(2) : nip05;
+  return display.length > 0 && display.length <= IDENTITY_MAX_LEN ? display : undefined;
 }
 
 /**
  * Tells the parent which account this is about.
  *
  * A narrower set than agents get: the contact-notes block also carries the case
- * deeplink and band, and qualifies the handle as claimed and unverified. A
- * parent needs only enough to recognise their child's account.
+ * deeplink, the band, and the claimed-and-unverified qualifier. A parent needs
+ * only enough to recognise their child's account.
  *
  * Every row is conditional except the npub. Capture is best effort -- an account
  * whose profile was already hidden by enforcement yields no name and no NIP-05
@@ -904,11 +939,12 @@ function displayNip05(nip05: string): string {
  */
 function buildAccountIdentityHtml(identity: AgeReviewCaseIdentity & { pubkey?: string }): string {
   const rows: string[] = [];
-  const name = identity.account_name?.trim();
-  const nip05 = identity.account_nip05?.trim();
 
-  if (name) rows.push(`Display name: ${escapeHtml(name)}`);
-  if (nip05) rows.push(`Username: ${escapeHtml(displayNip05(nip05))}`);
+  const name = identity.account_name?.trim().slice(0, IDENTITY_MAX_LEN);
+  const nip05 = identity.account_nip05 ? displayNip05(identity.account_nip05.trim()) : undefined;
+
+  if (name && !looksLinkish(name)) rows.push(`Display name: ${escapeHtml(name)}`);
+  if (nip05) rows.push(`Username: ${escapeHtml(nip05)}`);
   if (identity.pubkey) rows.push(`ID: ${escapeHtml(toNpub(identity.pubkey))}`);
   if (rows.length === 0) return '';
 

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -897,6 +897,7 @@ export function buildParentOutreachBody(): string {
     '<ul>',
     '  <li>the teen</li>',
     '  <li>a parent or guardian speaking on camera</li>',
+    '  <li>that the teen is between 13 and 15</li>',
     '  <li>that the teen has permission to use Divine</li>',
     '  <li>that the parent or guardian knows about the account and will supervise its use</li>',
     '  <li>the country or countries where you live</li>',

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -898,18 +898,14 @@ const IDENTITY_MAX_LEN = 80;
  * parent as if it were whole.
  */
 function cleanIdentityText(value: string): string {
-  // Control characters and the zero-width / format range, tested by code point
-  // rather than a regex: this repo sets noInlineConfig, so a control-character
-  // class cannot be exempted from no-control-regex inline. report-note.ts walks
-  // the string the same way.
+  // Control characters, invisible/format characters, and unpaired surrogates,
+  // tested by Unicode property rather than an enumerated list: the set that can
+  // hide a hostname from `looksLinkish` while a mail client still parses one is
+  // far wider than the well-known zero-width characters, and includes the bidi
+  // controls. Property escapes do not trip no-control-regex, so noInlineConfig
+  // is not a constraint here.
   const stripped = Array.from(value)
-    .filter((ch) => {
-      const c = ch.codePointAt(0) ?? 0;
-      return !(
-        c <= 0x1f || c === 0x7f || c === 0xad ||
-        (c >= 0x200b && c <= 0x200f) || c === 0x2060 || c === 0xfeff
-      );
-    })
+    .filter((ch) => !/[\p{Cc}\p{Cf}\p{Cs}\p{Co}\p{Zl}\p{Zp}\p{Default_Ignorable_Code_Point}]/u.test(ch))
     .join('')
     .trim();
   const points = Array.from(stripped);
@@ -977,7 +973,8 @@ function looksLinkish(value: string): boolean {
  * NIP-05 calls `_@domain` the "root" identifier and says to display it as the
  * bare domain (nips/05.md, "Showing just the domain as an identifier"). Divine
  * issues `_@<username>.<NIP05_DOMAIN>`, so the prefix is noise to a parent. Any
- * other local part is a real name and is left intact.
+ * other local part is left intact unless it is itself hostname-shaped: the host
+ * gate does not see the local part, so a `looksLinkish` one is dropped below.
  */
 function displayNip05(nip05: string, issuingDomain?: string): string | undefined {
   if (!issuingDomain) return undefined;
@@ -987,6 +984,14 @@ function displayNip05(nip05: string, issuingDomain?: string): string | undefined
   const domain = issuingDomain.toLowerCase();
   const lowerHost = host.toLowerCase();
   if (lowerHost !== domain && !lowerHost.endsWith(`.${domain}`)) return undefined;
+
+  // The gate above constrains only the host. The local part is attacker-chosen
+  // kind-0 and NIP-05 permits `.` there, so it can be hostname-shaped
+  // (`www.evil.example@divine.video`) even when the host is ours. Drop it for the
+  // same reason looksLinkish drops a display name: a mail client may parse a link
+  // out of text delivered under Divine branding. The root form `_@…` and a plain
+  // local part like `alice` survive; only a dotted, hostname-shaped one is refused.
+  if (looksLinkish(nip05.split('@')[0] ?? '')) return undefined;
 
   const display = nip05.startsWith('_@') ? nip05.slice(2) : nip05;
   return display.length > 0 && display.length <= IDENTITY_MAX_LEN ? display : undefined;

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -945,7 +945,14 @@ function cleanIdentityText(value: string): string {
  */
 function looksLinkish(value: string): boolean {
   const normalized = value.normalize('NFKC').replace(/[。．｡]/g, '.');
-  return /:\/\/|\bwww\./iu.test(normalized) || /[\p{L}\p{N}-]+\.[\p{L}]{2,}/u.test(normalized);
+  return (
+    /:\/\/|\bwww\./iu.test(normalized) ||
+    /[\p{L}\p{N}-]+\.[\p{L}]{2,}/u.test(normalized) ||
+    // A bare IPv4 host has no letters after the final dot, so the rule above
+    // does not see it. Narrower than widening that suffix class, which would
+    // also drop ordinary names containing a decimal.
+    /\b\d{1,3}(\.\d{1,3}){3}\b/.test(normalized)
+  );
 }
 
 /**

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -907,7 +907,8 @@ export function buildParentOutreachBody(): string {
     '<p><strong>Please do NOT send government IDs, payment details, school or medical records, ' +
       'or passwords.</strong> We only need the short video.</p>',
     '',
-    '<p>Please reply within 15 days. If we do not hear from you, your child&#39;s account will be deleted.</p>',
+    `<p>Please reply within ${DEADLINE_DAYS} days. If we do not hear from you, ` +
+      'your child&#39;s account will be deleted.</p>',
     '',
     '<p>If you are the account holder and you are 16 or older, reply and tell us that. ' +
       'No video needed, and we will take another look.</p>',

--- a/worker/src/relay-profile.ts
+++ b/worker/src/relay-profile.ts
@@ -174,9 +174,12 @@ export async function fetchAccountIdentity(
     if (res?.events?.length) {
       return {
         completed: true,
-        // Raw: this is persisted, and both surfaces that render it
-        // (buildAgeReviewIdentityBlock, buildClaimedParentName) sanitize on the
-        // way out. Sanitizing here instead would store a mangled handle.
+        // Raw: this is persisted, and every surface that renders it sanitizes
+        // on the way out for its own medium -- buildAgeReviewIdentityBlock and
+        // buildClaimedParentName for the agent-facing note, and
+        // buildAccountIdentityHtml for the parent outreach mail, which also has
+        // to defend against linkification. Sanitizing here instead would store
+        // a mangled handle. Any new render surface owns its own escaping.
         profile: parseKind0Profile(
           res.events[0] as { content?: string; tags?: string[][] },
           { raw: true },

--- a/worker/src/report-note.ts
+++ b/worker/src/report-note.ts
@@ -80,7 +80,7 @@ function sanitizeInline(value: string | undefined, maxLen = 80): string | undefi
  * truncation, but "unsanitized" must not mean "unbounded": kind-0 content is
  * chosen by the account under review, and the captured values are bound
  * straight into the INSERT that opens the case. Far beyond any real handle, so
- * nothing legitimate is touched; the render path applies its own 80-char cap.
+ * nothing legitimate is touched; each render path applies its own 80-char cap.
  */
 const CAPTURED_VALUE_MAX_LEN = 512;
 

--- a/worker/src/report-note.ts
+++ b/worker/src/report-note.ts
@@ -157,7 +157,7 @@ export function parseKind0Profile(
   };
 }
 
-function toNpub(hex: string): string {
+export function toNpub(hex: string): string {
   try {
     return nip19.npubEncode(hex);
   } catch {


### PR DESCRIPTION
## Summary

- The first message a parent receives now leads with the verification video and its requirements, instead of asking them to confirm they are the parent.
- It names the account under review, so a parent knows which account this concerns.
- Sent as HTML, so the do-not-send warning reads as a warning and the family and kids pages are links.
- One template serves both age bands this path reaches; the age-band label is gone.

## Motivation

The opening message asked a parent only to confirm they were the parent. Parents replied "yes", which establishes nothing, and the real requirements arrived a round trip later. Anyone who is not the parent cannot produce the video regardless, so the confirmation step bought nothing and cost a step. Copy is signed off by the Trust & Safety leads, including the legal-permission qualifier, the emphasis on what not to send, and the family-resources framing.

Two things fell out of writing it down:

- The age-band label rendered as "may belong to a minor in the 16+ (claimed) age range" for the band where nobody is claiming the holder is a minor. One template with no label is correct for both.
- The video list omitted "a clear statement that the teen is between 13 and 15", which both divine.video/kids and divine.video/age-review require. A parent following the email exactly produced a video missing a required element, costing the round trip this change exists to remove.

## This reverses a decision from #222 - please look here first

#222 established that this pre-reply message stays handle-free: the address is supplied by the account under review and is unverified until someone replies from it, so naming the account discloses a minor's handle to whoever holds a mistyped address.

This names the account anyway. The tradeoff was weighed and taken: a parent cannot act on a review without knowing which account it concerns, and the earlier approach of asking them to supply an identifier produced display names that identify nothing.

The residual risk is real and unchanged. The reversal is scoped as narrowly as it can be:

- The Zendesk requester name stays address-only, so no handle reaches the To: header of outbound mail.
- The "Claimed parent of &lt;handle&gt;" rename still waits for a reply.
- Agents keep the fuller block - case deeplink, band, claimed-and-unverified qualifier.

Only the message body changed. Two of #222's assertions flipped to match, deliberately and visibly rather than quietly.

## Hardening that came out of review

Naming the account puts attacker-chosen text into outbound mail, and the same account also chooses the recipient. Escaping stops markup but not mail-client auto-linking, so:

- A display name that looks like a link is dropped rather than rendered. Otherwise a name of "verify at http://not-divine.example/claim" would have Divine Trust & Safety deliver an attacker's link, under Divine branding, to an address the attacker picked.
- The username renders only on a domain we issue, read from `NIP05_DOMAIN`. A NIP-05 is a bare hostname by construction, so it cannot be screened the same way. Unset means no username row, matching the call #222 made for capture - staging has no identity domain of its own.
- Unicode dot equivalents, zero-width characters and control characters are normalized or stripped before the check, so a hostname cannot hide from us while remaining legible to the mail client.
- Truncation is by code point at 80 with an ellipsis, so an emoji is never cut into a lone surrogate.

## Validation

| Check | Result |
|---|---|
| `cd worker && npx vitest run` | 533 passed |
| `cd worker && npm run test:d1` | 26 passed |
| `cd worker && npm run typecheck` | clean |
| `npx tsc -p tsconfig.app.json --noEmit` | clean |
| `npx eslint` | clean |
| root `npx vitest run` | 609 passed, 1 skipped |

HTML delivery was verified against the live Zendesk instance, not inferred from settings: a throwaway ticket confirmed bullets render as a list, the warning renders bold, and both links are live anchors. Ticket and its throwaway end user were deleted afterwards. The script that does it is in `divine-zendesk-tooling`.

Every guard here is mutation-tested - each was removed and the test confirmed to go red. Two rounds of that found tests of mine that passed for the wrong reason; both are fixed and the reasoning is recorded where it happened.

## Out of scope

The email says "reply within 15 days". The clock's actual behaviour on pause and resume is being handled separately and is not touched here.
