### PR TITLE
fix(auth): accept canonical host for mobile pre-auth

### DIFF
--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1364,13 +1364,12 @@ describe('mobile NIP-98 endpoint host allowlist (#173)', () => {
   });
 });
 
-describe('zendesk pre-auth NIP-98 scope boundary (#173)', () => {
+describe('zendesk pre-auth canonical public host', () => {
   const OWN_HOST_PREAUTH_URL = 'https://api-relay-prod.divine.video/api/zendesk/pre-auth';
   const PUBLIC_HOST_PREAUTH_URL = 'https://api.divine.video/api/zendesk/pre-auth';
 
-  // Tolerates ensureSchemaOnce's DDL (db.ts: a sequence of `.prepare(sql).run()`
-  // calls, no `.bind()`/`.first()` needed for schema setup) as async no-ops. The
-  // pre-auth nonce INSERT is never reached in this test — auth fails first.
+  // Tolerates ensureSchemaOnce's DDL and the pre-auth nonce INSERT as async
+  // no-ops; the response proves canonical-host auth reached token issuance.
   function makeZendeskDb() {
     const statement = (): { bind: () => unknown; run: () => Promise<{ success: boolean }>; first: () => Promise<null> } => ({
       bind: () => statement(),
@@ -1380,24 +1379,26 @@ describe('zendesk pre-auth NIP-98 scope boundary (#173)', () => {
     return { prepare: statement };
   }
 
-  // Proves the Zendesk pre-auth route stays same-host-only even with the mobile
-  // allowlist configured (Global Constraint 4: Zendesk is out of #173's scope).
-  it('rejects a public-host-signed request even when the mobile allowlist is configured (scope boundary)', async () => {
+  function preAuthRequest(signedUrl: string): Request {
     const sk = generateSecretKey();
     const evt = finalizeEvent(
       {
         kind: 27235,
         content: '',
-        tags: [['u', PUBLIC_HOST_PREAUTH_URL], ['method', 'POST']],
+        tags: [['u', signedUrl], ['method', 'POST']],
         created_at: Math.floor(Date.now() / 1000),
       },
       sk,
     );
+    return new Request(OWN_HOST_PREAUTH_URL, {
+      method: 'POST',
+      headers: { Authorization: 'Nostr ' + btoa(JSON.stringify(evt)) },
+    });
+  }
+
+  it('accepts a public-host-signed request when the host is allowlisted', async () => {
     const res = await worker.fetch(
-      new Request(OWN_HOST_PREAUTH_URL, {
-        method: 'POST',
-        headers: { Authorization: 'Nostr ' + btoa(JSON.stringify(evt)) },
-      }),
+      preAuthRequest(PUBLIC_HOST_PREAUTH_URL),
       {
         ZENDESK_PREAUTH_SECRET: 'test-secret',
         DB: makeZendeskDb(),
@@ -1405,7 +1406,37 @@ describe('zendesk pre-auth NIP-98 scope boundary (#173)', () => {
       } as never,
       ctx,
     );
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      success: true,
+      token: expect.any(String),
+    });
+  });
+
+  it('rejects a public-host-signed request when the host is not allowlisted', async () => {
+    const res = await worker.fetch(
+      preAuthRequest(PUBLIC_HOST_PREAUTH_URL),
+      {
+        ZENDESK_PREAUTH_SECRET: 'test-secret',
+        DB: makeZendeskDb(),
+      } as never,
+      ctx,
+    );
+
     expect(res.status).toBe(401);
+  });
+
+  it('keeps accepting an own-host-signed request without an allowlist', async () => {
+    const res = await worker.fetch(
+      preAuthRequest(OWN_HOST_PREAUTH_URL),
+      {
+        ZENDESK_PREAUTH_SECRET: 'test-secret',
+        DB: makeZendeskDb(),
+      } as never,
+      ctx,
+    );
+
+    expect(res.status).toBe(200);
   });
 });
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2215,9 +2215,9 @@ interface Nip98Result {
 // Returns true iff `signedUrl` matches `expectedUrl` in scheme + path + query,
 // and its hostname is in `allowedHosts` (bare hostnames). Port and fragment are
 // intentionally not compared — this is a bare-hostname allowlist by design;
-// tightening to port would mean comparing `.host` instead of `.hostname`. Used
-// only by mobile-facing endpoints; strict callers pass an empty
-// allowlist, so this can never return true for them. Malformed URLs → false.
+// tightening to port would mean comparing `.host` instead of `.hostname`.
+// Passing an empty allowlist keeps this helper strict: it can never return true
+// for a different host. Malformed URLs → false.
 function hostAllowlistedUrlMatch(signedUrl: string, expectedUrl: string, allowedHosts: string[]): boolean {
   if (allowedHosts.length === 0) return false;
   try {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -52,7 +52,7 @@ interface Env extends KeycastEnv {
   RELAY_URL: string;
   ALLOWED_ORIGINS: string;
   // Comma-separated public hostnames whose NIP-98 `u`-tag host is accepted in
-  // addition to the worker's own request host, for the two mobile endpoints only
+  // addition to the worker's own request host, for mobile-facing endpoints only
   // (divine-relay-manager#173). Non-secret. Empty/unset ⇒ strict same-host.
   NIP98_PUBLIC_HOST_ALLOWLIST?: string;
   ANTHROPIC_API_KEY?: string;
@@ -2216,7 +2216,7 @@ interface Nip98Result {
 // and its hostname is in `allowedHosts` (bare hostnames). Port and fragment are
 // intentionally not compared — this is a bare-hostname allowlist by design;
 // tightening to port would mean comparing `.host` instead of `.hostname`. Used
-// only by the two mobile endpoints (#173); strict callers pass an empty
+// only by mobile-facing endpoints; strict callers pass an empty
 // allowlist, so this can never return true for them. Malformed URLs → false.
 function hostAllowlistedUrlMatch(signedUrl: string, expectedUrl: string, allowedHosts: string[]): boolean {
   if (allowedHosts.length === 0) return false;
@@ -2808,9 +2808,14 @@ async function handleZendeskPreAuth(
     // Ensure nonce table exists
     await ensureSchemaOnce(env.DB);
 
-    // Verify NIP-98 auth. Intentionally strict: no allowedHosts passed, so this
-    // Zendesk pre-auth path stays same-host only (#173 scope — do not relax).
-    const authResult = await verifyNip98Auth(request, request.url);
+    // Mobile signs the canonical public API URL while the edge forwards to the
+    // worker host. Relax only the host via the configured allowlist; scheme,
+    // path, query, method, timestamp, and event signature remain exact.
+    const authResult = await verifyNip98Auth(
+      request,
+      request.url,
+      getNip98AllowedHosts(env),
+    );
     if (!authResult.valid) {
       return jsonResponse(
         { success: false, error: `NIP-98 auth required: ${authResult.error}` },

--- a/worker/src/nip98-auth.test.ts
+++ b/worker/src/nip98-auth.test.ts
@@ -83,13 +83,14 @@ describe('verifyNip98Auth host allowlist', () => {
     expect(res.valid).toBe(false);
   });
 
-  it('SCOPE BOUNDARY: a Zendesk-style call (no allowedHosts) rejects the public host', async () => {
-    // Mirrors the Zendesk pre-auth call site (index.ts:2442), which passes NO third arg.
+  it('default empty allowlist rejects the public host', async () => {
+    // Omitting the third arg keeps verifyNip98Auth strict unless a caller opts
+    // into host relaxation with an explicit allowlist.
     const evt = signEvent({ u: PUBLIC, method: 'GET' });
     const res = await verifyNip98Auth(reqAtOwnHost(toHeader(evt)), OWN);
     expect(res.valid).toBe(false);
     // Mutation check: temporarily pass [PUBLIC_HOST] as the 3rd arg here and this
-    // assertion flips to valid — proving the test detects the scope boundary.
+    // assertion flips to valid, proving the default behavior stays strict.
   });
 
   it('empty/unset allowlist ⇒ own host still valid, public host rejected', async () => {

--- a/worker/wrangler.prod.toml
+++ b/worker/wrangler.prod.toml
@@ -92,7 +92,7 @@ MODERATION_ADMIN_URL = "https://moderation-api.divine.video"
 # Allow admin UI plus the managed web app and its preview deployments
 ALLOWED_ORIGINS = "https://relay.admin.divine.video,https://app.divine.video,https://*.openvine-app.pages.dev,*.divine-relay-manager.pages.dev,*.divine-relay-admin.pages.dev"
 # Public hostname(s) whose NIP-98 u-tag host is accepted in addition to this
-# worker's own host, for the two mobile endpoints only (divine-relay-manager#173).
+# worker's own host, for mobile-facing endpoints only (divine-relay-manager#173).
 # Comma-separated bare hostnames, no wildcards. Empty/unset = strict same-host.
 NIP98_PUBLIC_HOST_ALLOWLIST = "api.divine.video"
 # CDN domain for media proxy (Blossom admin bypass for blocked content preview)

--- a/worker/wrangler.staging.toml
+++ b/worker/wrangler.staging.toml
@@ -91,7 +91,7 @@ MODERATION_ADMIN_URL = "https://moderation-api.divine.video"
 # Allow admin UI plus the managed web app and its preview deployments
 ALLOWED_ORIGINS = "https://relay.admin.divine.video,https://app.divine.video,https://*.openvine-app.pages.dev,*.divine-relay-manager.pages.dev,*.divine-relay-admin.pages.dev"
 # Public hostname(s) whose NIP-98 u-tag host is accepted in addition to this
-# worker's own host, for the two mobile endpoints only (divine-relay-manager#173).
+# worker's own host, for mobile-facing endpoints only (divine-relay-manager#173).
 # TO CONFIRM before deploy: the staging public-host equivalent of api.divine.video
 # is not yet known — do NOT guess. Leave empty until the Half-1 proxy owner confirms it.
 NIP98_PUBLIC_HOST_ALLOWLIST = ""


### PR DESCRIPTION
## Summary

- accept the configured canonical public host for the mobile support pre-auth request
- retain exact NIP-98 scheme, path, query, method, timestamp, and signature validation
- preserve direct-worker compatibility and strict rejection when no host is allowlisted

## Motivation

Mobile should sign and call the canonical public API rather than depend on an internal service hostname. The two minor-review endpoints already support this host-relaxation contract; this completes the same contract for the remaining mobile-facing pre-auth call.

Related to #173. This change is backward-compatible and inert until the canonical edge route is deployed.

## Validation

- npm run test:run (542 passed)
- npm run typecheck
- git diff --check