### PR TITLE
Standalone admin media viewer for restricted content, linked from Coop

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -475,11 +475,25 @@ export default {
       // authenticated moderator reaches it. Serves a minimal self-contained page,
       // NOT the relay-manager SPA, and streams the blob via /api/media-proxy.
       if (path.startsWith('/media/') && request.method === 'GET') {
-        const raw = path.slice('/media/'.length).replace(/\.[^./]+$/, '').toLowerCase();
-        const valid = /^[a-f0-9]{64}$/.test(raw);
-        return new Response(renderMediaPage(raw), {
-          status: valid ? 200 : 400,
-          headers: { 'content-type': 'text/html; charset=utf-8', ...corsHeaders },
+        const raw = path.slice('/media/'.length).replace(/\.[^./]+$/, '');
+        const { status, html } = renderMediaPage(raw);
+        return new Response(html, {
+          status,
+          headers: {
+            ...corsHeaders,
+            'content-type': 'text/html; charset=utf-8',
+            // The URL and body name a content hash (potentially CSAM); keep it off disk.
+            'cache-control': 'no-store',
+            // Locks the page to exactly what it needs: same-origin fetch to the proxy,
+            // its own inline script/style, blob: media. Also makes the inline-script
+            // dependency explicit rather than resting on no CSP ever being added here.
+            'content-security-policy':
+              "default-src 'none'; script-src 'unsafe-inline'; connect-src 'self'; " +
+              "img-src blob:; media-src blob:; style-src 'unsafe-inline'; " +
+              "frame-ancestors 'none'; base-uri 'none'",
+            'x-content-type-options': 'nosniff',
+            'referrer-policy': 'no-referrer',
+          },
         });
       }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -475,8 +475,14 @@ export default {
       // authenticated moderator reaches it. Serves a minimal self-contained page,
       // NOT the relay-manager SPA, and streams the blob via /api/media-proxy.
       if (path.startsWith('/media/') && request.method === 'GET') {
-        const raw = path.slice('/media/'.length).replace(/\.[^./]+$/, '');
-        const { status, html } = renderMediaPage(raw);
+        // Keep the (optional) extension as a type hint: the page branches on the
+        // proxy's Content-Type, and falls back to this when that type is
+        // unhelpful (e.g. application/octet-stream), mirroring how the SPA's
+        // MediaPreview treats the URL as a signal alongside the MIME type.
+        const rest = path.slice('/media/'.length);
+        const extMatch = rest.match(/\.([^.\/]+)$/);
+        const raw = extMatch ? rest.slice(0, extMatch.index) : rest;
+        const { status, html } = renderMediaPage(raw, extMatch?.[1]);
         return new Response(html, {
           status,
           headers: {
@@ -2573,6 +2579,14 @@ async function handleMediaProxy(
       // a Blob URL, so nothing re-reads the HTTP cache anyway.
       'Cache-Control': 'private, no-store',
       'X-Admin-Proxy': 'blossom-admin',
+      // The upstream Content-Type is stored as-uploaded and is not validated, so
+      // a text/html blob navigated to directly would run script on this origin,
+      // which holds the moderator's CF Access session. nosniff alone does not
+      // stop a declared text/html from rendering; sandbox neutralizes it (unique
+      // origin, no script). Blob-fetch consumers are unaffected: a CSP response
+      // header applies to document loads, not to fetch()-into-Blob pipelines.
+      'X-Content-Type-Options': 'nosniff',
+      'Content-Security-Policy': 'sandbox',
     };
 
     // Pass through relevant headers from upstream

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2567,7 +2567,11 @@ async function handleMediaProxy(
     // Stream response body through without buffering
     const responseHeaders: Record<string, string> = {
       ...corsHeaders,
-      'Cache-Control': 'private, no-cache',
+      // no-store, not no-cache: these bytes can be CSAM, and no-cache still lets
+      // the browser write them to its HTTP disk cache (revalidated on reuse).
+      // Both consumers (SPA MediaPreview and the /media/ viewer) fetch once into
+      // a Blob URL, so nothing re-reads the HTTP cache anyway.
+      'Cache-Control': 'private, no-store',
       'X-Admin-Proxy': 'blossom-admin',
     };
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -480,7 +480,7 @@ export default {
         // unhelpful (e.g. application/octet-stream), mirroring how the SPA's
         // MediaPreview treats the URL as a signal alongside the MIME type.
         const rest = path.slice('/media/'.length);
-        const extMatch = rest.match(/\.([^.\/]+)$/);
+        const extMatch = rest.match(/\.([^./]+)$/);
         const raw = extMatch ? rest.slice(0, extMatch.index) : rest;
         const { status, html } = renderMediaPage(raw, extMatch?.[1]);
         return new Response(html, {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -12,6 +12,7 @@ import { ensureSchema } from './db';
 import { buildReportsFilter } from './reports-filter';
 import { generatePreAuthToken, verifyPreAuthToken, base64UrlEncode } from './zendesk-preauth';
 import { deriveFunnelcakeApiUrl, proxyFunnelcakeRequest } from './funnelcake-proxy';
+import { renderMediaPage } from './media-page';
 import type { KeycastEnv } from './keycast-client';
 import { suspendUser, unsuspendUser, banUser } from './keycast-client';
 import {
@@ -467,6 +468,19 @@ export default {
       });
       if (adminAuthError) {
         return jsonResponse({ success: false, error: adminAuthError }, 401, corsHeaders);
+      }
+
+      // Standalone media viewer, linked from a Coop review card. Behind the same
+      // CF Access + verifyAdminAccess gate as everything above, so only an
+      // authenticated moderator reaches it. Serves a minimal self-contained page,
+      // NOT the relay-manager SPA, and streams the blob via /api/media-proxy.
+      if (path.startsWith('/media/') && request.method === 'GET') {
+        const raw = path.slice('/media/'.length).replace(/\.[^./]+$/, '').toLowerCase();
+        const valid = /^[a-f0-9]{64}$/.test(raw);
+        return new Response(renderMediaPage(raw), {
+          status: valid ? 200 : 400,
+          headers: { 'content-type': 'text/html; charset=utf-8', ...corsHeaders },
+        });
       }
 
       // Moderator-facing account status (surfaces keycast verified_minor for the age-review view).

--- a/worker/src/media-page.test.ts
+++ b/worker/src/media-page.test.ts
@@ -4,23 +4,24 @@ import { renderMediaPage } from './media-page';
 const VALID = 'a'.repeat(64);
 
 describe('renderMediaPage', () => {
-  it('embeds the media-proxy URL for the given sha', () => {
-    const html = renderMediaPage(VALID);
+  it('embeds the media-proxy URL for the given sha and returns 200', () => {
+    const { status, html } = renderMediaPage(VALID);
+    expect(status).toBe(200);
     expect(html).toContain(`/api/media-proxy/${VALID}`);
   });
 
   it('shows the sha so a moderator can confirm which blob they are viewing', () => {
-    expect(renderMediaPage(VALID)).toContain(VALID);
+    expect(renderMediaPage(VALID).html).toContain(VALID);
   });
 
   it('carries the restricted admin-view banner', () => {
-    const html = renderMediaPage(VALID).toLowerCase();
+    const html = renderMediaPage(VALID).html.toLowerCase();
     expect(html).toContain('restricted');
     expect(html).toContain('admin');
   });
 
   it('is a self-contained document, not an SPA shell (no app bundle, no tab nav)', () => {
-    const html = renderMediaPage(VALID);
+    const { html } = renderMediaPage(VALID);
     expect(html).toMatch(/^<!doctype html>/i);
     // The whole point is to NOT drop the moderator into relay-manager's nav.
     expect(html).not.toContain('/reports');
@@ -28,16 +29,24 @@ describe('renderMediaPage', () => {
     expect(html).not.toMatch(/<script[^>]+src=/i); // no external app bundle
   });
 
-  it('refuses a non-hex sha and never reflects it into the page (no XSS)', () => {
+  it('refuses a non-hex sha with 400 and never reflects it into the page (no XSS)', () => {
     const evil = '"><script>alert(1)</script>';
-    const html = renderMediaPage(evil);
+    const { status, html } = renderMediaPage(evil);
+    expect(status).toBe(400);
     expect(html).not.toContain('<script>alert(1)</script>');
     expect(html).not.toContain(evil);
     expect(html.toLowerCase()).toContain('invalid');
   });
 
-  it('accepts uppercase hex (relay ids and hashes are case-insensitive)', () => {
-    const upper = 'A'.repeat(64);
-    expect(renderMediaPage(upper)).toContain(`/api/media-proxy/${upper}`);
+  it('refuses an empty id with 400', () => {
+    expect(renderMediaPage('').status).toBe(400);
+  });
+
+  it('normalises uppercase hex to lowercase (the form the proxy and Blossom expect)', () => {
+    // relay ids and hashes are case-insensitive; the canonical on-wire form is lowercase.
+    const { status, html } = renderMediaPage('A'.repeat(64));
+    expect(status).toBe(200);
+    expect(html).toContain(`/api/media-proxy/${'a'.repeat(64)}`);
+    expect(html).not.toContain('A'.repeat(64));
   });
 });

--- a/worker/src/media-page.test.ts
+++ b/worker/src/media-page.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { renderMediaPage } from './media-page';
+
+const VALID = 'a'.repeat(64);
+
+describe('renderMediaPage', () => {
+  it('embeds the media-proxy URL for the given sha', () => {
+    const html = renderMediaPage(VALID);
+    expect(html).toContain(`/api/media-proxy/${VALID}`);
+  });
+
+  it('shows the sha so a moderator can confirm which blob they are viewing', () => {
+    expect(renderMediaPage(VALID)).toContain(VALID);
+  });
+
+  it('carries the restricted admin-view banner', () => {
+    const html = renderMediaPage(VALID).toLowerCase();
+    expect(html).toContain('restricted');
+    expect(html).toContain('admin');
+  });
+
+  it('is a self-contained document, not an SPA shell (no app bundle, no tab nav)', () => {
+    const html = renderMediaPage(VALID);
+    expect(html).toMatch(/^<!doctype html>/i);
+    // The whole point is to NOT drop the moderator into relay-manager's nav.
+    expect(html).not.toContain('/reports');
+    expect(html).not.toContain('/age-review');
+    expect(html).not.toMatch(/<script[^>]+src=/i); // no external app bundle
+  });
+
+  it('refuses a non-hex sha and never reflects it into the page (no XSS)', () => {
+    const evil = '"><script>alert(1)</script>';
+    const html = renderMediaPage(evil);
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).not.toContain(evil);
+    expect(html.toLowerCase()).toContain('invalid');
+  });
+
+  it('accepts uppercase hex (relay ids and hashes are case-insensitive)', () => {
+    const upper = 'A'.repeat(64);
+    expect(renderMediaPage(upper)).toContain(`/api/media-proxy/${upper}`);
+  });
+});

--- a/worker/src/media-page.test.ts
+++ b/worker/src/media-page.test.ts
@@ -38,6 +38,16 @@ describe('renderMediaPage', () => {
     expect(html).toContain('Unsupported type (');
   });
 
+  it('suppresses the video controls\' download, PiP, and Cast affordances', () => {
+    // The browser\'s default video chrome offers a download menu item and a Cast
+    // target; the page\'s own rule is that these bytes are never offered as a
+    // download and stay off external displays.
+    const { html } = renderMediaPage(VALID);
+    expect(html).toContain("controlsList', 'nodownload'");
+    expect(html).toContain('disablePictureInPicture');
+    expect(html).toContain('disableRemotePlayback');
+  });
+
   it('refuses a non-hex sha with 400 and never reflects it into the page (no XSS)', () => {
     const evil = '"><script>alert(1)</script>';
     const { status, html } = renderMediaPage(evil);
@@ -57,5 +67,17 @@ describe('renderMediaPage', () => {
     expect(status).toBe(200);
     expect(html).toContain(`/api/media-proxy/${'a'.repeat(64)}`);
     expect(html).not.toContain('A'.repeat(64));
+  });
+
+  it('embeds the URL extension as a fallback type hint when given one', () => {
+    // Used only when the proxy Content-Type is not image/* or video/*, so an
+    // octet-stream blob whose URL says .mp4 still renders instead of showing
+    // "Unsupported type" for viewable media.
+    const { html } = renderMediaPage(VALID, 'mp4');
+    expect(html).toContain('var ext = "mp4"');
+  });
+
+  it('embeds an empty hint when the URL has no extension', () => {
+    expect(renderMediaPage(VALID).html).toContain('var ext = ""');
   });
 });

--- a/worker/src/media-page.test.ts
+++ b/worker/src/media-page.test.ts
@@ -29,6 +29,15 @@ describe('renderMediaPage', () => {
     expect(html).not.toMatch(/<script[^>]+src=/i); // no external app bundle
   });
 
+  it('does not offer a download for unknown blob types; sends the moderator back to Coop', () => {
+    // Writing unknown bytes to the moderator's disk is a CSAM footgun (one-way,
+    // NCMEC-bound). The unknown-type branch must show the type, not download it.
+    const { html } = renderMediaPage(VALID);
+    expect(html).not.toMatch(/\.download\s*=/);
+    expect(html).not.toMatch(/createElement\(['"]a['"]\)/);
+    expect(html).toContain('Unsupported type (');
+  });
+
   it('refuses a non-hex sha with 400 and never reflects it into the page (no XSS)', () => {
     const evil = '"><script>alert(1)</script>';
     const { status, html } = renderMediaPage(evil);

--- a/worker/src/media-page.test.ts
+++ b/worker/src/media-page.test.ts
@@ -80,4 +80,31 @@ describe('renderMediaPage', () => {
   it('embeds an empty hint when the URL has no extension', () => {
     expect(renderMediaPage(VALID).html).toContain('var ext = ""');
   });
+
+  it('drops an extension hint that is not a short alphanumeric token', () => {
+    // The hint is interpolated into the document, and JSON.stringify does not
+    // escape "<" or "/", so anything that could close the script element (or is
+    // merely garbage) must never be embedded. The URL parser blocks such values
+    // today; this makes the guarantee independent of the caller.
+    const { html } = renderMediaPage(VALID, '</script><script>alert(1)</script>');
+    expect(html).toContain('var ext = ""');
+    expect(html).not.toContain('</script><script>');
+    expect(renderMediaPage(VALID, 'not a token!').html).toContain('var ext = ""');
+  });
+
+  it('lowercases the extension hint before embedding it', () => {
+    expect(renderMediaPage(VALID, 'MP4').html).toContain('var ext = "mp4"');
+  });
+
+  it('builds both video paths through one hardened constructor with decode errors surfaced', () => {
+    // Both the content-type branch and the extension-fallback branch must share
+    // makeVideo, so a future hardening cannot apply to one and not the other.
+    const { html } = renderMediaPage(VALID, 'mp4');
+    expect(html).toContain('function makeVideo(');
+    expect(html).toContain('could not decode the video');
+    expect(html).toContain('could not decode the image');
+    // Exactly one constructor for exactly two video call sites.
+    expect(html.match(/createElement\('video'\)/g)).toEqual(['createElement(\'video\')']);
+    expect(html.match(/= makeVideo\(obj\)/g)?.length).toBe(2);
+  });
 });

--- a/worker/src/media-page.ts
+++ b/worker/src/media-page.ts
@@ -87,10 +87,12 @@ export function renderMediaPage(sha256: string): { status: number; html: string 
     } else if (b.type.indexOf('image') === 0) {
       el = document.createElement('img'); el.src = obj;
     } else {
-      el = document.createElement('a');
-      el.href = obj; el.download = ${JSON.stringify(id)};
-      el.textContent = 'Download (' + (b.type || 'unknown type') + ')';
-      el.style.color = '#8cf';
+      // Never write unknown bytes to the moderator's disk: this may be CSAM, which
+      // is one-way and NCMEC-bound. Show the type and send them back to Coop rather
+      // than offering a download.
+      el = document.createElement('p');
+      el.className = 'status';
+      el.textContent = 'Unsupported type (' + (b.type || 'unknown') + '). Act in Coop.';
     }
     stage.innerHTML = ''; stage.appendChild(el);
   }).catch(function (e) {

--- a/worker/src/media-page.ts
+++ b/worker/src/media-page.ts
@@ -30,13 +30,17 @@ const ERROR_PAGE = [
  * crafted id cannot inject markup (a non-hex value returns the static error page
  * and is never reflected).
  */
-export function renderMediaPage(sha256: string): { status: number; html: string } {
+export function renderMediaPage(sha256: string, extHint?: string): { status: number; html: string } {
   const id = sha256.toLowerCase();
   if (!HEX64.test(id)) {
     return { status: 400, html: ERROR_PAGE };
   }
 
   const proxy = `/api/media-proxy/${id}`;
+  // Optional extension from the /media/<sha>.<ext> URL, used only when the
+  // proxy's Content-Type is not an image/* or video/* (e.g. octet-stream).
+  // Lists mirror the SPA's MediaPreview URL-hint lists.
+  const ext = (extHint || '').toLowerCase();
   const html = `<!doctype html>
 <html lang="en">
 <head>
@@ -60,6 +64,9 @@ export function renderMediaPage(sha256: string): { status: number; html: string 
 <script>
 (function () {
   var url = ${JSON.stringify(proxy)};
+  var ext = ${JSON.stringify(ext)};
+  var VIDEO_EXTS = ${JSON.stringify(['mp4', 'webm', 'mov', 'm4v', 'avi', 'mkv'])};
+  var IMAGE_EXTS = ${JSON.stringify(['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg'])};
   var stage = document.getElementById('stage');
   function fail(message) {
     // Rebuild from the stage so an error still shows even if it is thrown after
@@ -84,7 +91,24 @@ export function renderMediaPage(sha256: string): { status: number; html: string 
     if (b.type.indexOf('video') === 0) {
       el = document.createElement('video');
       el.controls = true; el.src = obj;
+      // The unknown-type branch refuses downloads; keep the video branch from
+      // re-offering one through browser chrome, and keep restricted media off
+      // Cast/external displays and Picture-in-Picture. (Right-click save remains
+      // possible; this narrows the offered paths, it does not close them.)
+      el.setAttribute('controlsList', 'nodownload');
+      el.disablePictureInPicture = true;
+      el.disableRemotePlayback = true;
     } else if (b.type.indexOf('image') === 0) {
+      el = document.createElement('img'); el.src = obj;
+    } else if (ext && VIDEO_EXTS.indexOf(ext) !== -1) {
+      // The proxy stored the blob's type as something unhelpful (octet-stream
+      // and the like); the URL extension says it is still viewable media.
+      el = document.createElement('video');
+      el.controls = true; el.src = obj;
+      el.setAttribute('controlsList', 'nodownload');
+      el.disablePictureInPicture = true;
+      el.disableRemotePlayback = true;
+    } else if (ext && IMAGE_EXTS.indexOf(ext) !== -1) {
       el = document.createElement('img'); el.src = obj;
     } else {
       // Never write unknown bytes to the moderator's disk: this may be CSAM, which

--- a/worker/src/media-page.ts
+++ b/worker/src/media-page.ts
@@ -25,10 +25,11 @@ const ERROR_PAGE = [
  *
  * Returns the HTTP status alongside the HTML so a single validity check drives
  * both: the route never has to re-decide whether the sha is valid, so the two
- * cannot drift out of agreement. The sha is normalised to lowercase once and
- * that normalised value is the only thing interpolated into the document, so a
- * crafted id cannot inject markup (a non-hex value returns the static error page
- * and is never reflected).
+ * cannot drift out of agreement. The sha is normalised to lowercase once and,
+ * with the strictly-validated extension hint, is the only value interpolated
+ * into the document, so a crafted id cannot inject markup (a non-hex value
+ * returns the static error page and is never reflected; a non-alphanumeric
+ * extension hint is dropped, since JSON.stringify does not escape "<" or "/").
  */
 export function renderMediaPage(sha256: string, extHint?: string): { status: number; html: string } {
   const id = sha256.toLowerCase();
@@ -39,8 +40,11 @@ export function renderMediaPage(sha256: string, extHint?: string): { status: num
   const proxy = `/api/media-proxy/${id}`;
   // Optional extension from the /media/<sha>.<ext> URL, used only when the
   // proxy's Content-Type is not an image/* or video/* (e.g. octet-stream).
-  // Lists mirror the SPA's MediaPreview URL-hint lists.
-  const ext = (extHint || '').toLowerCase();
+  // Lists mirror the SPA's MediaPreview URL-hint lists. Strictly validated
+  // because it is interpolated into the document: JSON.stringify escapes
+  // quotes but not "<" or "/", so only a short alphanumeric token may pass.
+  const rawExt = (extHint || '').toLowerCase();
+  const ext = /^[a-z0-9]{1,5}$/.test(rawExt) ? rawExt : '';
   const html = `<!doctype html>
 <html lang="en">
 <head>
@@ -77,6 +81,19 @@ export function renderMediaPage(sha256: string, extHint?: string): { status: num
     p.textContent = 'Could not load media: ' + message;
     stage.appendChild(p);
   }
+  function makeVideo(obj) {
+    var el = document.createElement('video');
+    el.controls = true; el.src = obj;
+    // The unknown-type branch refuses downloads; keep the video branch from
+    // re-offering one through browser chrome, and keep restricted media off
+    // Cast/external displays and Picture-in-Picture. (Right-click save remains
+    // possible; this narrows the offered paths, it does not close them.)
+    el.setAttribute('controlsList', 'nodownload');
+    el.disablePictureInPicture = true;
+    el.disableRemotePlayback = true;
+    el.onerror = function () { fail('could not decode the video'); };
+    return el;
+  }
   fetch(url, { credentials: 'include' }).then(function (r) {
     if (!r.ok) throw new Error('HTTP ' + r.status);
     return r.blob();
@@ -89,27 +106,17 @@ export function renderMediaPage(sha256: string, extHint?: string): { status: num
     });
     var el;
     if (b.type.indexOf('video') === 0) {
-      el = document.createElement('video');
-      el.controls = true; el.src = obj;
-      // The unknown-type branch refuses downloads; keep the video branch from
-      // re-offering one through browser chrome, and keep restricted media off
-      // Cast/external displays and Picture-in-Picture. (Right-click save remains
-      // possible; this narrows the offered paths, it does not close them.)
-      el.setAttribute('controlsList', 'nodownload');
-      el.disablePictureInPicture = true;
-      el.disableRemotePlayback = true;
+      el = makeVideo(obj);
     } else if (b.type.indexOf('image') === 0) {
       el = document.createElement('img'); el.src = obj;
+      el.onerror = function () { fail('could not decode the image'); };
     } else if (ext && VIDEO_EXTS.indexOf(ext) !== -1) {
       // The proxy stored the blob's type as something unhelpful (octet-stream
       // and the like); the URL extension says it is still viewable media.
-      el = document.createElement('video');
-      el.controls = true; el.src = obj;
-      el.setAttribute('controlsList', 'nodownload');
-      el.disablePictureInPicture = true;
-      el.disableRemotePlayback = true;
+      el = makeVideo(obj);
     } else if (ext && IMAGE_EXTS.indexOf(ext) !== -1) {
       el = document.createElement('img'); el.src = obj;
+      el.onerror = function () { fail('could not decode the image'); };
     } else {
       // Never write unknown bytes to the moderator's disk: this may be CSAM, which
       // is one-way and NCMEC-bound. Show the type and send them back to Coop rather

--- a/worker/src/media-page.ts
+++ b/worker/src/media-page.ts
@@ -1,0 +1,84 @@
+// A minimal, self-contained page for viewing a single piece of restricted media,
+// linked from a Coop review card. It deliberately does NOT load the relay-manager
+// SPA or its tab navigation: a moderator arrives to check one blob before acting
+// in Coop, not to browse relay-manager.
+//
+// Security: this page and the /api/media-proxy call it makes are both gated by
+// CF Access (the whole worker host redirects to Cloudflare Access) and by the
+// worker's verifyAdminAccess. The media bytes are streamed through the admin
+// bypass, so the page is only ever served to an authenticated moderator.
+
+const HEX64 = /^[a-f0-9]{64}$/;
+
+/**
+ * Render the standalone media-viewer HTML for a content hash.
+ *
+ * `sha256` is validated here rather than trusted: a non-hex value returns an
+ * error page and is never reflected into the document, so a crafted id cannot
+ * inject markup. A valid hash is safe to interpolate because it is hex only.
+ */
+export function renderMediaPage(sha256: string): string {
+  if (!HEX64.test(sha256.toLowerCase())) {
+    return [
+      '<!doctype html>',
+      '<html lang="en"><head><meta charset="utf-8">',
+      '<meta name="robots" content="noindex, nofollow">',
+      '<title>Media viewer</title></head>',
+      '<body style="font-family:system-ui,sans-serif;padding:16px">',
+      '<p>Invalid content id.</p>',
+      '</body></html>',
+    ].join('\n');
+  }
+
+  const proxy = `/api/media-proxy/${sha256}`;
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
+<title>Restricted media, admin view</title>
+<style>
+  body { margin:0; font-family:system-ui,sans-serif; background:#111; color:#eee; }
+  .banner { background:#7a1f1f; color:#fff; padding:8px 12px; font-size:14px; line-height:1.4; }
+  .sha { font-family:ui-monospace,monospace; font-size:12px; color:#9aa; padding:6px 12px; word-break:break-all; }
+  .stage { display:flex; align-items:center; justify-content:center; padding:16px; min-height:40vh; }
+  .stage video, .stage img { max-width:100%; max-height:80vh; }
+  .status { color:#f88; }
+</style>
+</head>
+<body>
+<div class="banner">Restricted content, admin view. Shown here because moderation has hidden it from the public. Check it, then act in Coop.</div>
+<div class="sha">sha256: ${sha256}</div>
+<div class="stage" id="stage"><p class="status" id="status">Loading media...</p></div>
+<script>
+(function () {
+  var url = ${JSON.stringify(proxy)};
+  var stage = document.getElementById('stage');
+  var status = document.getElementById('status');
+  fetch(url, { credentials: 'include' }).then(function (r) {
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+    return r.blob();
+  }).then(function (b) {
+    var obj = URL.createObjectURL(b);
+    var el;
+    if (b.type.indexOf('video') === 0) {
+      el = document.createElement('video');
+      el.controls = true; el.src = obj;
+    } else if (b.type.indexOf('image') === 0) {
+      el = document.createElement('img'); el.src = obj;
+    } else {
+      el = document.createElement('a');
+      el.href = obj; el.download = ${JSON.stringify(sha256)};
+      el.textContent = 'Download (' + (b.type || 'unknown type') + ')';
+      el.style.color = '#8cf';
+    }
+    stage.innerHTML = ''; stage.appendChild(el);
+  }).catch(function (e) {
+    status.textContent = 'Could not load media: ' + e.message;
+  });
+})();
+</script>
+</body>
+</html>`;
+}

--- a/worker/src/media-page.ts
+++ b/worker/src/media-page.ts
@@ -10,28 +10,34 @@
 
 const HEX64 = /^[a-f0-9]{64}$/;
 
+const ERROR_PAGE = [
+  '<!doctype html>',
+  '<html lang="en"><head><meta charset="utf-8">',
+  '<meta name="robots" content="noindex, nofollow">',
+  '<title>Media viewer</title></head>',
+  '<body style="font-family:system-ui,sans-serif;padding:16px">',
+  '<p>Invalid content id.</p>',
+  '</body></html>',
+].join('\n');
+
 /**
- * Render the standalone media-viewer HTML for a content hash.
+ * Render the standalone media-viewer page for a content hash.
  *
- * `sha256` is validated here rather than trusted: a non-hex value returns an
- * error page and is never reflected into the document, so a crafted id cannot
- * inject markup. A valid hash is safe to interpolate because it is hex only.
+ * Returns the HTTP status alongside the HTML so a single validity check drives
+ * both: the route never has to re-decide whether the sha is valid, so the two
+ * cannot drift out of agreement. The sha is normalised to lowercase once and
+ * that normalised value is the only thing interpolated into the document, so a
+ * crafted id cannot inject markup (a non-hex value returns the static error page
+ * and is never reflected).
  */
-export function renderMediaPage(sha256: string): string {
-  if (!HEX64.test(sha256.toLowerCase())) {
-    return [
-      '<!doctype html>',
-      '<html lang="en"><head><meta charset="utf-8">',
-      '<meta name="robots" content="noindex, nofollow">',
-      '<title>Media viewer</title></head>',
-      '<body style="font-family:system-ui,sans-serif;padding:16px">',
-      '<p>Invalid content id.</p>',
-      '</body></html>',
-    ].join('\n');
+export function renderMediaPage(sha256: string): { status: number; html: string } {
+  const id = sha256.toLowerCase();
+  if (!HEX64.test(id)) {
+    return { status: 400, html: ERROR_PAGE };
   }
 
-  const proxy = `/api/media-proxy/${sha256}`;
-  return `<!doctype html>
+  const proxy = `/api/media-proxy/${id}`;
+  const html = `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -49,18 +55,31 @@ export function renderMediaPage(sha256: string): string {
 </head>
 <body>
 <div class="banner">Restricted content, admin view. Shown here because moderation has hidden it from the public. Check it, then act in Coop.</div>
-<div class="sha">sha256: ${sha256}</div>
+<div class="sha">sha256: ${id}</div>
 <div class="stage" id="stage"><p class="status" id="status">Loading media...</p></div>
 <script>
 (function () {
   var url = ${JSON.stringify(proxy)};
   var stage = document.getElementById('stage');
-  var status = document.getElementById('status');
+  function fail(message) {
+    // Rebuild from the stage so an error still shows even if it is thrown after
+    // the loading placeholder has been cleared (a detached node swallows writes).
+    stage.innerHTML = '';
+    var p = document.createElement('p');
+    p.className = 'status';
+    p.textContent = 'Could not load media: ' + message;
+    stage.appendChild(p);
+  }
   fetch(url, { credentials: 'include' }).then(function (r) {
     if (!r.ok) throw new Error('HTTP ' + r.status);
     return r.blob();
   }).then(function (b) {
     var obj = URL.createObjectURL(b);
+    // The blob URL must outlive playback (video seeks re-read it), so release it
+    // on unload rather than on load.
+    window.addEventListener('pagehide', function () {
+      try { URL.revokeObjectURL(obj); } catch (e) { /* already gone */ }
+    });
     var el;
     if (b.type.indexOf('video') === 0) {
       el = document.createElement('video');
@@ -69,16 +88,17 @@ export function renderMediaPage(sha256: string): string {
       el = document.createElement('img'); el.src = obj;
     } else {
       el = document.createElement('a');
-      el.href = obj; el.download = ${JSON.stringify(sha256)};
+      el.href = obj; el.download = ${JSON.stringify(id)};
       el.textContent = 'Download (' + (b.type || 'unknown type') + ')';
       el.style.color = '#8cf';
     }
     stage.innerHTML = ''; stage.appendChild(el);
   }).catch(function (e) {
-    status.textContent = 'Could not load media: ' + e.message;
+    fail(e.message);
   });
 })();
 </script>
 </body>
 </html>`;
+  return { status: 200, html };
 }

--- a/worker/src/media-route.test.ts
+++ b/worker/src/media-route.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import worker from './index';
+
+const ctx = {} as ExecutionContext;
+const env = {
+  ALLOWED_ORIGINS: 'https://relay.admin.divine.video',
+  RELAY_URL: 'wss://relay.divine.video',
+  ADMIN_API_KEY: 'test-admin-key',
+} as never;
+
+const SHA = 'a'.repeat(64);
+
+function get(path: string, headers: Record<string, string> = {}) {
+  return worker.fetch(
+    new Request(`https://api-relay-staging.divine.video${path}`, { method: 'GET', headers }),
+    env,
+    ctx,
+  );
+}
+
+describe('GET /media/:sha256', () => {
+  it('is gated: no admin auth is rejected, never serving the page', async () => {
+    const res = await get(`/media/${SHA}`);
+    expect(res.status).toBe(401);
+    const body = await res.text();
+    expect(body).not.toContain('/api/media-proxy/'); // page never rendered
+  });
+
+  it('serves the standalone page to an authenticated moderator', async () => {
+    const res = await get(`/media/${SHA}`, { 'X-Admin-Key': 'test-admin-key' });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+    const body = await res.text();
+    expect(body).toContain(`/api/media-proxy/${SHA}`);
+    expect(body).toContain(SHA);
+    expect(body.toLowerCase()).toContain('restricted');
+  });
+
+  it('400s a non-hex sha rather than serving anything reflective', async () => {
+    const res = await get('/media/not-a-real-hash', { 'X-Admin-Key': 'test-admin-key' });
+    expect(res.status).toBe(400);
+    const body = await res.text();
+    expect(body).not.toContain('not-a-real-hash');
+  });
+
+  it('tolerates a file extension on the path (…/media/<sha>.mp4)', async () => {
+    const res = await get(`/media/${SHA}.mp4`, { 'X-Admin-Key': 'test-admin-key' });
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain(`/api/media-proxy/${SHA}`);
+  });
+});

--- a/worker/src/media-route.test.ts
+++ b/worker/src/media-route.test.ts
@@ -59,11 +59,12 @@ describe('GET /media/:sha256', () => {
     expect(res.status).toBe(400);
   });
 
-  it('tolerates a file extension on the path (…/media/<sha>.mp4)', async () => {
+  it('tolerates a file extension on the path (…/media/<sha>.mp4) and passes it as a type hint', async () => {
     const res = await get(`/media/${SHA}.mp4`, AUTH);
     expect(res.status).toBe(200);
     const body = await res.text();
     expect(body).toContain(`/api/media-proxy/${SHA}`);
+    expect(body).toContain('var ext = "mp4"');
   });
 
   it('normalises an uppercase sha in the path to lowercase (the form that ships)', async () => {
@@ -100,6 +101,11 @@ describe('GET /api/media-proxy/:sha256 (the viewer page\'s media source)', () =>
       const cacheControl = res.headers.get('cache-control') || '';
       expect(cacheControl).toContain('no-store');
       expect(cacheControl).not.toContain('no-cache');
+      // Stored-as-uploaded Content-Type means a text/html blob would otherwise
+      // run script on the admin origin if navigated to directly; sandbox plus
+      // nosniff closes that. The fetch-into-Blob consumers are unaffected.
+      expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+      expect(res.headers.get('content-security-policy')).toBe('sandbox');
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/worker/src/media-route.test.ts
+++ b/worker/src/media-route.test.ts
@@ -9,6 +9,7 @@ const env = {
 } as never;
 
 const SHA = 'a'.repeat(64);
+const AUTH = { 'X-Admin-Key': 'test-admin-key' };
 
 function get(path: string, headers: Record<string, string> = {}) {
   return worker.fetch(
@@ -27,7 +28,7 @@ describe('GET /media/:sha256', () => {
   });
 
   it('serves the standalone page to an authenticated moderator', async () => {
-    const res = await get(`/media/${SHA}`, { 'X-Admin-Key': 'test-admin-key' });
+    const res = await get(`/media/${SHA}`, AUTH);
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type')).toContain('text/html');
     const body = await res.text();
@@ -36,15 +37,37 @@ describe('GET /media/:sha256', () => {
     expect(body.toLowerCase()).toContain('restricted');
   });
 
+  it('sends document security headers so the CSAM hash stays off disk and the page is locked down', async () => {
+    const res = await get(`/media/${SHA}`, AUTH);
+    expect(res.headers.get('cache-control')).toBe('no-store');
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(res.headers.get('referrer-policy')).toBe('no-referrer');
+    const csp = res.headers.get('content-security-policy') || '';
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain("connect-src 'self'"); // the proxy fetch must be allowed
+  });
+
   it('400s a non-hex sha rather than serving anything reflective', async () => {
-    const res = await get('/media/not-a-real-hash', { 'X-Admin-Key': 'test-admin-key' });
+    const res = await get('/media/not-a-real-hash', AUTH);
     expect(res.status).toBe(400);
     const body = await res.text();
     expect(body).not.toContain('not-a-real-hash');
   });
 
+  it('400s an empty id', async () => {
+    const res = await get('/media/', AUTH);
+    expect(res.status).toBe(400);
+  });
+
   it('tolerates a file extension on the path (…/media/<sha>.mp4)', async () => {
-    const res = await get(`/media/${SHA}.mp4`, { 'X-Admin-Key': 'test-admin-key' });
+    const res = await get(`/media/${SHA}.mp4`, AUTH);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain(`/api/media-proxy/${SHA}`);
+  });
+
+  it('normalises an uppercase sha in the path to lowercase (the form that ships)', async () => {
+    const res = await get(`/media/${'A'.repeat(64)}`, AUTH);
     expect(res.status).toBe(200);
     const body = await res.text();
     expect(body).toContain(`/api/media-proxy/${SHA}`);

--- a/worker/src/media-route.test.ts
+++ b/worker/src/media-route.test.ts
@@ -73,3 +73,35 @@ describe('GET /media/:sha256', () => {
     expect(body).toContain(`/api/media-proxy/${SHA}`);
   });
 });
+
+describe('GET /api/media-proxy/:sha256 (the viewer page\'s media source)', () => {
+  it('serves restricted bytes with no-store so they never reach the browser HTTP disk cache', async () => {
+    // no-cache permits disk-cache storage subject to revalidation; the bytes this
+    // route serves can be CSAM, so they must not be stored at all.
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response('bytes', { status: 200, headers: { 'content-type': 'image/jpeg' } })) as typeof fetch;
+    try {
+      const proxyEnv = {
+        ALLOWED_ORIGINS: 'https://relay.admin.divine.video',
+        RELAY_URL: 'wss://relay.divine.video',
+        ADMIN_API_KEY: 'test-admin-key',
+        BLOSSOM_WEBHOOK_SECRET: 'test-blossom-secret',
+      } as never;
+      const res = await worker.fetch(
+        new Request(`https://api-relay-staging.divine.video/api/media-proxy/${SHA}`, {
+          method: 'GET',
+          headers: AUTH,
+        }),
+        proxyEnv,
+        ctx,
+      );
+      expect(res.status).toBe(200);
+      const cacheControl = res.headers.get('cache-control') || '';
+      expect(cacheControl).toContain('no-store');
+      expect(cacheControl).not.toContain('no-cache');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
When content is already restricted, such as by an automated verdict, a moderator cannot view the reported media: the card's `media_url` no longer serves. This adds a minimal viewer so they can check the actual bytes before acting, without dropping them into relay-manager's full UI.

`GET /media/<sha256>` on the worker serves a self-contained page (not the SPA): the restricted media streamed through the existing `/api/media-proxy` admin bypass, a "restricted, admin view" banner, and the sha. It sits inside the same CF Access + `verifyAdminAccess` gate as every other admin route, so only an authenticated moderator reaches it, and it reuses the host that already serves the proxy, so no new config or origin is involved. Chosen over an SPA route because that host is already CF-Access-gated and it sidesteps the shared-frontend runtime-backend selector entirely.

Security posture, since the page can serve CSAM:

- one validity check drives both the HTTP status and the body, so a loosened check cannot 200 the error page or 400 the real one
- the sha is normalized once and only that value is interpolated, so the validated string and the rendered string cannot diverge
- document headers: `no-store` (the URL and body name a content hash), a locked-down CSP, `nosniff`, `no-referrer`
- proxy response (`/api/media-proxy`): `no-store` (restricted bytes never reach the browser HTTP disk cache), `nosniff` + `CSP: sandbox` (a blob stored as `text/html` cannot execute on the admin origin if navigated to directly); the viewer's video controls suppress the browser download/Cast/PiP affordances, and the optional URL extension is validated server-side before interpolation
- unknown blob types are not offered as a download, so possibly-CSAM bytes never touch a moderator's disk; the page shows the type and sends them back to Coop

Tests: `renderMediaPage` unit + route integration including the auth gate; 629 worker tests pass. The gate, the CSP header, the lowercase normalization, and the no-download rule are each mutation-checked.

**Sequencing:** this is the target of the osprey `relay_manager_url` change and must merge and deploy **before** it, or Coop cards would carry links that 404. Acceptance check after deploy: load `/media/<sha>` in a browser as a moderator on staging and confirm the media renders.

