### PR TITLE
fix(reports): scroll detail pane on short viewports; dismissable attribution banner

### DIFF
--- a/src/components/ReportDetail.tsx
+++ b/src/components/ReportDetail.tsx
@@ -8,7 +8,6 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -469,8 +468,14 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
   const categoryLabel = CATEGORY_LABELS[category] || category;
   const isHighPriorityCategory = HIGH_PRIORITY_CATEGORIES.includes(category);
 
+  // Scroll the whole pane, not just an inner region. On a short viewport the
+  // tall action footer used to starve the content area (it was a shrink-0 block
+  // outside the scroll), squeezing the report context to a sliver and making it
+  // unreachable. Scrolling the pane keeps the footer pinned to the bottom when
+  // it fits (tall screens) and lets the content + footer scroll together when it
+  // does not (short laptops).
   return (
-    <div className="h-full flex flex-col overflow-hidden">
+    <div className="h-full flex flex-col overflow-y-auto">
       {/* Dialogs - rendered as portals, don't affect flex layout */}
       {/* Ban Confirmation Dialog */}
       {/* Dismiss Report Dialog */}
@@ -523,8 +528,9 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
         />
       )}
 
-      {/* Scrollable content area */}
-      <ScrollArea className="flex-1 min-h-0 [&>div>div]:!block">
+      {/* Content area. flex-1 without min-h-0: it keeps its natural height and the
+          pane above scrolls, instead of collapsing to a sliver under the footer. */}
+      <div className="flex-1">
         <div className="p-4 space-y-4 overflow-x-hidden max-w-full">
           {/* Pending Review Banner - for auto-hidden items awaiting human review */}
           {isPendingReview && (
@@ -1159,9 +1165,10 @@ export function ReportDetail({ report, allReportsForTarget, allReports = [], onD
 
 
         </div>
-      </ScrollArea>
+      </div>
 
-      {/* Action Buttons - fixed at bottom */}
+      {/* Action buttons. Pinned to the bottom when the pane fits; scrolls into
+          view with the content above on short viewports. */}
       <div className="border-t bg-background p-4 space-y-3 shrink-0">
             {/* Resolution actions - dismiss or reopen */}
             <div className="flex flex-wrap gap-2">

--- a/src/components/auth/AttributionNotice.tsx
+++ b/src/components/auth/AttributionNotice.tsx
@@ -5,21 +5,50 @@
 // that replaces the login walls this tool used to put in front of the relay
 // management surfaces. Without it a moderator has no reason to sign in and
 // every decision they write lands moderator_pubkey = null (#178, #181).
-import { LogIn, UserX } from 'lucide-react';
+//
+// Dismissable: the banner is informational, not a gate, and on a short viewport
+// it steals vertical space from the report panes. A moderator who cannot (or
+// will not) sign in can dismiss it; the choice persists so it does not return
+// on every load.
+import { useState } from 'react';
+import { LogIn, UserX, X } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useDivineSession } from '@/hooks/useDivineSession';
 import { useStartSignIn } from '@/hooks/useStartSignIn';
 
+const DISMISS_KEY = 'attribution-notice:dismissed';
+
+// localStorage can throw (Safari private mode, storage disabled) -- the session
+// layer already degrades on that, so mirror it: never let a storage failure
+// crash the banner.
+function readDismissed(): boolean {
+  try {
+    return localStorage.getItem(DISMISS_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
 export function AttributionNotice() {
   const { user } = useCurrentUser();
   const { isResolving } = useDivineSession();
   const handleSignIn = useStartSignIn();
+  const [dismissed, setDismissed] = useState(readDismissed);
 
   // Nothing to say while the session is still resolving: an already-signed-in
   // moderator would otherwise see the warning flash on every load.
-  if (isResolving || user) return null;
+  if (isResolving || user || dismissed) return null;
+
+  const dismiss = () => {
+    try {
+      localStorage.setItem(DISMISS_KEY, '1');
+    } catch {
+      // Storage unavailable: still hide it for this session.
+    }
+    setDismissed(true);
+  };
 
   return (
     <Alert className="mb-3 shrink-0">
@@ -28,10 +57,15 @@ export function AttributionNotice() {
           <UserX className="h-4 w-4 shrink-0" aria-hidden />
           Moderation actions are being recorded without attribution.
         </span>
-        <Button size="sm" variant="outline" onClick={handleSignIn}>
-          <LogIn className="h-4 w-4 mr-2" />
-          Sign in
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button size="sm" variant="outline" onClick={handleSignIn}>
+            <LogIn className="h-4 w-4 mr-2" />
+            Sign in
+          </Button>
+          <Button size="sm" variant="ghost" onClick={dismiss} aria-label="Dismiss">
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
       </AlertDescription>
     </Alert>
   );


### PR DESCRIPTION
## Summary

Fixes a height-driven layout bug that made the Reports tab unusable on short (laptop, full-window) viewports, and makes the attribution banner dismissable.

On a short viewport the report **detail pane** clipped its content with no way to scroll: the action-button footer was a `shrink-0` block sitting *outside* the scroll region, so it squeezed the report context to a sliver and, when the footer alone exceeded the pane height, overflowed the pane's `overflow-hidden` and became unreachable. A moderator on a full-window laptop could not see the reported content or reach the action buttons ("won't let me see anything or even scroll the page").

The fix scrolls the whole detail pane rather than an inner region: the content keeps its natural height, and the footer stays pinned to the bottom when it fits (tall screens, unchanged) and scrolls into view with the content when it doesn't (short screens).

Separately, the "Moderation actions are being recorded without attribution" banner is now dismissable (persisted), since it is informational only and steals vertical space that matters on short viewports.

## Motivation

A moderator was fully blocked. The root cause was viewport **height**, not width or the sign-in flow: the fixed-height shell plus a non-shrinking action footer. Reproduced from the reported screen (1888×1256 @2× = 944×628 CSS).

## Changes

- `ReportDetail.tsx`: detail pane `overflow-hidden` → `overflow-y-auto`; inner `ScrollArea` (`flex-1 min-h-0`) → a plain `flex-1` div (drops the now-unused `ScrollArea` import).
- `AttributionNotice.tsx`: add a dismiss control; persist dismissal in `localStorage`, guarded so disabled storage never crashes the banner.

## Deploy status

Already deployed to CF Pages **Production** (commit `534089e`) as an urgent hotfix for the blocked moderator. This PR lands the same change on `main` so prod and the repo stay in sync — without it, the next `main` frontend deploy would revert the fix.

## Validation

- `npx tsc -p tsconfig.app.json --noEmit`: clean.
- `AttributionNotice.test.tsx`: 4/4 pass; accessibility snapshot confirms both **Sign in** and **Dismiss** render.
- Could not screenshot a live report locally — the Reports queue requires the relay stack / CF Access, so the detail pane can't be populated in local dev. Functional confirmation is a moderator hard-reloading `relay.admin.divine.video/reports` on a short laptop viewport, opening a report, and confirming the detail pane scrolls and the action buttons are reachable.

## No linked issue

Urgent hotfix in response to a blocked moderator; no pre-existing tracking issue. Can file one if we want it tracked.

## Follow-up (not in this PR)

The Age Review detail pane (`AgeReviewDetail.tsx`) uses the same `overflow-hidden` + `shrink-0` footer pattern and likely clips the same way on short viewports. Left out to keep this hotfix tight.
