### PR TITLE
fix(seed): require RELAY_URL so the test seeder can't default to production

### DIFF
--- a/scripts/no-production-endpoint-defaults.test.ts
+++ b/scripts/no-production-endpoint-defaults.test.ts
@@ -1,0 +1,145 @@
+// A script under scripts/ must not fall back to a deployed endpoint when its
+// environment variable is unset.
+//
+// This is not hygiene. seed-test-events.ts publishes fabricated profiles,
+// videos and kind 1984 reports, and it read
+// `process.env.RELAY_URL || 'wss://relay.divine.video'`. Running it without
+// setting RELAY_URL — the documented usage at the top of the file said exactly
+// that — injected fake content and fake reports into the live moderation
+// queue. wrangler.local.toml had the same shape and the same consequence
+// (see worker/test/local-config-targets-local-stack.test.ts).
+//
+// The check is deliberately inverted, like the worker one: rather than listing
+// the scripts that must be safe, it finds every hardcoded endpoint that a
+// script would silently adopt and requires each to be local or explicitly
+// excused. A script added later fails this test until someone decides which it
+// is, instead of inheriting a production default unnoticed.
+//
+// Two shapes are covered, because both make an unset environment reach a
+// deployed host with no action from the operator:
+//
+//   const X_URL = process.env.X_URL || 'wss://relay.divine.video';
+//   const X_URL = 'wss://relay.divine.video';
+//
+// A default carried on a command-line flag is not covered. bulk-delete-videos.mjs
+// defaults --relay to production because deleting production events is its
+// purpose; it names no target of its own and cannot run without --pubkeys. The
+// hazard here is specifically the run that looks local and is not.
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Hardcoded endpoints that are deliberately not local. Each needs a reason,
+ * because the point is that adding to this list is a decision rather than a
+ * default.
+ */
+const EXCUSED: Record<string, string> = {};
+
+const LOCAL_HOST_RE =
+  /^(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|::1|[A-Za-z0-9-]+\.localhost)$/;
+
+// `process.env.NAME || 'url'` and the `??` spelling. Quoted literals only: the
+// scripts build media URLs with template literals (`https://blossom…/${hash}`)
+// and those are event content, not an endpoint this process talks to.
+const ENV_FALLBACK_RE =
+  /process\.env\.([A-Za-z_$][\w$]*)\s*(?:\|\||\?\?)\s*(['"])([^'"]*)\2/g;
+
+// `const SOMETHING_URL = 'url'` with no env read at all — the same hazard with
+// the environment variable removed rather than defaulted.
+const BARE_URL_CONST_RE =
+  /\bconst\s+([A-Za-z_$][\w$]*(?:URL|Url|url))\s*=\s*(['"])([^'"]*)\2/g;
+
+const URL_SCHEME_RE = /^(wss?|https?):\/\//i;
+
+type Finding = { file: string; line: number; name: string; value: string };
+
+function lineOf(source: string, index: number): number {
+  return source.slice(0, index).split('\n').length;
+}
+
+function findingsIn(file: string, source: string): Finding[] {
+  const found: Finding[] = [];
+  for (const re of [ENV_FALLBACK_RE, BARE_URL_CONST_RE]) {
+    re.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(source)) !== null) {
+      const [, name, , value] = match;
+      if (!URL_SCHEME_RE.test(value)) continue;
+      found.push({ file, line: lineOf(source, match.index), name, value });
+    }
+  }
+  return found;
+}
+
+function isLocal(value: string): boolean {
+  try {
+    return LOCAL_HOST_RE.test(new URL(value).hostname);
+  } catch {
+    return false;
+  }
+}
+
+const scriptFiles = readdirSync(SCRIPTS_DIR)
+  .filter((f) => /\.(ts|mjs|js)$/.test(f) && !f.endsWith('.test.ts'))
+  .sort();
+
+describe('scripts do not default to deployed endpoints', () => {
+  it('finds the scripts it is meant to guard', () => {
+    expect(scriptFiles).toContain('seed-test-events.ts');
+    expect(scriptFiles.length).toBeGreaterThan(5);
+  });
+
+  it.each(scriptFiles)('%s', (file) => {
+    const source = readFileSync(join(SCRIPTS_DIR, file), 'utf-8');
+    const offenders = findingsIn(file, source)
+      .filter((f) => !isLocal(f.value))
+      .filter((f) => !(f.value in EXCUSED))
+      .map((f) => `${f.file}:${f.line} ${f.name} = ${f.value}`);
+
+    expect(
+      offenders,
+      `A script must not silently adopt a deployed endpoint. Either point the ` +
+        `default at the local stack, require the variable and exit when it is ` +
+        `unset (see seed-test-events.ts), or add the value to EXCUSED in this ` +
+        `file with a reason.`,
+    ).toEqual([]);
+  });
+
+  it('rejects a production default', () => {
+    const offenders = findingsIn(
+      'fake.ts',
+      "const RELAY_URL = process.env.RELAY_URL || 'wss://relay.divine.video';",
+    );
+    expect(offenders.map((f) => f.value)).toEqual(['wss://relay.divine.video']);
+  });
+
+  it('rejects a production endpoint with no environment variable at all', () => {
+    const offenders = findingsIn(
+      'fake.ts',
+      "const WORKER_URL = 'https://api-relay-prod.divine.video';",
+    );
+    expect(offenders.map((f) => f.value)).toEqual([
+      'https://api-relay-prod.divine.video',
+    ]);
+  });
+
+  it('accepts a local default', () => {
+    const offenders = findingsIn(
+      'fake.ts',
+      "const RELAY_URL = process.env.RELAY_URL || 'ws://127.0.0.1:4444';",
+    ).filter((f) => !isLocal(f.value));
+    expect(offenders).toEqual([]);
+  });
+
+  it('ignores a media URL built as a template literal', () => {
+    const offenders = findingsIn(
+      'fake.ts',
+      'const videoUrl = `https://blossom.divine.video/${mediaHash}.mp4`;',
+    );
+    expect(offenders).toEqual([]);
+  });
+});

--- a/scripts/seed-test-events.ts
+++ b/scripts/seed-test-events.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env npx tsx
 /**
  * Seed test events for moderation testing
- * Usage: npx tsx scripts/seed-test-events.ts
+ * Usage: RELAY_URL=ws://127.0.0.1:4444 npx tsx scripts/seed-test-events.ts
  */
 
 import { getPublicKey, finalizeEvent } from 'nostr-tools/pure';
@@ -9,7 +9,18 @@ import { bytesToHex } from '@noble/hashes/utils';
 import { sha256 } from '@noble/hashes/sha256';
 import WebSocket from 'ws';
 
-const RELAY_URL = process.env.RELAY_URL || 'wss://relay.divine.video';
+// This script publishes fabricated profiles, videos, and kind 1984 reports.
+// It must not default to a live relay: a run with RELAY_URL unset would inject
+// fake content and reports into whatever relay it hit. Require it explicitly.
+const configuredRelayUrl = process.env.RELAY_URL;
+if (!configuredRelayUrl) {
+  console.error(
+    'RELAY_URL is required. This script publishes fabricated events and reports and will not ' +
+    'default to a relay. Example: RELAY_URL=ws://127.0.0.1:4444 npx tsx scripts/seed-test-events.ts',
+  );
+  process.exit(1);
+}
+const RELAY_URL = configuredRelayUrl;
 
 // Generate a deterministic sha256 hash from a seed string
 function makeHash(seed: string): string {


### PR DESCRIPTION
## What this fixes

`scripts/seed-test-events.ts` loads fabricated test data (fake profiles, videos, and reports) for exercising the moderation tools. Run without `RELAY_URL` set, it defaulted to the production relay (`wss://relay.divine.video`), so an unconfigured run injects fake content and fake reports straight into the live moderation queue.

## The change

Require `RELAY_URL` explicitly and exit with a clear message when it is unset. No change in behavior when `RELAY_URL` is provided.

A second commit adds a regression guard, `scripts/no-production-endpoint-defaults.test.ts`. Without it nothing enforced the title's claim: `scripts/` is outside `tsconfig.app.json` and had no test, so the next script written with `process.env.RELAY_URL || 'wss://relay.divine.video'` would ship the same way this one did. The guard is inverted, like `worker/test/local-config-targets-local-stack.test.ts` (added by #233 for the same hazard in `wrangler.local.toml`): it finds every hardcoded endpoint a script would silently adopt and requires each to be local or explicitly excused, so a script added later has to be judged rather than inherit a default.

## What it deliberately does not change

The other five relay scripts already default to `ws://localhost:4444` and are untouched. A default carried on a command-line flag is out of the guard's scope: `bulk-delete-videos.mjs` defaults `--relay` to production because deleting production events is its purpose, and it cannot run without `--pubkeys`. The hazard being fixed is specifically the run that looks local and is not.

## Context

This is the one still-useful change from #242. The rest of #242 duplicated #231 (merged Aug 9), so #242 is being closed and this carries the fix forward on its own.

## Validation

`npm test` (`tsc -p tsconfig.app.json --noEmit`, `eslint`, `vitest run`, `vite build`) passes: 638 tests across 65 files. The guard was checked both ways — it fails, naming file, line, variable and value, when the production default is put back on line 15, and passes once it is removed. `RELAY_URL= npx tsx scripts/seed-test-events.ts` exits 1 and publishes nothing.

Closes #none
