### PR TITLE
feat(minors): preserve protection when hosted accounts are replaced

### DIFF
--- a/docs/api-webhooks.md
+++ b/docs/api-webhooks.md
@@ -4,6 +4,8 @@
 
 The Divine Relay Manager exposes several API endpoints for integration with external systems like Zendesk (ticket report parsing, decision sync, age-review replies). Note: Zendesk does **not** execute moderation actions. Moderation is performed in Relay Manager; Zendesk only receives decision updates back. The former inbound moderation-execution path has been retired (see the note under `POST /api/zendesk/webhook`).
 
+Protected-minor deletion and replacement service endpoints are documented in [protected-minor-registry.md](protected-minor-registry.md). They use a dedicated bearer credential and are not authorized by moderator/browser credentials.
+
 **Base URL:** `https://api-relay-prod.divine.video` (production) or `https://api-relay-staging.divine.video` (staging)
 
 ## Authentication

--- a/docs/protected-minor-registry.md
+++ b/docs/protected-minor-registry.md
@@ -1,0 +1,26 @@
+# Protected-minor registry
+
+Relay Manager is the durable authority for whether a protected-minor subject is active or cleared. Keycast's `verified_minor` value is an enforcement projection associated with the current hosted account; deleting that account does not clear the subject.
+
+The registry deliberately stores only opaque subject and operation UUIDs, account pubkeys, age-review case provenance, lifecycle state, reasons, and timestamps. It does not copy parent contact, identity-review evidence, usernames, display names, credentials, or recovery material. Subject state and binding history are retained indefinitely until the retention review in support-trust-safety#204 defines a deletion period. Provisioning and projection-operation records are likewise retained so an old operation cannot create a second account after its idempotency record expires.
+
+## Service API
+
+All `/api/internal/protected-minors/*` routes accept only `Authorization: Bearer <PROTECTED_MINOR_SERVICE_TOKEN>`. Cloudflare Access browser assertions and `X-Admin-Key` do not authorize them. Infrastructure must separately allow the caller through Cloudflare Access using a service token or a path-scoped policy; the Worker bearer remains mandatory defense in depth.
+
+- `POST /api/internal/protected-minors/resolve` accepts `{"pubkey":"<64 lowercase hex>"}` and returns either `{"classification":"active","subject_ref":"<uuid>","binding_state":"active"}` or `{"classification":"none"}`. Only these HTTP 200 responses are determinate. Database failures return 503, never a false negative.
+- `POST /api/internal/protected-minors/bindings/close` accepts `subject_ref`, `pubkey`, and `deletion_attempt_id`. Exact replay returns `{"outcome":"closed"}`. Conflicting operation reuse and stale bindings return stable 409 codes.
+- `POST /api/internal/protected-minors/replacements` accepts `subject_ref`, `provisioning_operation_id`, `username`, and optional `display_name`. It is disabled unless `PROTECTED_MINOR_REPLACEMENT_ENABLED=true`. Do not enable it until Keycast #385 is deployed and its replay contract has been verified.
+
+Opaque subject references must never be logged, emitted in analytics, placed in metrics labels, or returned in errors. Resolve's successful active response is the sole intended disclosure to the deletion coordinator.
+
+## Deployment and rollback
+
+1. Create the `PROTECTED_MINOR_SERVICE_TOKEN` Secrets Store entry and configure the Cloudflare Access service-token path.
+2. Deploy Keycast #385 before deploying Relay Manager, because onboarding now sends its provisioning operation ID for crash-safe recovery.
+3. Deploy Relay Manager with replacement disabled. `ensureSchema()` creates the tables; do not run Wrangler migrations against this database.
+4. Invoke `POST /api/admin/protected-minors/backfill` once in staging, inspect its counts, then repeat in production.
+5. Deploy and enable Funnelcake #1118 only after resolve/close have been verified.
+6. Enable replacement only after the full cross-service flow and retention gate support-trust-safety#204 are approved.
+
+Rollback application code without dropping registry tables or idempotency records. Disabling Funnelcake and replacement callers is safe; dropping or truncating registry data is not. A rollback to a Relay Manager version that does not send provisioning operation IDs also requires confirming Keycast's transitional compatibility remains enabled.

--- a/docs/protected-minor-registry.md
+++ b/docs/protected-minor-registry.md
@@ -10,7 +10,7 @@ All `/api/internal/protected-minors/*` routes accept only `Authorization: Bearer
 
 - `POST /api/internal/protected-minors/resolve` accepts `{"pubkey":"<64 lowercase hex>"}` and returns either `{"classification":"active","subject_ref":"<uuid>","binding_state":"active"}` or `{"classification":"none"}`. Only these HTTP 200 responses are determinate. Database failures return 503, never a false negative.
 - `POST /api/internal/protected-minors/bindings/close` accepts `subject_ref`, `pubkey`, and `deletion_attempt_id`. Exact replay returns `{"outcome":"closed"}`. Conflicting operation reuse and stale bindings return stable 409 codes.
-- `POST /api/internal/protected-minors/replacements` accepts `subject_ref`, `provisioning_operation_id`, `username`, and optional `display_name`. It is disabled unless `PROTECTED_MINOR_REPLACEMENT_ENABLED=true`. Do not enable it until Keycast #385 is deployed and its replay contract has been verified.
+- `POST /api/internal/protected-minors/replacements` accepts `subject_ref`, `provisioning_operation_id`, `username`, and optional `display_name`. The previous active binding must already be closed; otherwise the request returns HTTP 409 `stale_binding` without calling Keycast. It is disabled unless `PROTECTED_MINOR_REPLACEMENT_ENABLED=true`. Do not enable it until Keycast #385 is deployed and its replay contract has been verified.
 
 Opaque subject references must never be logged, emitted in analytics, placed in metrics labels, or returned in errors. Resolve's successful active response is the sole intended disclosure to the deletion coordinator.
 

--- a/docs/protected-minor-registry.md
+++ b/docs/protected-minor-registry.md
@@ -19,7 +19,7 @@ Opaque subject references must never be logged, emitted in analytics, placed in 
 1. Create the `PROTECTED_MINOR_SERVICE_TOKEN` Secrets Store entry and configure the Cloudflare Access service-token path.
 2. Deploy Keycast #385 before deploying Relay Manager, because onboarding now sends its provisioning operation ID for crash-safe recovery.
 3. Deploy Relay Manager with replacement disabled. `ensureSchema()` creates the tables; do not run Wrangler migrations against this database.
-4. Invoke `POST /api/admin/protected-minors/backfill` once in staging, inspect its counts, then repeat in production.
+4. Invoke `POST /api/admin/protected-minors/backfill` in staging and inspect its counts, then repeat in production. If a row exposes an integrity conflict, resolve it and rerun; committed rows are skipped by source case ID.
 5. Deploy and enable Funnelcake #1118 only after resolve/close have been verified.
 6. Enable replacement only after the full cross-service flow and retention gate support-trust-safety#204 are approved.
 

--- a/shared/age-review.ts
+++ b/shared/age-review.ts
@@ -132,6 +132,9 @@ export interface AgeReviewEnforcement {
    * payloads from an older worker still type-check. */
   keycastMinorClear?: EnforcementLegStatus;
   keycastMinorClearError?: string;
+  /** Durable protected-subject clear. It precedes the Keycast projection clear. */
+  subjectClear?: EnforcementLegStatus;
+  subjectClearError?: string;
 }
 
 // Response body for a case GET/PATCH. On a partial-enforcement PATCH the worker

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -181,6 +181,8 @@ export function AgeReviewDetail({ caseData: c }: Props) {
         if (enforcement?.relay === 'failed') failed.push('relay (existing posts and feed)');
         if (enforcement?.bulk === 'failed') failed.push('media and content');
         if (enforcement?.keycast === 'failed') failed.push('account sign-in');
+        if (enforcement?.subjectClear === 'failed') failed.push('protected-minor registry');
+        if (enforcement?.keycastMinorClear === 'failed') failed.push('protected-minor account projection');
         toast({
           title: 'Enforcement incomplete',
           description: `Case updated, but these did not apply: ${failed.join(', ') || 'one or more enforcement steps'}. The user's content or account may still be reachable. Retry the action or escalate.`,

--- a/src/components/AgeReviewDetail.tsx
+++ b/src/components/AgeReviewDetail.tsx
@@ -185,7 +185,7 @@ export function AgeReviewDetail({ caseData: c }: Props) {
         if (enforcement?.keycastMinorClear === 'failed') failed.push('protected-minor account projection');
         toast({
           title: 'Enforcement incomplete',
-          description: `Case updated, but these did not apply: ${failed.join(', ') || 'one or more enforcement steps'}. The user's content or account may still be reachable. Retry the action or escalate.`,
+          description: `Case updated, but these did not apply: ${failed.join(', ') || 'one or more enforcement steps'}. The case is now closed; automated retry will continue where supported. Escalate if enforcement does not converge.`,
           variant: 'destructive',
         });
       }

--- a/src/components/CreateMinorAccountDialog.tsx
+++ b/src/components/CreateMinorAccountDialog.tsx
@@ -23,11 +23,12 @@ export function CreateMinorAccountDialog() {
   const [displayName, setDisplayName] = useState("");
   const [zendeskTicketId, setZendeskTicketId] = useState("");
   const [claimUrlCopied, setClaimUrlCopied] = useState(false);
+  const [provisioningOperationId, setProvisioningOperationId] = useState(() => crypto.randomUUID());
 
   const createAccount = useMutation({
     mutationFn: () => {
       const ticketId = zendeskTicketId ? parseInt(zendeskTicketId, 10) : undefined;
-      return api.createMinorAccount(username.trim(), displayName.trim() || undefined, ticketId);
+      return api.createMinorAccount(username.trim(), displayName.trim() || undefined, ticketId, provisioningOperationId);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['age-review-cases'] });
@@ -54,6 +55,7 @@ export function CreateMinorAccountDialog() {
     setZendeskTicketId("");
     createAccount.reset();
     setClaimUrlCopied(false);
+    setProvisioningOperationId(crypto.randomUUID());
   }
 
   return (
@@ -76,7 +78,7 @@ export function CreateMinorAccountDialog() {
               <Input
                 placeholder="username"
                 value={username}
-                onChange={(e) => setUsername(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
+                onChange={(e) => { setUsername(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '')); setProvisioningOperationId(crypto.randomUUID()); }}
                 maxLength={63}
                 className="h-8 text-sm"
                 disabled={createAccount.isPending}
@@ -87,7 +89,7 @@ export function CreateMinorAccountDialog() {
               <Input
                 placeholder="Display name (optional)"
                 value={displayName}
-                onChange={(e) => setDisplayName(e.target.value)}
+                onChange={(e) => { setDisplayName(e.target.value); setProvisioningOperationId(crypto.randomUUID()); }}
                 className="h-8 text-sm"
                 disabled={createAccount.isPending}
               />
@@ -97,7 +99,7 @@ export function CreateMinorAccountDialog() {
               <Input
                 placeholder="e.g. 12345 (optional)"
                 value={zendeskTicketId}
-                onChange={(e) => setZendeskTicketId(e.target.value.replace(/\D/g, ''))}
+                onChange={(e) => { setZendeskTicketId(e.target.value.replace(/\D/g, '')); setProvisioningOperationId(crypto.randomUUID()); }}
                 className="h-8 text-sm"
                 disabled={createAccount.isPending}
               />

--- a/src/components/CreateMinorAccountDialog.tsx
+++ b/src/components/CreateMinorAccountDialog.tsx
@@ -132,27 +132,33 @@ export function CreateMinorAccountDialog() {
               </div>
             </div>
 
-            <div className="space-y-1.5">
-              <label className="text-xs font-medium">Claim Link</label>
-              <div className="flex gap-1.5">
-                <Input
-                  readOnly
-                  value={result.claim_url ?? ''}
-                  className="h-8 text-xs font-mono"
-                />
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-8 shrink-0"
-                  onClick={handleCopyClaimUrl}
-                >
-                  {claimUrlCopied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-                </Button>
-              </div>
-              <p className="text-[10px] text-muted-foreground">
-                Send this link to the parent via Zendesk reply. The minor uses it to set their email and password.
+            {result.account_state === 'claimed' ? (
+              <p className="text-xs text-muted-foreground">
+                This account has already been claimed. No claim link is needed.
               </p>
-            </div>
+            ) : (
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium">Claim Link</label>
+                <div className="flex gap-1.5">
+                  <Input
+                    readOnly
+                    value={result.claim_url ?? ''}
+                    className="h-8 text-xs font-mono"
+                  />
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-8 shrink-0"
+                    onClick={handleCopyClaimUrl}
+                  >
+                    {claimUrlCopied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                  </Button>
+                </div>
+                <p className="text-[10px] text-muted-foreground">
+                  Send this link to the parent via Zendesk reply. The minor uses it to set their email and password.
+                </p>
+              </div>
+            )}
 
             <Button variant="outline" className="w-full h-8 text-xs" onClick={handleClose}>
               Done

--- a/src/hooks/useAdminApi.ts
+++ b/src/hooks/useAdminApi.ts
@@ -162,8 +162,8 @@ export function useAdminApi() {
       adminApi.getAgeReviewConfig(apiUrl),
     updateAgeReviewConfig: (config: Partial<adminApi.AgeReviewConfig>) =>
       adminApi.updateAgeReviewConfig(apiUrl, config),
-    createMinorAccount: (username: string, displayName?: string, zendeskTicketId?: number) =>
-      adminApi.createMinorAccount(apiUrl, username, displayName, zendeskTicketId),
+    createMinorAccount: (username: string, displayName?: string, zendeskTicketId?: number, provisioningOperationId?: string) =>
+      adminApi.createMinorAccount(apiUrl, username, displayName, zendeskTicketId, provisioningOperationId),
 
   }), [apiUrl, relayUrl]);
 

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -1269,8 +1269,9 @@ export async function updateAgeReviewCase(
 export interface CreateMinorAccountResponse {
   success: boolean;
   pubkey?: string;
-  claim_url?: string;
+  claim_url?: string | null;
   expires_at?: string;
+  account_state?: 'unclaimed' | 'claimed';
   case_id?: string;
   provisioning_operation_id?: string;
   replayed?: boolean;

--- a/src/lib/adminApi.ts
+++ b/src/lib/adminApi.ts
@@ -1272,6 +1272,8 @@ export interface CreateMinorAccountResponse {
   claim_url?: string;
   expires_at?: string;
   case_id?: string;
+  provisioning_operation_id?: string;
+  replayed?: boolean;
   error?: string;
 }
 
@@ -1280,10 +1282,12 @@ export async function createMinorAccount(
   username: string,
   displayName?: string,
   zendeskTicketId?: number,
+  provisioningOperationId?: string,
 ): Promise<CreateMinorAccountResponse> {
   const body: Record<string, unknown> = { username };
   if (displayName != null) body.display_name = displayName;
   if (zendeskTicketId != null) body.zendesk_ticket_id = zendeskTicketId;
+  if (provisioningOperationId != null) body.provisioning_operation_id = provisioningOperationId;
   return apiRequest<CreateMinorAccountResponse>(apiUrl, '/api/age-review/create-minor-account', 'POST', body);
 }
 

--- a/worker/migrations/0012_protected_minor_registry.sql
+++ b/worker/migrations/0012_protected_minor_registry.sql
@@ -1,0 +1,47 @@
+-- Parity copy only: production schema is applied by ensureSchema().
+CREATE TABLE IF NOT EXISTS protected_minor_subjects (
+  subject_id TEXT PRIMARY KEY,
+  source_case_id TEXT UNIQUE,
+  classification_state TEXT NOT NULL CHECK (classification_state IN ('active', 'cleared')),
+  classified_at TEXT NOT NULL,
+  cleared_at TEXT,
+  cleared_by TEXT,
+  clear_reason TEXT,
+  CHECK ((classification_state = 'active' AND cleared_at IS NULL AND cleared_by IS NULL AND clear_reason IS NULL)
+    OR (classification_state = 'cleared' AND cleared_at IS NOT NULL AND clear_reason IS NOT NULL))
+);
+CREATE TABLE IF NOT EXISTS protected_minor_account_bindings (
+  id TEXT PRIMARY KEY,
+  subject_id TEXT NOT NULL,
+  pubkey TEXT NOT NULL CHECK (length(pubkey) = 64 AND pubkey = lower(pubkey)),
+  bound_at TEXT NOT NULL,
+  unbound_at TEXT,
+  deletion_attempt_id TEXT UNIQUE,
+  FOREIGN KEY (subject_id) REFERENCES protected_minor_subjects(subject_id)
+);
+CREATE TABLE IF NOT EXISTS protected_minor_provisioning_operations (
+  provisioning_operation_id TEXT PRIMARY KEY,
+  subject_id TEXT,
+  kind TEXT NOT NULL CHECK (kind IN ('onboarding', 'replacement')),
+  request_fingerprint TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN ('pending', 'complete', 'failed')),
+  result_pubkey TEXT CHECK (result_pubkey IS NULL OR (length(result_pubkey) = 64 AND result_pubkey = lower(result_pubkey))),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (subject_id) REFERENCES protected_minor_subjects(subject_id),
+  CHECK ((state = 'complete' AND result_pubkey IS NOT NULL AND subject_id IS NOT NULL) OR state != 'complete')
+);
+CREATE TABLE IF NOT EXISTS protected_minor_projection_jobs (
+  subject_id TEXT PRIMARY KEY,
+  pubkey TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN ('pending', 'complete')),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (subject_id) REFERENCES protected_minor_subjects(subject_id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_protected_minor_active_subject_binding ON protected_minor_account_bindings(subject_id) WHERE unbound_at IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_protected_minor_active_pubkey_binding ON protected_minor_account_bindings(pubkey) WHERE unbound_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_protected_minor_binding_history ON protected_minor_account_bindings(subject_id, bound_at);
+CREATE INDEX IF NOT EXISTS idx_protected_minor_operation_subject ON protected_minor_provisioning_operations(subject_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_protected_minor_projection_pending ON protected_minor_projection_jobs(state, created_at);

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -1327,7 +1327,7 @@ describe('checkAgeReviewDeadlines', () => {
     }));
 
     const closeCalls = db.prepare.mock.calls.filter(
-      (c: string[]) => c[0]?.includes('denied_closed')
+      (c: string[]) => c[0]?.includes('UPDATE age_review_cases') && c[0]?.includes('denied_closed')
     );
     expect(closeCalls.length).toBe(1);
 
@@ -1374,7 +1374,7 @@ describe('checkAgeReviewDeadlines', () => {
     await checkAgeReviewDeadlines(makeEnv(db));
 
     const closeCalls = db.prepare.mock.calls.filter(
-      (c: string[]) => c[0]?.includes('denied_closed')
+      (c: string[]) => c[0]?.includes('UPDATE age_review_cases') && c[0]?.includes('denied_closed')
     );
     expect(closeCalls.length).toBe(1);
     expect(banUser).toHaveBeenCalledOnce();

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -2932,7 +2932,7 @@ describe('handleCreateMinorAccount', () => {
   }
 
   function makeMinorDb(runImpl?: () => Promise<unknown>) {
-    const execute = runImpl ?? (() => Promise.resolve({ success: true }));
+    const execute = runImpl ?? (() => Promise.resolve({ success: true, meta: { changes: 1 } }));
     return {
       prepare: vi.fn().mockImplementation(() => {
         const bound = { run: vi.fn().mockImplementation(execute), first: vi.fn().mockResolvedValue(null) };

--- a/worker/src/age-review.test.ts
+++ b/worker/src/age-review.test.ts
@@ -2932,12 +2932,13 @@ describe('handleCreateMinorAccount', () => {
   }
 
   function makeMinorDb(runImpl?: () => Promise<unknown>) {
+    const execute = runImpl ?? (() => Promise.resolve({ success: true }));
     return {
-      prepare: vi.fn().mockReturnValue({
-        bind: vi.fn().mockReturnValue({
-          run: vi.fn().mockImplementation(runImpl ?? (() => Promise.resolve({ success: true }))),
-        }),
+      prepare: vi.fn().mockImplementation(() => {
+        const bound = { run: vi.fn().mockImplementation(execute), first: vi.fn().mockResolvedValue(null) };
+        return { bind: vi.fn().mockReturnValue(bound), run: vi.fn().mockImplementation(execute), first: vi.fn().mockResolvedValue(null) };
       }),
+      batch: vi.fn().mockImplementation(async () => { await execute(); return [{ meta: { changes: 1 } }]; }),
     } as unknown as D1Database;
   }
 
@@ -3114,7 +3115,7 @@ describe('handleCreateMinorAccount', () => {
   it('strips empty display_name before calling Keycast', async () => {
     const db = makeMinorDb();
     await handleCreateMinorAccount(makeRequest({ username: 'test', display_name: '  ' }), makeEnv(db), corsHeaders);
-    expect(mockCreateMinorAccount).toHaveBeenCalledWith('test', undefined, expect.anything());
+    expect(mockCreateMinorAccount).toHaveBeenCalledWith('test', undefined, expect.anything(), expect.any(String));
   });
 
   it('rejects non-integer zendesk_ticket_id', async () => {
@@ -3128,7 +3129,7 @@ describe('handleCreateMinorAccount', () => {
     expect(mockCreateMinorAccount).not.toHaveBeenCalled();
   });
 
-  it('returns 500 without claim_url when D1 insert fails after Keycast success', async () => {
+  it('returns 500 without calling Keycast when the operation ledger write fails', async () => {
     const db = makeMinorDb(() => Promise.reject(new Error('D1 write failed')));
     const res = await handleCreateMinorAccount(makeRequest({ username: 'testuser' }), makeEnv(db), corsHeaders);
     const body = await res.json() as Record<string, unknown>;
@@ -3136,8 +3137,9 @@ describe('handleCreateMinorAccount', () => {
     expect(res.status).toBe(500);
     expect(body.success).toBe(false);
     expect(body.claim_url).toBeUndefined();
-    expect(body.pubkey).toBe('a'.repeat(64));
-    expect(body.error).toContain('audit record failed');
+    expect(body.pubkey).toBeUndefined();
+    expect(body.error).toContain('no account was created');
+    expect(mockCreateMinorAccount).not.toHaveBeenCalled();
   });
 
   it('maps Keycast 409 to 409 status', async () => {
@@ -3162,15 +3164,7 @@ describe('handleCreateMinorAccount', () => {
   });
 
   it('persists claim_link_expires_at from the Keycast response', async () => {
-    const bindArgs: unknown[] = [];
-    const db = {
-      prepare: vi.fn().mockReturnValue({
-        bind: vi.fn().mockImplementation((...args: unknown[]) => {
-          bindArgs.push(...args);
-          return { run: vi.fn().mockResolvedValue({ success: true }) };
-        }),
-      }),
-    };
+    const db = makeMinorDb();
 
     const res = await handleCreateMinorAccount(
       makeRequest({ username: 'testuser' }),
@@ -3181,6 +3175,11 @@ describe('handleCreateMinorAccount', () => {
     expect(res.status).toBe(200);
     // INSERT bind order: caseId, pubkey, claim_url, claim_link_expires_at, zendesk_ticket_id.
     // Assert positionally so this also guards the column/bind ordering.
+    const values = identityBinds(db).sql;
+    expect(values).toContain('claim_link_expires_at');
+    const prepareMock = db.prepare as ReturnType<typeof vi.fn>;
+    const insert = prepareMock.mock.calls.findIndex((call: unknown[]) => String(call[0]).includes('INSERT INTO age_review_cases'));
+    const bindArgs = prepareMock.mock.results[insert].value.bind.mock.calls[0];
     expect(bindArgs[2]).toBe('https://login.test/claim/abc');
     expect(bindArgs[3]).toBe('2026-06-15T00:00:00Z');
   });
@@ -3192,15 +3191,7 @@ describe('handleCreateMinorAccount', () => {
       claim_url: 'https://login.test/claim/abc',
     });
 
-    const bindArgs: unknown[] = [];
-    const db = {
-      prepare: vi.fn().mockReturnValue({
-        bind: vi.fn().mockImplementation((...args: unknown[]) => {
-          bindArgs.push(...args);
-          return { run: vi.fn().mockResolvedValue({ success: true }) };
-        }),
-      }),
-    };
+    const db = makeMinorDb();
 
     const res = await handleCreateMinorAccount(
       makeRequest({ username: 'testuser' }),
@@ -3211,6 +3202,9 @@ describe('handleCreateMinorAccount', () => {
     expect(res.status).toBe(200);
     // claim_url is present (binds at index 2), but expires_at is absent -> bound as null at index 3.
     // Assert positionally: toContain(null) would also match the null zendesk_ticket_id.
+    const prepareMock = db.prepare as ReturnType<typeof vi.fn>;
+    const insert = prepareMock.mock.calls.findIndex((call: unknown[]) => String(call[0]).includes('INSERT INTO age_review_cases'));
+    const bindArgs = prepareMock.mock.results[insert].value.bind.mock.calls[0];
     expect(bindArgs[2]).toBe('https://login.test/claim/abc');
     expect(bindArgs[3]).toBeNull();
   });

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -23,6 +23,7 @@ import type { BulkAction } from '../../shared/bulk-moderation';
 import { suspendUser, unsuspendUser, banUser, clearVerifiedMinor, createMinorAccount, type KeycastEnv } from './keycast-client';
 import { suspendPubkey, unsuspendPubkey, banPubkey, type SecretStoreSecret } from './nip86';
 import { buildAgeReviewIdentityBlock, buildClaimedParentName, toNpub } from './report-note';
+import { clearSubject, fingerprintProvisioningRequest, markProjectionComplete, pendingProjectionJobs } from './protected-minors';
 
 /**
  * The identity a case captured at creation, as stored on `age_review_cases`.
@@ -442,6 +443,8 @@ export async function handleUpdateAgeReviewCase(
   let keycastError: string | undefined;
   let keycastMinorClear: EnforcementLegStatus = 'not_attempted';
   let keycastMinorClearError: string | undefined;
+  let subjectClear: EnforcementLegStatus = 'not_attempted';
+  let subjectClearError: string | undefined;
 
   // Shared wrapper for the relay and Keycast legs (both resolve to
   // { success, error }). Returns not_attempted when no call applies.
@@ -531,12 +534,19 @@ export async function handleUpdateAgeReviewCase(
     // moderator_pubkey is unvalidated on write). A malformed/absent actor is
     // dropped server-side in clearVerifiedMinor → keycast logs-only.
     const minorClearActor = (updated?.moderator_pubkey ?? existing.moderator_pubkey) ?? undefined;
+    const subjectClearLeg = await runStatusLeg('Protected subject clear', () =>
+      deniedCase && env.DB
+        ? clearSubject(env.DB, existing.pubkey, minorClearActor, 'age_review_denied')
+        : undefined);
+    subjectClear = subjectClearLeg.status;
+    subjectClearError = subjectClearLeg.error;
     const minorClearLeg = await runStatusLeg('Keycast verified_minor clear', () =>
-      deniedCase
+      deniedCase && subjectClear !== 'failed'
         ? clearVerifiedMinor(existing.pubkey, minorClearActor, 'age_review_denied', env)
         : undefined);
     keycastMinorClear = minorClearLeg.status;
     keycastMinorClearError = minorClearLeg.error;
+    if (deniedCase && keycastMinorClear === 'ok' && env.DB) await markProjectionComplete(env.DB, existing.pubkey);
   }
 
   // A failed critical leg is reported (success:false, HTTP 207) so the
@@ -551,10 +561,10 @@ export async function handleUpdateAgeReviewCase(
   }
   const enforcement: AgeReviewEnforcement = {
     relay, relayError, bulk, bulkError, keycast, keycastError,
-    keycastMinorClear, keycastMinorClearError,
+    keycastMinorClear, keycastMinorClearError, subjectClear, subjectClearError,
   };
   const enforcementComplete = relay !== 'failed' && bulk !== 'failed' && keycast !== 'failed'
-    && keycastMinorClear !== 'failed';
+    && keycastMinorClear !== 'failed' && subjectClear !== 'failed';
   const response: AgeReviewCaseResponse = {
     success: enforcementComplete,
     case: updated,
@@ -577,7 +587,7 @@ export async function handleCreateMinorAccount(
 ): Promise<Response> {
   if (!env.DB) return json({ success: false, error: 'Database not configured' }, 500, corsHeaders);
 
-  let body: { username?: string; display_name?: string; zendesk_ticket_id?: number };
+  let body: { username?: string; display_name?: string; zendesk_ticket_id?: number; provisioning_operation_id?: string };
   try {
     body = await request.json();
   } catch {
@@ -597,6 +607,10 @@ export async function handleCreateMinorAccount(
     return json({ success: false, error: 'display_name must be a string' }, 400, corsHeaders);
   }
   const displayName = body.display_name?.trim() || undefined;
+  const provisioningOperationId = body.provisioning_operation_id ?? crypto.randomUUID();
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(provisioningOperationId)) {
+    return json({ success: false, error: 'provisioning_operation_id must be a lowercase UUID' }, 400, corsHeaders);
+  }
 
   if (body.zendesk_ticket_id !== undefined && body.zendesk_ticket_id !== null) {
     if (typeof body.zendesk_ticket_id !== 'number' || !Number.isInteger(body.zendesk_ticket_id) || body.zendesk_ticket_id <= 0) {
@@ -604,15 +618,45 @@ export async function handleCreateMinorAccount(
     }
   }
 
-  const result = await createMinorAccount(username, displayName, env);
-  if (!result.success || !result.pubkey || !result.claim_url) {
+  const requestFingerprint = await fingerprintProvisioningRequest(username, displayName);
+  const existingOperation = await env.DB.prepare(`SELECT request_fingerprint, state, subject_id, result_pubkey
+    FROM protected_minor_provisioning_operations WHERE provisioning_operation_id = ?`).bind(provisioningOperationId)
+    .first<{ request_fingerprint: string; state: string; subject_id: string | null; result_pubkey: string | null }>();
+  if (existingOperation && existingOperation.request_fingerprint !== requestFingerprint) {
+    return json({ success: false, code: 'provisioning_operation_conflict', error: 'Provisioning operation conflicts with its original request' }, 409, corsHeaders);
+  }
+  if (!existingOperation) {
+    const now = new Date().toISOString();
+    try {
+      await env.DB.prepare(`INSERT INTO protected_minor_provisioning_operations
+        (provisioning_operation_id, subject_id, kind, request_fingerprint, state, created_at, updated_at)
+        VALUES (?, NULL, 'onboarding', ?, 'pending', ?, ?)`)
+        .bind(provisioningOperationId, requestFingerprint, now, now).run();
+    } catch {
+      return json({ success: false, error: 'Could not persist provisioning operation; no account was created.' }, 500, corsHeaders);
+    }
+  }
+
+  const result = await createMinorAccount(username, displayName, env, provisioningOperationId);
+  if (!result.success || !result.pubkey || (result.account_state !== 'claimed' && !result.claim_url)) {
     const is409 = result.error?.startsWith('409:');
     const is4xx = result.error?.match(/^4\d{2}:/);
     const status = is409 ? 409 : is4xx ? 400 : 502;
-    return json({ success: false, error: result.error ?? 'Keycast account creation failed' }, status, corsHeaders);
+    return json({ success: false, error: result.error ?? 'Keycast account creation failed', provisioning_operation_id: provisioningOperationId }, status, corsHeaders);
+  }
+
+  if (existingOperation?.state === 'complete') {
+    if (existingOperation.result_pubkey !== result.pubkey || !existingOperation.subject_id) {
+      return json({ success: false, code: 'provisioning_result_conflict', error: 'Provisioning replay returned a conflicting result' }, 409, corsHeaders);
+    }
+    const prior = await env.DB.prepare(`SELECT source_case_id FROM protected_minor_subjects WHERE subject_id = ?`)
+      .bind(existingOperation.subject_id).first<{ source_case_id: string }>();
+    return json({ success: true, pubkey: result.pubkey, claim_url: result.claim_url, expires_at: result.expires_at,
+      case_id: prior?.source_case_id, provisioning_operation_id: provisioningOperationId, replayed: true }, 200, corsHeaders);
   }
 
   const caseId = crypto.randomUUID();
+  const subjectId = crypto.randomUUID();
   try {
     // Identity is known up front on this path -- the operator supplied it -- so
     // there is nothing to look up. Storing it keeps this case as identifiable as
@@ -642,7 +686,8 @@ export async function handleCreateMinorAccount(
     //    this path and resolveHandle already falls back to it, so it costs
     //    nothing and reads correctly wherever the block is rendered.
     const nip05 = env.NIP05_DOMAIN ? `_@${username}.${env.NIP05_DOMAIN}` : null;
-    await env.DB.prepare(`
+    const now = new Date().toISOString();
+    await env.DB.batch([env.DB.prepare(`
       INSERT INTO age_review_cases
       (id, pubkey, suspected_age_band, state, allowed_resolution, resolution_note, created_via, claim_link_url, claim_link_expires_at, zendesk_ticket_id,
        account_name, account_nip05, account_vine_username, identity_captured_at)
@@ -656,13 +701,22 @@ export async function handleCreateMinorAccount(
       displayName ?? username,
       nip05,
       username,
-      new Date().toISOString(),
-    ).run();
+      now,
+    ), env.DB.prepare(`INSERT INTO protected_minor_subjects
+      (subject_id, source_case_id, classification_state, classified_at) VALUES (?, ?, 'active', ?)`)
+      .bind(subjectId, caseId, now),
+    env.DB.prepare(`INSERT INTO protected_minor_account_bindings
+      (id, subject_id, pubkey, bound_at) VALUES (?, ?, ?, ?)`)
+      .bind(crypto.randomUUID(), subjectId, result.pubkey, now),
+    env.DB.prepare(`UPDATE protected_minor_provisioning_operations
+      SET subject_id = ?, state = 'complete', result_pubkey = ?, updated_at = ?
+      WHERE provisioning_operation_id = ? AND state = 'pending'`)
+      .bind(subjectId, result.pubkey, now, provisioningOperationId)]);
   } catch (err) {
     console.error(`[age-review] D1 audit record failed for minor account: pubkey=${result.pubkey}, case=${caseId}`, err);
     return json({
       success: false,
-      error: 'Account created in Keycast but audit record failed. Contact engineering to reconcile.',
+      error: `Account created in Keycast but registry persistence failed. Retry with provisioning operation ${provisioningOperationId}.`,
       pubkey: result.pubkey,
       case_id: caseId,
     }, 500, corsHeaders);
@@ -676,6 +730,7 @@ export async function handleCreateMinorAccount(
     claim_url: result.claim_url,
     expires_at: result.expires_at,
     case_id: caseId,
+    provisioning_operation_id: provisioningOperationId,
   }, 200, corsHeaders);
 }
 
@@ -1808,21 +1863,19 @@ export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> 
       console.error(`[age-review] Keycast ban failed for expired case ${row.id}:`, error);
     }
 
-    // Clear verified_minor on the auto-deny path too (#147): the interactive
-    // deny leg does this; the deadline-expiry auto-deny is the same terminal
-    // outcome with no moderator, so it must not leave a banned account with
-    // its protected-minor flag still set. System-initiated => no actor
-    // (keycast falls back to log-only audit). Idempotent no-op for a
-    // never-minor account. Best-effort, logged on failure.
-    try {
-      const clearResult = await clearVerifiedMinor(row.pubkey, undefined, 'age_review_expired', env);
-      if (clearResult.success) {
-        console.log(`[age-review] Keycast verified_minor clear sent for expired case ${row.id}`);
-      } else {
-        console.error(`[age-review] Keycast verified_minor clear failed for expired case ${row.id}: ${clearResult.error}`);
+    // Commit the durable classification clear first. That creates a projection
+    // job which this tick (or a later tick after an outage) converges in Keycast.
+    const durableClear = await clearSubject(env.DB, row.pubkey, undefined, 'age_review_expired');
+    if (!durableClear.success) {
+      console.error(`[age-review] Protected subject clear failed for expired case ${row.id}: ${durableClear.error}`);
+    } else {
+      try {
+        const clearResult = await clearVerifiedMinor(row.pubkey, undefined, 'age_review_expired', env);
+        if (clearResult.success) await markProjectionComplete(env.DB, row.pubkey);
+        else console.error(`[age-review] Keycast verified_minor clear failed for expired case ${row.id}: ${clearResult.error}`);
+      } catch (error) {
+        console.error(`[age-review] Keycast verified_minor clear failed for expired case ${row.id}:`, error);
       }
-    } catch (error) {
-      console.error(`[age-review] Keycast verified_minor clear failed for expired case ${row.id}:`, error);
     }
 
     // purge the user's events at the relay (one-way) -- the case is closed
@@ -1836,6 +1889,25 @@ export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> 
       }
     } catch (error) {
       console.error(`[age-review] Relay banpubkey failed for expired case ${row.id}:`, error);
+    }
+  }
+
+  // Durable retry boundary for both interactive and scheduled clears. A case
+  // is already terminal when an external Keycast call fails, so the projection
+  // job—not the case query—is what makes the next cron retry it.
+  let projectionJobs: Array<{ pubkey: string; reason: string }> = [];
+  try {
+    projectionJobs = await pendingProjectionJobs(env.DB);
+  } catch (error) {
+    console.error('[age-review] Failed to load protected-minor projection retries:', error);
+  }
+  for (const job of projectionJobs) {
+    try {
+      const result = await clearVerifiedMinor(job.pubkey, undefined, job.reason as 'age_review_denied' | 'age_review_expired', env);
+      if (result.success) await markProjectionComplete(env.DB, job.pubkey);
+      else console.error(`[age-review] Keycast protected-minor projection retry failed for ${job.pubkey}: ${result.error}`);
+    } catch (error) {
+      console.error(`[age-review] Keycast protected-minor projection retry failed for ${job.pubkey}:`, error);
     }
   }
 

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -23,7 +23,15 @@ import type { BulkAction } from '../../shared/bulk-moderation';
 import { suspendUser, unsuspendUser, banUser, clearVerifiedMinor, createMinorAccount, type KeycastEnv } from './keycast-client';
 import { suspendPubkey, unsuspendPubkey, banPubkey, type SecretStoreSecret } from './nip86';
 import { buildAgeReviewIdentityBlock, buildClaimedParentName, toNpub } from './report-note';
-import { clearSubject, fingerprintProvisioningRequest, markProjectionComplete, pendingProjectionJobs } from './protected-minors';
+import {
+  clearSubject,
+  fingerprintProvisioningRequest,
+  markProjectionAttempt,
+  markProjectionComplete,
+  pendingProjectionJobs,
+  pendingSubjectClears,
+  UUID_RE,
+} from './protected-minors';
 
 /**
  * The identity a case captured at creation, as stored on `age_review_cases`.
@@ -626,7 +634,7 @@ export async function handleCreateMinorAccount(
   }
   const displayName = body.display_name?.trim() || undefined;
   const provisioningOperationId = body.provisioning_operation_id ?? crypto.randomUUID();
-  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(provisioningOperationId)) {
+  if (!UUID_RE.test(provisioningOperationId)) {
     return json({ success: false, error: 'provisioning_operation_id must be a lowercase UUID' }, 400, corsHeaders);
   }
 
@@ -1942,9 +1950,25 @@ export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> 
     }
   }
 
-  // Durable retry boundary for both interactive and scheduled clears. A case
-  // is already terminal when an external Keycast call fails, so the projection
-  // job—not the case query—is what makes the next cron retry it.
+  // A terminal denial is itself the durable retry source if the subject update
+  // failed before it could create a projection job.
+  let subjectClearRetries: Awaited<ReturnType<typeof pendingSubjectClears>> = [];
+  try {
+    subjectClearRetries = await pendingSubjectClears(env.DB);
+  } catch (error) {
+    console.error('[age-review] Failed to load protected-subject clear retries:', error);
+  }
+  for (const retry of subjectClearRetries) {
+    const result = await clearSubject(
+      env.DB, retry.pubkey, retry.clearedBy, retry.reason, retry.subjectId,
+    );
+    if (!result.success) {
+      console.error(`[age-review] Protected-subject clear retry failed for ${retry.pubkey}: ${result.error}`);
+    }
+  }
+
+  // Durable retry boundary for Keycast projection failures after the subject
+  // clear commits.
   let projectionJobs: Array<{ pubkey: string; reason: string }> = [];
   try {
     projectionJobs = await pendingProjectionJobs(env.DB);
@@ -1955,8 +1979,16 @@ export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> 
     try {
       const result = await clearVerifiedMinor(job.pubkey, undefined, job.reason as 'age_review_denied' | 'age_review_expired', env);
       if (result.success) await markProjectionComplete(env.DB, job.pubkey);
-      else console.error(`[age-review] Keycast protected-minor projection retry failed for ${job.pubkey}: ${result.error}`);
+      else {
+        await markProjectionAttempt(env.DB, job.pubkey);
+        console.error(`[age-review] Keycast protected-minor projection retry failed for ${job.pubkey}: ${result.error}`);
+      }
     } catch (error) {
+      try {
+        await markProjectionAttempt(env.DB, job.pubkey);
+      } catch (markError) {
+        console.error(`[age-review] Failed to rotate protected-minor projection retry ${job.pubkey}:`, markError);
+      }
       console.error(`[age-review] Keycast protected-minor projection retry failed for ${job.pubkey}:`, error);
     }
   }

--- a/worker/src/age-review.ts
+++ b/worker/src/age-review.ts
@@ -445,6 +445,7 @@ export async function handleUpdateAgeReviewCase(
   let keycastMinorClearError: string | undefined;
   let subjectClear: EnforcementLegStatus = 'not_attempted';
   let subjectClearError: string | undefined;
+  let minorProjectionPubkey = existing.pubkey;
 
   // Shared wrapper for the relay and Keycast legs (both resolve to
   // { success, error }). Returns not_attempted when no call applies.
@@ -534,19 +535,36 @@ export async function handleUpdateAgeReviewCase(
     // moderator_pubkey is unvalidated on write). A malformed/absent actor is
     // dropped server-side in clearVerifiedMinor → keycast logs-only.
     const minorClearActor = (updated?.moderator_pubkey ?? existing.moderator_pubkey) ?? undefined;
-    const subjectClearLeg = await runStatusLeg('Protected subject clear', () =>
-      deniedCase && env.DB
-        ? clearSubject(env.DB, existing.pubkey, minorClearActor, 'age_review_denied')
-        : undefined);
-    subjectClear = subjectClearLeg.status;
-    subjectClearError = subjectClearLeg.error;
+    if (deniedCase && env.DB) {
+      try {
+        const result = await clearSubject(env.DB, existing.pubkey, minorClearActor, 'age_review_denied');
+        subjectClear = result.success ? 'ok' : 'failed';
+        subjectClearError = result.error;
+        minorProjectionPubkey = result.projectionPubkey ?? existing.pubkey;
+        if (!result.success) {
+          console.error(`[age-review] Protected subject clear ${requestedState} failed for case ${caseId}: ${result.error}`);
+        }
+      } catch (error) {
+        subjectClear = 'failed';
+        subjectClearError = error instanceof Error ? error.message : String(error);
+        console.error(`[age-review] Protected subject clear action failed for case ${caseId}:`, error);
+      }
+    }
     const minorClearLeg = await runStatusLeg('Keycast verified_minor clear', () =>
       deniedCase && subjectClear !== 'failed'
-        ? clearVerifiedMinor(existing.pubkey, minorClearActor, 'age_review_denied', env)
+        ? clearVerifiedMinor(minorProjectionPubkey, minorClearActor, 'age_review_denied', env)
         : undefined);
     keycastMinorClear = minorClearLeg.status;
     keycastMinorClearError = minorClearLeg.error;
-    if (deniedCase && keycastMinorClear === 'ok' && env.DB) await markProjectionComplete(env.DB, existing.pubkey);
+    if (deniedCase && keycastMinorClear === 'ok' && env.DB) {
+      try {
+        await markProjectionComplete(env.DB, minorProjectionPubkey);
+      } catch (error) {
+        // The pending job remains a safe retry boundary after the projection
+        // itself succeeded, so do not turn an applied denial into a 500.
+        console.error(`[age-review] Failed to mark protected-minor projection complete for case ${caseId}:`, error);
+      }
+    }
   }
 
   // A failed critical leg is reported (success:false, HTTP 207) so the
@@ -618,11 +636,13 @@ export async function handleCreateMinorAccount(
     }
   }
 
-  const requestFingerprint = await fingerprintProvisioningRequest(username, displayName);
-  const existingOperation = await env.DB.prepare(`SELECT request_fingerprint, state, subject_id, result_pubkey
+  const requestFingerprint = await fingerprintProvisioningRequest({
+    kind: 'onboarding', username, displayName, zendeskTicketId: body.zendesk_ticket_id,
+  });
+  let existingOperation = await env.DB.prepare(`SELECT kind, request_fingerprint, state, subject_id, result_pubkey
     FROM protected_minor_provisioning_operations WHERE provisioning_operation_id = ?`).bind(provisioningOperationId)
-    .first<{ request_fingerprint: string; state: string; subject_id: string | null; result_pubkey: string | null }>();
-  if (existingOperation && existingOperation.request_fingerprint !== requestFingerprint) {
+    .first<{ kind: string; request_fingerprint: string; state: string; subject_id: string | null; result_pubkey: string | null }>();
+  if (existingOperation && (existingOperation.kind !== 'onboarding' || existingOperation.request_fingerprint !== requestFingerprint)) {
     return json({ success: false, code: 'provisioning_operation_conflict', error: 'Provisioning operation conflicts with its original request' }, 409, corsHeaders);
   }
   if (!existingOperation) {
@@ -645,6 +665,32 @@ export async function handleCreateMinorAccount(
     return json({ success: false, error: result.error ?? 'Keycast account creation failed', provisioning_operation_id: provisioningOperationId }, status, corsHeaders);
   }
 
+  if (existingOperation?.result_pubkey && existingOperation.result_pubkey !== result.pubkey) {
+    return json({ success: false, code: 'provisioning_result_conflict', error: 'Provisioning replay returned a conflicting result' }, 409, corsHeaders);
+  }
+  if (existingOperation?.state !== 'complete') {
+    const observedAt = new Date().toISOString();
+    const observed = await env.DB.prepare(`UPDATE protected_minor_provisioning_operations
+      SET result_pubkey = ?, updated_at = ?
+      WHERE provisioning_operation_id = ? AND kind = 'onboarding' AND state = 'pending'
+        AND (result_pubkey IS NULL OR result_pubkey = ?)`)
+      .bind(result.pubkey, observedAt, provisioningOperationId, result.pubkey).run();
+    if (observed.meta.changes !== 1) {
+      const current = await env.DB.prepare(`SELECT kind, request_fingerprint, state, subject_id, result_pubkey
+        FROM protected_minor_provisioning_operations WHERE provisioning_operation_id = ?`).bind(provisioningOperationId)
+        .first<{ kind: string; request_fingerprint: string; state: string; subject_id: string | null; result_pubkey: string | null }>();
+      if (current?.result_pubkey && current.result_pubkey !== result.pubkey) {
+        return json({ success: false, code: 'provisioning_result_conflict', error: 'Provisioning replay returned a conflicting result' }, 409, corsHeaders);
+      }
+      if (!current || current.kind !== 'onboarding') {
+        return json({ success: false, error: 'Could not persist provisioning result. Retry with the same operation ID.', provisioning_operation_id: provisioningOperationId }, 500, corsHeaders);
+      }
+      existingOperation = current;
+    } else if (existingOperation) {
+      existingOperation = { ...existingOperation, result_pubkey: result.pubkey };
+    }
+  }
+
   if (existingOperation?.state === 'complete') {
     if (existingOperation.result_pubkey !== result.pubkey || !existingOperation.subject_id) {
       return json({ success: false, code: 'provisioning_result_conflict', error: 'Provisioning replay returned a conflicting result' }, 409, corsHeaders);
@@ -652,7 +698,8 @@ export async function handleCreateMinorAccount(
     const prior = await env.DB.prepare(`SELECT source_case_id FROM protected_minor_subjects WHERE subject_id = ?`)
       .bind(existingOperation.subject_id).first<{ source_case_id: string }>();
     return json({ success: true, pubkey: result.pubkey, claim_url: result.claim_url, expires_at: result.expires_at,
-      case_id: prior?.source_case_id, provisioning_operation_id: provisioningOperationId, replayed: true }, 200, corsHeaders);
+      account_state: result.account_state, case_id: prior?.source_case_id,
+      provisioning_operation_id: provisioningOperationId, replayed: true }, 200, corsHeaders);
   }
 
   const caseId = crypto.randomUUID();
@@ -719,6 +766,7 @@ export async function handleCreateMinorAccount(
       error: `Account created in Keycast but registry persistence failed. Retry with provisioning operation ${provisioningOperationId}.`,
       pubkey: result.pubkey,
       case_id: caseId,
+      provisioning_operation_id: provisioningOperationId,
     }, 500, corsHeaders);
   }
 
@@ -729,6 +777,7 @@ export async function handleCreateMinorAccount(
     pubkey: result.pubkey,
     claim_url: result.claim_url,
     expires_at: result.expires_at,
+    account_state: result.account_state,
     case_id: caseId,
     provisioning_operation_id: provisioningOperationId,
   }, 200, corsHeaders);
@@ -1870,8 +1919,9 @@ export async function checkAgeReviewDeadlines(env: AgeReviewEnv): Promise<void> 
       console.error(`[age-review] Protected subject clear failed for expired case ${row.id}: ${durableClear.error}`);
     } else {
       try {
-        const clearResult = await clearVerifiedMinor(row.pubkey, undefined, 'age_review_expired', env);
-        if (clearResult.success) await markProjectionComplete(env.DB, row.pubkey);
+        const projectionPubkey = durableClear.projectionPubkey ?? row.pubkey;
+        const clearResult = await clearVerifiedMinor(projectionPubkey, undefined, 'age_review_expired', env);
+        if (clearResult.success) await markProjectionComplete(env.DB, projectionPubkey);
         else console.error(`[age-review] Keycast verified_minor clear failed for expired case ${row.id}: ${clearResult.error}`);
       } catch (error) {
         console.error(`[age-review] Keycast verified_minor clear failed for expired case ${row.id}:`, error);

--- a/worker/src/db.ts
+++ b/worker/src/db.ts
@@ -1,6 +1,6 @@
 // ABOUTME: Shared D1 schema initialization for worker and Durable Objects
 // ABOUTME: Creates moderation_decisions, moderation_targets, age_review_cases,
-// ABOUTME: age_review_config, and zendesk_preauth_nonces DDL on a fresh D1
+// ABOUTME: age_review_config, protected-minor registry, and Zendesk DDL on a fresh D1
 
 /**
  * Ensure all moderation tables and indexes exist.
@@ -180,4 +180,73 @@ export async function ensureSchema(db: D1Database): Promise<void> {
   } catch {
     // Index already exists
   }
+
+  // Protected-minor classification belongs to a durable subject, not to the
+  // replaceable Keycast account row. Keep this DDL in sync with migration 0012;
+  // ensureSchema is the applied production schema path in this repository.
+  await db.prepare(`
+    CREATE TABLE IF NOT EXISTS protected_minor_subjects (
+      subject_id TEXT PRIMARY KEY,
+      source_case_id TEXT UNIQUE,
+      classification_state TEXT NOT NULL CHECK (classification_state IN ('active', 'cleared')),
+      classified_at TEXT NOT NULL,
+      cleared_at TEXT,
+      cleared_by TEXT,
+      clear_reason TEXT,
+      CHECK (
+        (classification_state = 'active' AND cleared_at IS NULL AND cleared_by IS NULL AND clear_reason IS NULL)
+        OR (classification_state = 'cleared' AND cleared_at IS NOT NULL AND clear_reason IS NOT NULL)
+      )
+    )
+  `).run();
+
+  await db.prepare(`
+    CREATE TABLE IF NOT EXISTS protected_minor_account_bindings (
+      id TEXT PRIMARY KEY,
+      subject_id TEXT NOT NULL,
+      pubkey TEXT NOT NULL CHECK (length(pubkey) = 64 AND pubkey = lower(pubkey)),
+      bound_at TEXT NOT NULL,
+      unbound_at TEXT,
+      deletion_attempt_id TEXT UNIQUE,
+      FOREIGN KEY (subject_id) REFERENCES protected_minor_subjects(subject_id)
+    )
+  `).run();
+
+  await db.prepare(`
+    CREATE TABLE IF NOT EXISTS protected_minor_provisioning_operations (
+      provisioning_operation_id TEXT PRIMARY KEY,
+      subject_id TEXT,
+      kind TEXT NOT NULL CHECK (kind IN ('onboarding', 'replacement')),
+      request_fingerprint TEXT NOT NULL,
+      state TEXT NOT NULL CHECK (state IN ('pending', 'complete', 'failed')),
+      result_pubkey TEXT CHECK (result_pubkey IS NULL OR (length(result_pubkey) = 64 AND result_pubkey = lower(result_pubkey))),
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (subject_id) REFERENCES protected_minor_subjects(subject_id),
+      CHECK ((state = 'complete' AND result_pubkey IS NOT NULL AND subject_id IS NOT NULL) OR state != 'complete')
+    )
+  `).run();
+
+  await db.prepare(`
+    CREATE TABLE IF NOT EXISTS protected_minor_projection_jobs (
+      subject_id TEXT PRIMARY KEY,
+      pubkey TEXT NOT NULL,
+      reason TEXT NOT NULL,
+      state TEXT NOT NULL CHECK (state IN ('pending', 'complete')),
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (subject_id) REFERENCES protected_minor_subjects(subject_id)
+    )
+  `).run();
+
+  await db.prepare(`CREATE UNIQUE INDEX IF NOT EXISTS idx_protected_minor_active_subject_binding
+    ON protected_minor_account_bindings(subject_id) WHERE unbound_at IS NULL`).run();
+  await db.prepare(`CREATE UNIQUE INDEX IF NOT EXISTS idx_protected_minor_active_pubkey_binding
+    ON protected_minor_account_bindings(pubkey) WHERE unbound_at IS NULL`).run();
+  await db.prepare(`CREATE INDEX IF NOT EXISTS idx_protected_minor_binding_history
+    ON protected_minor_account_bindings(subject_id, bound_at)`).run();
+  await db.prepare(`CREATE INDEX IF NOT EXISTS idx_protected_minor_operation_subject
+    ON protected_minor_provisioning_operations(subject_id, created_at)`).run();
+  await db.prepare(`CREATE INDEX IF NOT EXISTS idx_protected_minor_projection_pending
+    ON protected_minor_projection_jobs(state, created_at)`).run();
 }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -451,8 +451,7 @@ export default {
       // Dedicated service boundary: moderator/browser credentials must never
       // authorize protected-subject lifecycle calls.
       if (path.startsWith('/api/internal/protected-minors/')) {
-        if (env.DB) await ensureSchemaOnce(env.DB);
-        return handleProtectedMinorServiceRoute(request, path, env, corsHeaders);
+        return handleProtectedMinorServiceRoute(request, path, env, corsHeaders, ensureSchemaOnce);
       }
 
       // Mobile-facing endpoints: NIP-98 user auth, not admin auth

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -9,6 +9,7 @@ import {
   type SecretStoreSecret,
 } from './nip86';
 import { ensureSchema } from './db';
+import { backfillProtectedMinorSubjects, handleProtectedMinorServiceRoute } from './protected-minors';
 import { buildReportsFilter } from './reports-filter';
 import { generatePreAuthToken, verifyPreAuthToken, base64UrlEncode } from './zendesk-preauth';
 import { deriveFunnelcakeApiUrl, proxyFunnelcakeRequest } from './funnelcake-proxy';
@@ -103,6 +104,8 @@ interface Env extends KeycastEnv {
   // Secrets Store secret (MODERATION_TO_RELAY_ADMIN_KEY), accepted in addition to
   // ADMIN_API_KEY on that route so it can be rotated independently of other callers (#170).
   MOD_RELAY_ADMIN_KEY?: string | SecretStoreSecret;
+  PROTECTED_MINOR_SERVICE_TOKEN?: string | SecretStoreSecret;
+  PROTECTED_MINOR_REPLACEMENT_ENABLED?: string;
   // Slack webhook for age review deadline alerts
   SLACK_WEBHOOK_URL?: string;
   // Environment identifier for deep links (e.g., "production", "staging")
@@ -445,6 +448,13 @@ export default {
         return handleZendeskRoutes(request, path, env, corsHeaders);
       }
 
+      // Dedicated service boundary: moderator/browser credentials must never
+      // authorize protected-subject lifecycle calls.
+      if (path.startsWith('/api/internal/protected-minors/')) {
+        if (env.DB) await ensureSchemaOnce(env.DB);
+        return handleProtectedMinorServiceRoute(request, path, env, corsHeaders);
+      }
+
       // Mobile-facing endpoints: NIP-98 user auth, not admin auth
       if (path === '/v1/account/moderation-status' && request.method === 'GET') {
         const authResult = await verifyNip98Auth(request, request.url, getNip98AllowedHosts(env));
@@ -511,6 +521,13 @@ export default {
 
       if (path === '/api/publish' && request.method === 'POST') {
         return handlePublish(request, env, corsHeaders);
+      }
+
+      if (path === '/api/admin/protected-minors/backfill' && request.method === 'POST') {
+        if (!env.DB) return jsonResponse({ success: false, error: 'Database not configured' }, 500, corsHeaders);
+        await ensureSchemaOnce(env.DB);
+        const result = await backfillProtectedMinorSubjects(env.DB);
+        return jsonResponse({ success: true, ...result }, 200, corsHeaders);
       }
 
       if (path === '/api/moderate' && request.method === 'POST') {

--- a/worker/src/keycast-client.ts
+++ b/worker/src/keycast-client.ts
@@ -241,8 +241,10 @@ export async function getUserStatus(pubkey: string, env: KeycastEnv): Promise<Us
 export interface CreateMinorAccountResult {
   success: boolean;
   pubkey?: string;
-  claim_url?: string;
+  claim_url?: string | null;
   expires_at?: string;
+  account_state?: 'unclaimed' | 'claimed';
+  replayed?: boolean;
   error?: string;
 }
 
@@ -250,6 +252,7 @@ export async function createMinorAccount(
   username: string,
   displayName: string | undefined,
   env: KeycastEnv,
+  provisioningOperationId?: string,
 ): Promise<CreateMinorAccountResult> {
   if (!env.KEYCAST_URL || !env.KEYCAST_SERVICE_TOKEN) {
     return { success: false, error: 'not configured' };
@@ -261,6 +264,7 @@ export async function createMinorAccount(
   try {
     const body: Record<string, string> = { username };
     if (displayName !== undefined) body.display_name = displayName;
+    if (provisioningOperationId !== undefined) body.provisioning_operation_id = provisioningOperationId;
 
     const res = await fetch(`${env.KEYCAST_URL}/api/admin/create-minor-account`, {
       method: 'POST',
@@ -279,8 +283,10 @@ export async function createMinorAccount(
     return {
       success: true,
       pubkey: typeof data.pubkey === 'string' ? data.pubkey : undefined,
-      claim_url: typeof data.claim_url === 'string' ? data.claim_url : undefined,
+      claim_url: typeof data.claim_url === 'string' ? data.claim_url : data.claim_url === null ? null : undefined,
       expires_at: typeof data.expires_at === 'string' ? data.expires_at : undefined,
+      account_state: data.account_state === 'claimed' ? 'claimed' : data.account_state === 'unclaimed' ? 'unclaimed' : undefined,
+      replayed: data.replayed === true,
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/worker/src/protected-minors.test.ts
+++ b/worker/src/protected-minors.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { handleProtectedMinorServiceRoute } from './protected-minors';
 
 const path = '/api/internal/protected-minors/resolve';
@@ -23,6 +23,24 @@ describe('protected-minor service authentication', () => {
   it('resolves Secrets Store bindings and reaches the service boundary', async () => {
     const response = await handleProtectedMinorServiceRoute(request({ Authorization: 'Bearer service-token' }), path,
       { PROTECTED_MINOR_SERVICE_TOKEN: { get: async () => 'service-token' } }, cors);
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: 'service_unavailable' });
+  });
+
+  it('rejects unauthorized requests before preparing D1', async () => {
+    const prepareDb = vi.fn();
+    const response = await handleProtectedMinorServiceRoute(request(), path,
+      { DB: {} as D1Database, PROTECTED_MINOR_SERVICE_TOKEN: 'service-token' }, cors, prepareDb);
+    expect(response.status).toBe(401);
+    expect(prepareDb).not.toHaveBeenCalled();
+  });
+
+  it('keeps schema-preparation failures retryable', async () => {
+    const prepareDb = vi.fn().mockRejectedValue(new Error('D1 unavailable'));
+    const response = await handleProtectedMinorServiceRoute(
+      request({ Authorization: 'Bearer service-token' }), path,
+      { DB: {} as D1Database, PROTECTED_MINOR_SERVICE_TOKEN: 'service-token' }, cors, prepareDb,
+    );
     expect(response.status).toBe(503);
     expect(await response.json()).toEqual({ error: 'service_unavailable' });
   });

--- a/worker/src/protected-minors.test.ts
+++ b/worker/src/protected-minors.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { handleProtectedMinorServiceRoute } from './protected-minors';
+
+const path = '/api/internal/protected-minors/resolve';
+const cors = {};
+function request(headers?: HeadersInit) {
+  return new Request(`https://api.test${path}`, { method: 'POST', headers, body: JSON.stringify({ pubkey: 'a'.repeat(64) }) });
+}
+
+describe('protected-minor service authentication', () => {
+  it.each([
+    ['missing', undefined],
+    ['wrong bearer', { Authorization: 'Bearer wrong' }],
+    ['CF Access browser assertion', { 'Cf-Access-Jwt-Assertion': 'browser-session' }],
+    ['moderator admin key', { 'X-Admin-Key': 'admin-key' }],
+  ])('rejects %s credentials', async (_name, headers) => {
+    const response = await handleProtectedMinorServiceRoute(request(headers), path,
+      { PROTECTED_MINOR_SERVICE_TOKEN: 'service-token' }, cors);
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'unauthorized' });
+  });
+
+  it('resolves Secrets Store bindings and reaches the service boundary', async () => {
+    const response = await handleProtectedMinorServiceRoute(request({ Authorization: 'Bearer service-token' }), path,
+      { PROTECTED_MINOR_SERVICE_TOKEN: { get: async () => 'service-token' } }, cors);
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: 'service_unavailable' });
+  });
+});

--- a/worker/src/protected-minors.test.ts
+++ b/worker/src/protected-minors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { handleProtectedMinorServiceRoute } from './protected-minors';
+import { handleProtectedMinorServiceRoute, UUID_RE } from './protected-minors';
 
 const path = '/api/internal/protected-minors/resolve';
 const cors = {};
@@ -8,6 +8,12 @@ function request(headers?: HeadersInit) {
 }
 
 describe('protected-minor service authentication', () => {
+  it('accepts modern lowercase UUID versions without interpreting them', () => {
+    for (const version of ['6', '7', '8']) {
+      expect(UUID_RE.test(`018f1f4e-7b3a-${version}abc-8def-0123456789ab`)).toBe(true);
+    }
+    expect(UUID_RE.test('018f1f4e-7b3a-9abc-8def-0123456789ab')).toBe(false);
+  });
   it.each([
     ['missing', undefined],
     ['wrong bearer', { Authorization: 'Bearer wrong' }],

--- a/worker/src/protected-minors.ts
+++ b/worker/src/protected-minors.ts
@@ -1,0 +1,306 @@
+// ABOUTME: Durable protected-minor subject registry and service-only lifecycle operations.
+// ABOUTME: Keeps classification independent from replaceable Keycast account rows.
+
+import { createMinorAccount, type KeycastEnv } from './keycast-client';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const PUBKEY_RE = /^[0-9a-f]{64}$/;
+
+export interface ProtectedMinorEnv extends KeycastEnv {
+  DB?: D1Database;
+  PROTECTED_MINOR_SERVICE_TOKEN?: string | SecretStoreSecret;
+  PROTECTED_MINOR_REPLACEMENT_ENABLED?: string;
+}
+
+type SecretStoreSecret = { get(): Promise<string> };
+
+function json(body: unknown, status: number, corsHeaders: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store', ...corsHeaders },
+  });
+}
+
+async function resolveSecret(secret: string | SecretStoreSecret | undefined): Promise<string | undefined> {
+  if (typeof secret === 'string') return secret;
+  return secret?.get();
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+  const encoder = new TextEncoder();
+  const a = encoder.encode(left);
+  const b = encoder.encode(right);
+  let difference = a.length ^ b.length;
+  const length = Math.max(a.length, b.length);
+  for (let i = 0; i < length; i += 1) difference |= (a[i % Math.max(a.length, 1)] ?? 0) ^ (b[i % Math.max(b.length, 1)] ?? 0);
+  return difference === 0;
+}
+
+export async function verifyProtectedMinorService(request: Request, env: ProtectedMinorEnv): Promise<boolean> {
+  const authorization = request.headers.get('Authorization');
+  if (!authorization?.startsWith('Bearer ')) return false;
+  const supplied = authorization.slice('Bearer '.length);
+  const expected = await resolveSecret(env.PROTECTED_MINOR_SERVICE_TOKEN);
+  return Boolean(expected && supplied && constantTimeEqual(supplied, expected));
+}
+
+export async function createSubjectWithBinding(
+  db: D1Database,
+  sourceCaseId: string,
+  pubkey: string,
+  classifiedAt = new Date().toISOString(),
+): Promise<{ subjectId: string }> {
+  const subjectId = crypto.randomUUID();
+  await db.batch([
+    db.prepare(`INSERT INTO protected_minor_subjects
+      (subject_id, source_case_id, classification_state, classified_at)
+      VALUES (?, ?, 'active', ?)`)
+      .bind(subjectId, sourceCaseId, classifiedAt),
+    db.prepare(`INSERT INTO protected_minor_account_bindings
+      (id, subject_id, pubkey, bound_at) VALUES (?, ?, ?, ?)`)
+      .bind(crypto.randomUUID(), subjectId, pubkey, classifiedAt),
+  ]);
+  return { subjectId };
+}
+
+export async function clearSubject(
+  db: D1Database,
+  pubkey: string,
+  clearedBy: string | undefined,
+  reason: string,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const now = new Date().toISOString();
+    const subject = await db.prepare(`SELECT s.subject_id, s.classification_state
+      FROM protected_minor_subjects s JOIN protected_minor_account_bindings b ON b.subject_id = s.subject_id
+      WHERE b.pubkey = ? AND b.unbound_at IS NULL LIMIT 1`).bind(pubkey)
+      .first<{ subject_id: string; classification_state: string }>();
+    if (!subject || subject.classification_state === 'cleared') return { success: true };
+    await db.batch([
+      db.prepare(`UPDATE protected_minor_subjects
+        SET classification_state = 'cleared', cleared_at = ?, cleared_by = ?, clear_reason = ?
+        WHERE subject_id = ? AND classification_state = 'active'`)
+        .bind(now, clearedBy ?? null, reason, subject.subject_id),
+      db.prepare(`INSERT INTO protected_minor_projection_jobs
+        (subject_id, pubkey, reason, state, created_at, updated_at)
+        VALUES (?, ?, ?, 'pending', ?, ?)
+        ON CONFLICT(subject_id) DO NOTHING`)
+        .bind(subject.subject_id, pubkey, reason, now, now),
+    ]);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export async function markProjectionComplete(db: D1Database, pubkey: string): Promise<void> {
+  await db.prepare(`UPDATE protected_minor_projection_jobs SET state = 'complete', updated_at = ?
+    WHERE pubkey = ? AND state = 'pending'`).bind(new Date().toISOString(), pubkey).run();
+}
+
+export async function pendingProjectionJobs(db: D1Database): Promise<Array<{ pubkey: string; reason: string }>> {
+  const rows = await db.prepare(`SELECT pubkey, reason FROM protected_minor_projection_jobs
+    WHERE state = 'pending' ORDER BY created_at LIMIT 100`).all<{ pubkey: string; reason: string }>();
+  return rows.results.filter((row) => typeof row.pubkey === 'string' && typeof row.reason === 'string');
+}
+
+export async function resolveByPubkey(db: D1Database, pubkey: string): Promise<{ subjectRef: string } | null> {
+  const row = await db.prepare(`SELECT s.subject_id
+    FROM protected_minor_subjects s
+    JOIN protected_minor_account_bindings b ON b.subject_id = s.subject_id
+    WHERE b.pubkey = ? AND b.unbound_at IS NULL AND s.classification_state = 'active'
+    LIMIT 1`).bind(pubkey).first<{ subject_id: string }>();
+  return row ? { subjectRef: row.subject_id } : null;
+}
+
+export async function closeBinding(
+  db: D1Database,
+  subjectRef: string,
+  pubkey: string,
+  deletionAttemptId: string,
+): Promise<'closed' | 'idempotency_conflict' | 'stale_binding'> {
+  const replay = await db.prepare(`SELECT subject_id, pubkey FROM protected_minor_account_bindings
+    WHERE deletion_attempt_id = ?`).bind(deletionAttemptId).first<{ subject_id: string; pubkey: string }>();
+  if (replay) return replay.subject_id === subjectRef && replay.pubkey === pubkey ? 'closed' : 'idempotency_conflict';
+
+  const current = await db.prepare(`SELECT id FROM protected_minor_account_bindings
+    WHERE subject_id = ? AND pubkey = ? AND unbound_at IS NULL`).bind(subjectRef, pubkey).first<{ id: string }>();
+  if (!current) return 'stale_binding';
+
+  try {
+    const result = await db.prepare(`UPDATE protected_minor_account_bindings
+      SET unbound_at = ?, deletion_attempt_id = ?
+      WHERE id = ? AND unbound_at IS NULL`).bind(new Date().toISOString(), deletionAttemptId, current.id).run();
+    if (result.meta.changes === 1) return 'closed';
+    return 'stale_binding';
+  } catch {
+    const concurrent = await db.prepare(`SELECT subject_id, pubkey FROM protected_minor_account_bindings
+      WHERE deletion_attempt_id = ?`).bind(deletionAttemptId).first<{ subject_id: string; pubkey: string }>();
+    return concurrent?.subject_id === subjectRef && concurrent.pubkey === pubkey ? 'closed' : 'idempotency_conflict';
+  }
+}
+
+export async function backfillProtectedMinorSubjects(db: D1Database): Promise<{ created: number; skippedDuplicates: number }> {
+  const rows = await db.prepare(`SELECT id, pubkey, created_at FROM age_review_cases
+    WHERE created_via = 'minor_onboarding' ORDER BY created_at ASC, id ASC`).all<{
+      id: string; pubkey: string; created_at: string;
+    }>();
+  let created = 0;
+  let skippedDuplicates = 0;
+  const seenPubkeys = new Set<string>();
+  for (const row of rows.results) {
+    if (seenPubkeys.has(row.pubkey)) {
+      skippedDuplicates += 1;
+      continue;
+    }
+    seenPubkeys.add(row.pubkey);
+    const exists = await db.prepare(`SELECT subject_id FROM protected_minor_subjects WHERE source_case_id = ?`)
+      .bind(row.id).first();
+    if (exists) continue;
+    const ending = await db.prepare(`SELECT moderator_pubkey, resolution_note, updated_at
+      FROM age_review_cases WHERE pubkey = ? AND state = 'denied_closed'
+        AND datetime(updated_at) > datetime(?) ORDER BY datetime(updated_at) DESC, id DESC LIMIT 1`)
+      .bind(row.pubkey, row.created_at).first<{ moderator_pubkey: string | null; resolution_note: string | null; updated_at: string }>();
+    const subjectId = crypto.randomUUID();
+    const bindingId = crypto.randomUUID();
+    if (ending) {
+      await db.batch([
+        db.prepare(`INSERT INTO protected_minor_subjects
+          (subject_id, source_case_id, classification_state, classified_at, cleared_at, cleared_by, clear_reason)
+          VALUES (?, ?, 'cleared', ?, ?, ?, ?)`)
+          .bind(subjectId, row.id, row.created_at, ending.updated_at, ending.moderator_pubkey, ending.resolution_note || 'age_review_denied'),
+        db.prepare(`INSERT INTO protected_minor_account_bindings
+          (id, subject_id, pubkey, bound_at) VALUES (?, ?, ?, ?)`)
+          .bind(bindingId, subjectId, row.pubkey, row.created_at),
+      ]);
+    } else {
+      await db.batch([
+        db.prepare(`INSERT INTO protected_minor_subjects
+          (subject_id, source_case_id, classification_state, classified_at) VALUES (?, ?, 'active', ?)`)
+          .bind(subjectId, row.id, row.created_at),
+        db.prepare(`INSERT INTO protected_minor_account_bindings
+          (id, subject_id, pubkey, bound_at) VALUES (?, ?, ?, ?)`)
+          .bind(bindingId, subjectId, row.pubkey, row.created_at),
+      ]);
+    }
+    created += 1;
+  }
+  return { created, skippedDuplicates };
+}
+
+export async function fingerprintProvisioningRequest(username: string, displayName: string | undefined): Promise<string> {
+  const input = JSON.stringify({ username, display_name: displayName ?? null });
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+export async function startOrResumeReplacement(
+  env: ProtectedMinorEnv,
+  input: { subjectRef: string; provisioningOperationId: string; username: string; displayName?: string },
+): Promise<{ outcome: 'complete'; pubkey: string; claimUrl: string | null; expiresAt: string | null; accountState: 'unclaimed' | 'claimed'; replayed: boolean } | { outcome: 'conflict'; code: string } | { outcome: 'failed'; error: string }> {
+  if (!env.DB) return { outcome: 'failed', error: 'Database not configured' };
+  const fingerprint = await fingerprintProvisioningRequest(input.username, input.displayName);
+  const existing = await env.DB.prepare(`SELECT subject_id, request_fingerprint, state, result_pubkey
+    FROM protected_minor_provisioning_operations WHERE provisioning_operation_id = ?`)
+    .bind(input.provisioningOperationId).first<{ subject_id: string; request_fingerprint: string; state: string; result_pubkey: string | null }>();
+  if (existing && (existing.subject_id !== input.subjectRef || existing.request_fingerprint !== fingerprint)) {
+    return { outcome: 'conflict', code: 'provisioning_operation_conflict' };
+  }
+  const subject = await env.DB.prepare(`SELECT classification_state FROM protected_minor_subjects WHERE subject_id = ?`)
+    .bind(input.subjectRef).first<{ classification_state: string }>();
+  if (!subject || subject.classification_state !== 'active') return { outcome: 'conflict', code: 'classification_cleared' };
+  if (!existing) {
+    const now = new Date().toISOString();
+    await env.DB.prepare(`INSERT INTO protected_minor_provisioning_operations
+      (provisioning_operation_id, subject_id, kind, request_fingerprint, state, created_at, updated_at)
+      VALUES (?, ?, 'replacement', ?, 'pending', ?, ?)`)
+      .bind(input.provisioningOperationId, input.subjectRef, fingerprint, now, now).run();
+  }
+  const result = await createMinorAccount(input.username, input.displayName, env, input.provisioningOperationId);
+  if (!result.success || !result.pubkey || !PUBKEY_RE.test(result.pubkey)) {
+    return { outcome: 'failed', error: result.error ?? 'Provisioning failed' };
+  }
+  if (existing?.result_pubkey && existing.result_pubkey !== result.pubkey) {
+    return { outcome: 'conflict', code: 'provisioning_result_conflict' };
+  }
+  if (existing?.state === 'complete' && existing.result_pubkey === result.pubkey) {
+    const binding = await env.DB.prepare(`SELECT id FROM protected_minor_account_bindings
+      WHERE subject_id = ? AND pubkey = ? AND unbound_at IS NULL`).bind(input.subjectRef, result.pubkey).first();
+    if (!binding) return { outcome: 'failed', error: 'Replacement operation is missing its active binding' };
+    return {
+      outcome: 'complete', pubkey: result.pubkey, claimUrl: result.claim_url ?? null,
+      expiresAt: result.expires_at ?? null, accountState: result.account_state ?? 'unclaimed', replayed: true,
+    };
+  }
+  const now = new Date().toISOString();
+  try {
+    const batch = await env.DB.batch([
+      env.DB.prepare(`INSERT INTO protected_minor_account_bindings (id, subject_id, pubkey, bound_at)
+        SELECT ?, subject_id, ?, ? FROM protected_minor_subjects
+        WHERE subject_id = ? AND classification_state = 'active'
+          AND NOT EXISTS (SELECT 1 FROM protected_minor_account_bindings WHERE subject_id = ? AND unbound_at IS NULL)`)
+        .bind(crypto.randomUUID(), result.pubkey, now, input.subjectRef, input.subjectRef),
+      env.DB.prepare(`UPDATE protected_minor_provisioning_operations SET state = 'complete', result_pubkey = ?, updated_at = ?
+        WHERE provisioning_operation_id = ? AND subject_id IN
+          (SELECT subject_id FROM protected_minor_subjects WHERE classification_state = 'active')`)
+        .bind(result.pubkey, now, input.provisioningOperationId),
+    ]);
+    if (batch[1].meta.changes !== 1) return { outcome: 'conflict', code: 'classification_cleared' };
+  } catch {
+    const current = await env.DB.prepare(`SELECT classification_state FROM protected_minor_subjects WHERE subject_id = ?`)
+      .bind(input.subjectRef).first<{ classification_state: string }>();
+    if (current?.classification_state !== 'active') return { outcome: 'conflict', code: 'classification_cleared' };
+    return { outcome: 'failed', error: 'Replacement persistence failed' };
+  }
+  return {
+    outcome: 'complete', pubkey: result.pubkey, claimUrl: result.claim_url ?? null,
+    expiresAt: result.expires_at ?? null, accountState: result.account_state ?? 'unclaimed', replayed: result.replayed === true,
+  };
+}
+
+export async function handleProtectedMinorServiceRoute(
+  request: Request,
+  path: string,
+  env: ProtectedMinorEnv,
+  corsHeaders: Record<string, string>,
+): Promise<Response> {
+  if (!(await verifyProtectedMinorService(request, env))) return json({ error: 'unauthorized' }, 401, corsHeaders);
+  if (!env.DB) return json({ error: 'service_unavailable' }, 503, corsHeaders);
+  let body: Record<string, unknown>;
+  try { body = await request.json(); } catch { return json({ error: 'invalid_request' }, 400, corsHeaders); }
+  try {
+    if (path === '/api/internal/protected-minors/resolve' && request.method === 'POST') {
+      if (typeof body.pubkey !== 'string' || !PUBKEY_RE.test(body.pubkey)) return json({ error: 'invalid_request' }, 400, corsHeaders);
+      const resolved = await resolveByPubkey(env.DB, body.pubkey);
+      return resolved
+        ? json({ classification: 'active', subject_ref: resolved.subjectRef, binding_state: 'active' }, 200, corsHeaders)
+        : json({ classification: 'none' }, 200, corsHeaders);
+    }
+    if (path === '/api/internal/protected-minors/bindings/close' && request.method === 'POST') {
+      if (typeof body.subject_ref !== 'string' || !UUID_RE.test(body.subject_ref)
+        || typeof body.pubkey !== 'string' || !PUBKEY_RE.test(body.pubkey)
+        || typeof body.deletion_attempt_id !== 'string' || !UUID_RE.test(body.deletion_attempt_id)) {
+        return json({ error: 'invalid_request' }, 400, corsHeaders);
+      }
+      const outcome = await closeBinding(env.DB, body.subject_ref, body.pubkey, body.deletion_attempt_id);
+      return outcome === 'closed' ? json({ outcome: 'closed' }, 200, corsHeaders) : json({ code: outcome }, 409, corsHeaders);
+    }
+    if (path === '/api/internal/protected-minors/replacements' && request.method === 'POST') {
+      if (env.PROTECTED_MINOR_REPLACEMENT_ENABLED !== 'true') return json({ error: 'not_enabled' }, 503, corsHeaders);
+      if (typeof body.subject_ref !== 'string' || !UUID_RE.test(body.subject_ref)
+        || typeof body.provisioning_operation_id !== 'string' || !UUID_RE.test(body.provisioning_operation_id)
+        || typeof body.username !== 'string' || !/^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])$/.test(body.username)
+        || (body.display_name !== undefined && typeof body.display_name !== 'string')) return json({ error: 'invalid_request' }, 400, corsHeaders);
+      const result = await startOrResumeReplacement(env, {
+        subjectRef: body.subject_ref, provisioningOperationId: body.provisioning_operation_id,
+        username: body.username, displayName: body.display_name as string | undefined,
+      });
+      if (result.outcome === 'conflict') return json({ code: result.code }, 409, corsHeaders);
+      if (result.outcome === 'failed') return json({ error: 'service_unavailable' }, 503, corsHeaders);
+      return json({ outcome: 'complete', pubkey: result.pubkey, claim_url: result.claimUrl, expires_at: result.expiresAt, account_state: result.accountState, replayed: result.replayed }, 200, corsHeaders);
+    }
+    return json({ error: 'not_found' }, 404, corsHeaders);
+  } catch {
+    return json({ error: 'service_unavailable' }, 503, corsHeaders);
+  }
+}

--- a/worker/src/protected-minors.ts
+++ b/worker/src/protected-minors.ts
@@ -68,14 +68,19 @@ export async function clearSubject(
   pubkey: string,
   clearedBy: string | undefined,
   reason: string,
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; projectionPubkey?: string; error?: string }> {
   try {
     const now = new Date().toISOString();
-    const subject = await db.prepare(`SELECT s.subject_id, s.classification_state
-      FROM protected_minor_subjects s JOIN protected_minor_account_bindings b ON b.subject_id = s.subject_id
-      WHERE b.pubkey = ? AND b.unbound_at IS NULL LIMIT 1`).bind(pubkey)
-      .first<{ subject_id: string; classification_state: string }>();
-    if (!subject || subject.classification_state === 'cleared') return { success: true };
+    const subject = await db.prepare(`SELECT s.subject_id, s.classification_state,
+        (SELECT current.pubkey FROM protected_minor_account_bindings current
+          WHERE current.subject_id = s.subject_id AND current.unbound_at IS NULL LIMIT 1) AS projection_pubkey
+      FROM protected_minor_subjects s
+      JOIN protected_minor_account_bindings history ON history.subject_id = s.subject_id
+      WHERE history.pubkey = ?
+      ORDER BY (history.unbound_at IS NULL) DESC, datetime(history.bound_at) DESC, history.rowid DESC LIMIT 1`).bind(pubkey)
+      .first<{ subject_id: string; classification_state: string; projection_pubkey: string | null }>();
+    const projectionPubkey = subject?.projection_pubkey ?? pubkey;
+    if (!subject || subject.classification_state === 'cleared') return { success: true, projectionPubkey };
     await db.batch([
       db.prepare(`UPDATE protected_minor_subjects
         SET classification_state = 'cleared', cleared_at = ?, cleared_by = ?, clear_reason = ?
@@ -85,9 +90,9 @@ export async function clearSubject(
         (subject_id, pubkey, reason, state, created_at, updated_at)
         VALUES (?, ?, ?, 'pending', ?, ?)
         ON CONFLICT(subject_id) DO NOTHING`)
-        .bind(subject.subject_id, pubkey, reason, now, now),
+        .bind(subject.subject_id, projectionPubkey, reason, now, now),
     ]);
-    return { success: true };
+    return { success: true, projectionPubkey };
   } catch (error) {
     return { success: false, error: error instanceof Error ? error.message : String(error) };
   }
@@ -141,9 +146,9 @@ export async function closeBinding(
 }
 
 export async function backfillProtectedMinorSubjects(db: D1Database): Promise<{ created: number; skippedDuplicates: number }> {
-  const rows = await db.prepare(`SELECT id, pubkey, created_at FROM age_review_cases
-    WHERE created_via = 'minor_onboarding' ORDER BY created_at ASC, id ASC`).all<{
-      id: string; pubkey: string; created_at: string;
+  const rows = await db.prepare(`SELECT rowid AS source_rowid, id, pubkey, created_at FROM age_review_cases
+    WHERE created_via = 'minor_onboarding' ORDER BY datetime(created_at) ASC, rowid ASC`).all<{
+      source_rowid: number; id: string; pubkey: string; created_at: string;
     }>();
   let created = 0;
   let skippedDuplicates = 0;
@@ -159,8 +164,10 @@ export async function backfillProtectedMinorSubjects(db: D1Database): Promise<{ 
     if (exists) continue;
     const ending = await db.prepare(`SELECT moderator_pubkey, resolution_note, updated_at
       FROM age_review_cases WHERE pubkey = ? AND state = 'denied_closed'
-        AND datetime(updated_at) > datetime(?) ORDER BY datetime(updated_at) DESC, id DESC LIMIT 1`)
-      .bind(row.pubkey, row.created_at).first<{ moderator_pubkey: string | null; resolution_note: string | null; updated_at: string }>();
+        AND (datetime(updated_at) > datetime(?) OR (datetime(updated_at) = datetime(?) AND rowid > ?))
+        ORDER BY datetime(updated_at) DESC, rowid DESC LIMIT 1`)
+      .bind(row.pubkey, row.created_at, row.created_at, row.source_rowid)
+      .first<{ moderator_pubkey: string | null; resolution_note: string | null; updated_at: string }>();
     const subjectId = crypto.randomUUID();
     const bindingId = crypto.randomUUID();
     if (ending) {
@@ -188,9 +195,19 @@ export async function backfillProtectedMinorSubjects(db: D1Database): Promise<{ 
   return { created, skippedDuplicates };
 }
 
-export async function fingerprintProvisioningRequest(username: string, displayName: string | undefined): Promise<string> {
-  const input = JSON.stringify({ username, display_name: displayName ?? null });
-  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+export async function fingerprintProvisioningRequest(input: {
+  kind: 'onboarding' | 'replacement';
+  username: string;
+  displayName?: string;
+  zendeskTicketId?: number;
+}): Promise<string> {
+  const canonical = JSON.stringify({
+    kind: input.kind,
+    username: input.username,
+    display_name: input.displayName ?? null,
+    zendesk_ticket_id: input.zendeskTicketId ?? null,
+  });
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(canonical));
   return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
 }
 
@@ -199,16 +216,23 @@ export async function startOrResumeReplacement(
   input: { subjectRef: string; provisioningOperationId: string; username: string; displayName?: string },
 ): Promise<{ outcome: 'complete'; pubkey: string; claimUrl: string | null; expiresAt: string | null; accountState: 'unclaimed' | 'claimed'; replayed: boolean } | { outcome: 'conflict'; code: string } | { outcome: 'failed'; error: string }> {
   if (!env.DB) return { outcome: 'failed', error: 'Database not configured' };
-  const fingerprint = await fingerprintProvisioningRequest(input.username, input.displayName);
-  const existing = await env.DB.prepare(`SELECT subject_id, request_fingerprint, state, result_pubkey
+  const fingerprint = await fingerprintProvisioningRequest({
+    kind: 'replacement', username: input.username, displayName: input.displayName,
+  });
+  let existing = await env.DB.prepare(`SELECT subject_id, kind, request_fingerprint, state, result_pubkey
     FROM protected_minor_provisioning_operations WHERE provisioning_operation_id = ?`)
-    .bind(input.provisioningOperationId).first<{ subject_id: string; request_fingerprint: string; state: string; result_pubkey: string | null }>();
-  if (existing && (existing.subject_id !== input.subjectRef || existing.request_fingerprint !== fingerprint)) {
+    .bind(input.provisioningOperationId).first<{ subject_id: string; kind: string; request_fingerprint: string; state: string; result_pubkey: string | null }>();
+  if (existing && (existing.kind !== 'replacement' || existing.subject_id !== input.subjectRef || existing.request_fingerprint !== fingerprint)) {
     return { outcome: 'conflict', code: 'provisioning_operation_conflict' };
   }
   const subject = await env.DB.prepare(`SELECT classification_state FROM protected_minor_subjects WHERE subject_id = ?`)
     .bind(input.subjectRef).first<{ classification_state: string }>();
   if (!subject || subject.classification_state !== 'active') return { outcome: 'conflict', code: 'classification_cleared' };
+  if (existing?.state !== 'complete') {
+    const activeBinding = await env.DB.prepare(`SELECT id FROM protected_minor_account_bindings
+      WHERE subject_id = ? AND unbound_at IS NULL LIMIT 1`).bind(input.subjectRef).first();
+    if (activeBinding) return { outcome: 'conflict', code: 'stale_binding' };
+  }
   if (!existing) {
     const now = new Date().toISOString();
     await env.DB.prepare(`INSERT INTO protected_minor_provisioning_operations
@@ -217,11 +241,37 @@ export async function startOrResumeReplacement(
       .bind(input.provisioningOperationId, input.subjectRef, fingerprint, now, now).run();
   }
   const result = await createMinorAccount(input.username, input.displayName, env, input.provisioningOperationId);
-  if (!result.success || !result.pubkey || !PUBKEY_RE.test(result.pubkey)) {
+  if (!result.success || !result.pubkey || !PUBKEY_RE.test(result.pubkey)
+    || (result.account_state !== 'claimed' && result.account_state !== 'unclaimed')
+    || (result.account_state === 'claimed' && result.claim_url != null)
+    || (result.account_state === 'unclaimed' && (typeof result.claim_url !== 'string' || typeof result.expires_at !== 'string'))) {
     return { outcome: 'failed', error: result.error ?? 'Provisioning failed' };
   }
+  const accountState = result.account_state;
   if (existing?.result_pubkey && existing.result_pubkey !== result.pubkey) {
     return { outcome: 'conflict', code: 'provisioning_result_conflict' };
+  }
+  if (existing?.state !== 'complete') {
+    const observed = await env.DB.prepare(`UPDATE protected_minor_provisioning_operations
+      SET result_pubkey = ?, updated_at = ?
+      WHERE provisioning_operation_id = ? AND subject_id = ? AND kind = 'replacement' AND state = 'pending'
+        AND (result_pubkey IS NULL OR result_pubkey = ?)`)
+      .bind(result.pubkey, new Date().toISOString(), input.provisioningOperationId, input.subjectRef, result.pubkey).run();
+    if (observed.meta.changes !== 1) {
+      const current = await env.DB.prepare(`SELECT subject_id, kind, request_fingerprint, state, result_pubkey
+        FROM protected_minor_provisioning_operations WHERE provisioning_operation_id = ?`)
+        .bind(input.provisioningOperationId)
+        .first<{ subject_id: string; kind: string; request_fingerprint: string; state: string; result_pubkey: string | null }>();
+      if (current?.result_pubkey && current.result_pubkey !== result.pubkey) {
+        return { outcome: 'conflict', code: 'provisioning_result_conflict' };
+      }
+      if (!current || current.kind !== 'replacement' || current.subject_id !== input.subjectRef) {
+        return { outcome: 'failed', error: 'Replacement persistence failed' };
+      }
+      existing = current;
+    } else if (existing) {
+      existing = { ...existing, result_pubkey: result.pubkey };
+    }
   }
   if (existing?.state === 'complete' && existing.result_pubkey === result.pubkey) {
     const binding = await env.DB.prepare(`SELECT id FROM protected_minor_account_bindings
@@ -229,7 +279,7 @@ export async function startOrResumeReplacement(
     if (!binding) return { outcome: 'failed', error: 'Replacement operation is missing its active binding' };
     return {
       outcome: 'complete', pubkey: result.pubkey, claimUrl: result.claim_url ?? null,
-      expiresAt: result.expires_at ?? null, accountState: result.account_state ?? 'unclaimed', replayed: true,
+      expiresAt: result.expires_at ?? null, accountState, replayed: true,
     };
   }
   const now = new Date().toISOString();
@@ -241,20 +291,42 @@ export async function startOrResumeReplacement(
           AND NOT EXISTS (SELECT 1 FROM protected_minor_account_bindings WHERE subject_id = ? AND unbound_at IS NULL)`)
         .bind(crypto.randomUUID(), result.pubkey, now, input.subjectRef, input.subjectRef),
       env.DB.prepare(`UPDATE protected_minor_provisioning_operations SET state = 'complete', result_pubkey = ?, updated_at = ?
-        WHERE provisioning_operation_id = ? AND subject_id IN
-          (SELECT subject_id FROM protected_minor_subjects WHERE classification_state = 'active')`)
-        .bind(result.pubkey, now, input.provisioningOperationId),
+        WHERE provisioning_operation_id = ? AND subject_id = ? AND kind = 'replacement' AND state = 'pending'
+          AND subject_id IN (SELECT subject_id FROM protected_minor_subjects WHERE classification_state = 'active')
+          AND EXISTS (SELECT 1 FROM protected_minor_account_bindings
+            WHERE subject_id = ? AND pubkey = ? AND unbound_at IS NULL)`)
+        .bind(result.pubkey, now, input.provisioningOperationId, input.subjectRef, input.subjectRef, result.pubkey),
     ]);
-    if (batch[1].meta.changes !== 1) return { outcome: 'conflict', code: 'classification_cleared' };
+    if (batch[1].meta.changes !== 1) {
+      const current = await env.DB.prepare(`SELECT classification_state FROM protected_minor_subjects WHERE subject_id = ?`)
+        .bind(input.subjectRef).first<{ classification_state: string }>();
+      if (current?.classification_state !== 'active') return { outcome: 'conflict', code: 'classification_cleared' };
+      return { outcome: 'failed', error: 'Replacement persistence failed' };
+    }
   } catch {
     const current = await env.DB.prepare(`SELECT classification_state FROM protected_minor_subjects WHERE subject_id = ?`)
       .bind(input.subjectRef).first<{ classification_state: string }>();
     if (current?.classification_state !== 'active') return { outcome: 'conflict', code: 'classification_cleared' };
+    const completed = await env.DB.prepare(`SELECT state, result_pubkey FROM protected_minor_provisioning_operations
+      WHERE provisioning_operation_id = ? AND subject_id = ? AND kind = 'replacement'`)
+      .bind(input.provisioningOperationId, input.subjectRef)
+      .first<{ state: string; result_pubkey: string | null }>();
+    if (completed?.state === 'complete' && completed.result_pubkey === result.pubkey) {
+      const binding = await env.DB.prepare(`SELECT id FROM protected_minor_account_bindings
+        WHERE subject_id = ? AND pubkey = ? AND unbound_at IS NULL`)
+        .bind(input.subjectRef, result.pubkey).first();
+      if (binding) {
+        return {
+          outcome: 'complete', pubkey: result.pubkey, claimUrl: result.claim_url ?? null,
+          expiresAt: result.expires_at ?? null, accountState, replayed: true,
+        };
+      }
+    }
     return { outcome: 'failed', error: 'Replacement persistence failed' };
   }
   return {
     outcome: 'complete', pubkey: result.pubkey, claimUrl: result.claim_url ?? null,
-    expiresAt: result.expires_at ?? null, accountState: result.account_state ?? 'unclaimed', replayed: result.replayed === true,
+    expiresAt: result.expires_at ?? null, accountState, replayed: result.replayed === true,
   };
 }
 
@@ -263,9 +335,15 @@ export async function handleProtectedMinorServiceRoute(
   path: string,
   env: ProtectedMinorEnv,
   corsHeaders: Record<string, string>,
+  prepareDb?: (db: D1Database) => Promise<void>,
 ): Promise<Response> {
   if (!(await verifyProtectedMinorService(request, env))) return json({ error: 'unauthorized' }, 401, corsHeaders);
   if (!env.DB) return json({ error: 'service_unavailable' }, 503, corsHeaders);
+  try {
+    if (prepareDb) await prepareDb(env.DB);
+  } catch {
+    return json({ error: 'service_unavailable' }, 503, corsHeaders);
+  }
   let body: Record<string, unknown>;
   try { body = await request.json(); } catch { return json({ error: 'invalid_request' }, 400, corsHeaders); }
   try {

--- a/worker/src/protected-minors.ts
+++ b/worker/src/protected-minors.ts
@@ -3,7 +3,7 @@
 
 import { createMinorAccount, type KeycastEnv } from './keycast-client';
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const PUBKEY_RE = /^[0-9a-f]{64}$/;
 
 export interface ProtectedMinorEnv extends KeycastEnv {
@@ -68,6 +68,7 @@ export async function clearSubject(
   pubkey: string,
   clearedBy: string | undefined,
   reason: string,
+  expectedSubjectId?: string,
 ): Promise<{ success: boolean; projectionPubkey?: string; error?: string }> {
   try {
     const now = new Date().toISOString();
@@ -76,8 +77,9 @@ export async function clearSubject(
           WHERE current.subject_id = s.subject_id AND current.unbound_at IS NULL LIMIT 1) AS projection_pubkey
       FROM protected_minor_subjects s
       JOIN protected_minor_account_bindings history ON history.subject_id = s.subject_id
-      WHERE history.pubkey = ?
-      ORDER BY (history.unbound_at IS NULL) DESC, datetime(history.bound_at) DESC, history.rowid DESC LIMIT 1`).bind(pubkey)
+      WHERE history.pubkey = ? AND (? IS NULL OR s.subject_id = ?)
+      ORDER BY (history.unbound_at IS NULL) DESC, datetime(history.bound_at) DESC, history.rowid DESC LIMIT 1`)
+      .bind(pubkey, expectedSubjectId ?? null, expectedSubjectId ?? null)
       .first<{ subject_id: string; classification_state: string; projection_pubkey: string | null }>();
     const projectionPubkey = subject?.projection_pubkey ?? pubkey;
     if (!subject || subject.classification_state === 'cleared') return { success: true, projectionPubkey };
@@ -103,10 +105,38 @@ export async function markProjectionComplete(db: D1Database, pubkey: string): Pr
     WHERE pubkey = ? AND state = 'pending'`).bind(new Date().toISOString(), pubkey).run();
 }
 
+export async function markProjectionAttempt(db: D1Database, pubkey: string): Promise<void> {
+  await db.prepare(`UPDATE protected_minor_projection_jobs SET updated_at = ?
+    WHERE pubkey = ? AND state = 'pending'`).bind(new Date().toISOString(), pubkey).run();
+}
+
 export async function pendingProjectionJobs(db: D1Database): Promise<Array<{ pubkey: string; reason: string }>> {
   const rows = await db.prepare(`SELECT pubkey, reason FROM protected_minor_projection_jobs
-    WHERE state = 'pending' ORDER BY created_at LIMIT 100`).all<{ pubkey: string; reason: string }>();
+    WHERE state = 'pending' ORDER BY updated_at, created_at LIMIT 100`).all<{ pubkey: string; reason: string }>();
   return rows.results.filter((row) => typeof row.pubkey === 'string' && typeof row.reason === 'string');
+}
+
+export async function pendingSubjectClears(db: D1Database): Promise<Array<{
+  subjectId: string; pubkey: string; clearedBy?: string; reason: 'age_review_denied' | 'age_review_expired';
+}>> {
+  const rows = await db.prepare(`SELECT s.subject_id, c.pubkey, c.moderator_pubkey, c.resolution_note
+    FROM protected_minor_subjects s
+    JOIN protected_minor_account_bindings b ON b.subject_id = s.subject_id
+    JOIN age_review_cases c ON c.pubkey = b.pubkey AND c.state = 'denied_closed'
+    WHERE s.classification_state = 'active'
+      AND c.rowid = (SELECT c2.rowid FROM age_review_cases c2
+        JOIN protected_minor_account_bindings b2 ON b2.pubkey = c2.pubkey
+        WHERE b2.subject_id = s.subject_id AND c2.state = 'denied_closed'
+        ORDER BY datetime(c2.updated_at) DESC, c2.rowid DESC LIMIT 1)
+    ORDER BY datetime(c.updated_at), c.rowid LIMIT 100`).all<{
+      subject_id: string; pubkey: string; moderator_pubkey: string | null; resolution_note: string | null;
+    }>();
+  return rows.results.map((row) => ({
+    subjectId: row.subject_id,
+    pubkey: row.pubkey,
+    clearedBy: row.moderator_pubkey ?? undefined,
+    reason: row.resolution_note?.startsWith('Auto-closed:') ? 'age_review_expired' : 'age_review_denied',
+  }));
 }
 
 export async function resolveByPubkey(db: D1Database, pubkey: string): Promise<{ subjectRef: string } | null> {

--- a/worker/test/protected-minors.d1.test.ts
+++ b/worker/test/protected-minors.d1.test.ts
@@ -2,7 +2,7 @@ import { Miniflare } from 'miniflare';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ensureSchema } from '../src/db';
 import { handleCreateMinorAccount } from '../src/age-review';
-import { backfillProtectedMinorSubjects, clearSubject, closeBinding, createSubjectWithBinding, fingerprintProvisioningRequest, handleProtectedMinorServiceRoute, resolveByPubkey, startOrResumeReplacement } from '../src/protected-minors';
+import { backfillProtectedMinorSubjects, clearSubject, closeBinding, createSubjectWithBinding, fingerprintProvisioningRequest, handleProtectedMinorServiceRoute, pendingSubjectClears, resolveByPubkey, startOrResumeReplacement } from '../src/protected-minors';
 
 const PUBKEY_A = 'a'.repeat(64);
 const PUBKEY_B = 'b'.repeat(64);
@@ -68,6 +68,19 @@ describe('protected-minor registry on real D1', () => {
     expect(await resolveByPubkey(DB, PUBKEY_B)).toBeNull();
     const job = await DB.prepare('SELECT pubkey, state FROM protected_minor_projection_jobs').first();
     expect(job).toEqual({ pubkey: PUBKEY_B, state: 'pending' });
+  });
+
+  it('derives subject-clear retries from terminal denial rows', async () => {
+    const { subjectId } = await createSubjectWithBinding(DB, 'case-a', PUBKEY_A);
+    await DB.prepare(`INSERT INTO age_review_cases
+      (id, pubkey, state, moderator_pubkey, resolution_note, created_at, updated_at)
+      VALUES ('deny-a', ?, 'denied_closed', ?, 'Denied by moderator', ?, ?)`)
+      .bind(PUBKEY_A, PUBKEY_B, '2026-01-01T00:00:00Z', '2026-01-02T00:00:00Z').run();
+    expect(await pendingSubjectClears(DB)).toEqual([{
+      subjectId, pubkey: PUBKEY_A, clearedBy: PUBKEY_B, reason: 'age_review_denied',
+    }]);
+    await clearSubject(DB, PUBKEY_A, PUBKEY_B, 'age_review_denied', subjectId);
+    expect(await pendingSubjectClears(DB)).toEqual([]);
   });
 
   it('serves the frozen resolve and close response shapes without logging the subject reference', async () => {

--- a/worker/test/protected-minors.d1.test.ts
+++ b/worker/test/protected-minors.d1.test.ts
@@ -1,0 +1,150 @@
+import { Miniflare } from 'miniflare';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ensureSchema } from '../src/db';
+import { handleCreateMinorAccount } from '../src/age-review';
+import { backfillProtectedMinorSubjects, clearSubject, closeBinding, createSubjectWithBinding, handleProtectedMinorServiceRoute, resolveByPubkey, startOrResumeReplacement } from '../src/protected-minors';
+
+const PUBKEY_A = 'a'.repeat(64);
+const PUBKEY_B = 'b'.repeat(64);
+const ATTEMPT_A = '11111111-1111-4111-8111-111111111111';
+let mf: Miniflare;
+let DB: D1Database;
+
+beforeAll(async () => {
+  mf = new Miniflare({ modules: true, script: 'export default { fetch() { return new Response("ok"); } };',
+    compatibilityDate: '2024-12-01', compatibilityFlags: ['nodejs_compat'], d1Databases: ['DB'] });
+  DB = (await mf.getD1Database('DB')) as unknown as D1Database;
+  await ensureSchema(DB);
+});
+afterAll(async () => mf.dispose());
+beforeEach(async () => {
+  await DB.prepare('DELETE FROM protected_minor_projection_jobs').run();
+  await DB.prepare('DELETE FROM protected_minor_provisioning_operations').run();
+  await DB.prepare('DELETE FROM protected_minor_account_bindings').run();
+  await DB.prepare('DELETE FROM protected_minor_subjects').run();
+  await DB.prepare('DELETE FROM age_review_cases').run();
+});
+
+describe('protected-minor registry on real D1', () => {
+  it('ensureSchema creates all registry tables and remains idempotent', async () => {
+    await expect(ensureSchema(DB)).resolves.not.toThrow();
+    const rows = await DB.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'protected_minor_%' ORDER BY name`).all<{ name: string }>();
+    expect(rows.results.map((row) => row.name)).toEqual([
+      'protected_minor_account_bindings', 'protected_minor_projection_jobs',
+      'protected_minor_provisioning_operations', 'protected_minor_subjects',
+    ]);
+  });
+
+  it('resolves active subjects and clear wins without deleting binding history', async () => {
+    const { subjectId } = await createSubjectWithBinding(DB, 'case-a', PUBKEY_A);
+    expect(await resolveByPubkey(DB, PUBKEY_A)).toEqual({ subjectRef: subjectId });
+    await expect(clearSubject(DB, PUBKEY_A, undefined, 'age_review_denied')).resolves.toEqual({ success: true });
+    await expect(clearSubject(DB, PUBKEY_A, undefined, 'age_review_denied')).resolves.toEqual({ success: true });
+    expect(await resolveByPubkey(DB, PUBKEY_A)).toBeNull();
+    const binding = await DB.prepare('SELECT subject_id, unbound_at FROM protected_minor_account_bindings').first();
+    expect(binding).toEqual({ subject_id: subjectId, unbound_at: null });
+    const job = await DB.prepare('SELECT state FROM protected_minor_projection_jobs').first<{ state: string }>();
+    expect(job?.state).toBe('pending');
+  });
+
+  it('closes idempotently and rejects conflicting or stale deliveries', async () => {
+    const { subjectId } = await createSubjectWithBinding(DB, 'case-a', PUBKEY_A);
+    expect(await closeBinding(DB, subjectId, PUBKEY_A, ATTEMPT_A)).toBe('closed');
+    expect(await closeBinding(DB, subjectId, PUBKEY_A, ATTEMPT_A)).toBe('closed');
+    expect(await closeBinding(DB, subjectId, PUBKEY_B, ATTEMPT_A)).toBe('idempotency_conflict');
+    expect(await closeBinding(DB, subjectId, PUBKEY_A, '22222222-2222-4222-8222-222222222222')).toBe('stale_binding');
+  });
+
+  it('serves the frozen resolve and close response shapes without logging the subject reference', async () => {
+    const { subjectId } = await createSubjectWithBinding(DB, 'case-a', PUBKEY_A);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const env = { DB, PROTECTED_MINOR_SERVICE_TOKEN: 'service-token' };
+    const resolve = await handleProtectedMinorServiceRoute(new Request('https://api.test/api/internal/protected-minors/resolve', {
+      method: 'POST', headers: { Authorization: 'Bearer service-token' }, body: JSON.stringify({ pubkey: PUBKEY_A }),
+    }), '/api/internal/protected-minors/resolve', env, {});
+    expect(resolve.status).toBe(200);
+    expect(await resolve.json()).toEqual({ classification: 'active', subject_ref: subjectId, binding_state: 'active' });
+    const close = await handleProtectedMinorServiceRoute(new Request('https://api.test/api/internal/protected-minors/bindings/close', {
+      method: 'POST', headers: { Authorization: 'Bearer service-token' },
+      body: JSON.stringify({ subject_ref: subjectId, pubkey: PUBKEY_A, deletion_attempt_id: ATTEMPT_A }),
+    }), '/api/internal/protected-minors/bindings/close', env, {});
+    expect(close.status).toBe(200);
+    expect(await close.json()).toEqual({ outcome: 'closed' });
+    expect(JSON.stringify([...log.mock.calls, ...error.mock.calls])).not.toContain(subjectId);
+    log.mockRestore();
+    error.mockRestore();
+  });
+
+  it('enforces at most one active binding per subject and pubkey', async () => {
+    const { subjectId } = await createSubjectWithBinding(DB, 'case-a', PUBKEY_A);
+    await expect(DB.prepare(`INSERT INTO protected_minor_account_bindings (id, subject_id, pubkey, bound_at)
+      VALUES (?, ?, ?, ?)`).bind(crypto.randomUUID(), subjectId, PUBKEY_B, new Date().toISOString()).run()).rejects.toThrow();
+    const second = await createSubjectWithBinding(DB, 'case-b', PUBKEY_B);
+    await expect(DB.prepare(`UPDATE protected_minor_account_bindings SET pubkey = ? WHERE subject_id = ?`)
+      .bind(PUBKEY_A, second.subjectId).run()).rejects.toThrow();
+  });
+
+  it('backfills onboarding provenance, later denial, duplicates, and is idempotent', async () => {
+    await DB.prepare(`INSERT INTO age_review_cases (id, pubkey, state, created_via, created_at, updated_at)
+      VALUES ('onboard-a', ?, 'cleared', 'minor_onboarding', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+             ('duplicate-a', ?, 'cleared', 'minor_onboarding', '2026-01-02T00:00:00Z', '2026-01-02T00:00:00Z'),
+             ('deny-a', ?, 'denied_closed', 'report', '2026-01-03T00:00:00Z', '2026-01-04T00:00:00Z'),
+             ('onboard-b', ?, 'cleared', 'minor_onboarding', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')`)
+      .bind(PUBKEY_A, PUBKEY_A, PUBKEY_A, PUBKEY_B).run();
+    expect(await backfillProtectedMinorSubjects(DB)).toEqual({ created: 2, skippedDuplicates: 1 });
+    expect(await backfillProtectedMinorSubjects(DB)).toEqual({ created: 0, skippedDuplicates: 1 });
+    expect(await resolveByPubkey(DB, PUBKEY_A)).toBeNull();
+    expect(await resolveByPubkey(DB, PUBKEY_B)).not.toBeNull();
+    const copied = await DB.prepare(`SELECT parent_contact_email FROM age_review_cases WHERE id = 'onboard-a'`).first();
+    expect(copied).toEqual({ parent_contact_email: null });
+  });
+
+  it('replays replacement with the same operation and a clear wins stale retries', async () => {
+    const { subjectId } = await createSubjectWithBinding(DB, 'case-a', PUBKEY_A);
+    await closeBinding(DB, subjectId, PUBKEY_A, ATTEMPT_A);
+    const replacementPubkey = 'c'.repeat(64);
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ pubkey: replacementPubkey, claim_url: 'https://claim.test/one',
+        expires_at: '2026-09-01T00:00:00Z', account_state: 'unclaimed', replayed: false }), { status: 201 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ pubkey: replacementPubkey, claim_url: 'https://claim.test/one',
+        expires_at: '2026-09-01T00:00:00Z', account_state: 'unclaimed', replayed: true }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const input = { subjectRef: subjectId, provisioningOperationId: '33333333-3333-4333-8333-333333333333', username: 'replacement' };
+    const env = { DB, KEYCAST_URL: 'https://keycast.test', KEYCAST_SERVICE_TOKEN: 'token' };
+    expect((await startOrResumeReplacement(env, input)).outcome).toBe('complete');
+    expect((await startOrResumeReplacement(env, input)).outcome).toBe('complete');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await clearSubject(DB, replacementPubkey, undefined, 'age_review_denied');
+    const stale = await startOrResumeReplacement(env, input);
+    expect(stale).toEqual({ outcome: 'conflict', code: 'classification_cleared' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    vi.unstubAllGlobals();
+  });
+
+  it('records onboarding case, subject, binding, and operation atomically and replays safely', async () => {
+    const operationId = '44444444-4444-4444-8444-444444444444';
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ pubkey: PUBKEY_A, claim_url: 'https://claim.test/onboard',
+        expires_at: '2026-09-01T00:00:00Z', account_state: 'unclaimed', replayed: false }), { status: 201 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ pubkey: PUBKEY_A, claim_url: 'https://claim.test/onboard',
+        expires_at: '2026-09-01T00:00:00Z', account_state: 'unclaimed', replayed: true }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const makeRequest = () => new Request('https://api.test/api/age-review/create-minor-account', {
+      method: 'POST', body: JSON.stringify({ username: 'new-minor', provisioning_operation_id: operationId }),
+    });
+    const env = { DB, KEYCAST_URL: 'https://keycast.test', KEYCAST_SERVICE_TOKEN: 'token' };
+    expect((await handleCreateMinorAccount(makeRequest(), env, {})).status).toBe(200);
+    expect((await handleCreateMinorAccount(makeRequest(), env, {})).status).toBe(200);
+    const counts = await DB.prepare(`SELECT
+      (SELECT count(*) FROM age_review_cases) AS cases,
+      (SELECT count(*) FROM protected_minor_subjects) AS subjects,
+      (SELECT count(*) FROM protected_minor_account_bindings) AS bindings,
+      (SELECT count(*) FROM protected_minor_provisioning_operations) AS operations`).first<{
+        cases: number; subjects: number; bindings: number; operations: number;
+      }>();
+    expect(counts).toEqual({ cases: 1, subjects: 1, bindings: 1, operations: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    vi.unstubAllGlobals();
+  });
+});

--- a/worker/test/protected-minors.d1.test.ts
+++ b/worker/test/protected-minors.d1.test.ts
@@ -2,10 +2,11 @@ import { Miniflare } from 'miniflare';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ensureSchema } from '../src/db';
 import { handleCreateMinorAccount } from '../src/age-review';
-import { backfillProtectedMinorSubjects, clearSubject, closeBinding, createSubjectWithBinding, handleProtectedMinorServiceRoute, resolveByPubkey, startOrResumeReplacement } from '../src/protected-minors';
+import { backfillProtectedMinorSubjects, clearSubject, closeBinding, createSubjectWithBinding, fingerprintProvisioningRequest, handleProtectedMinorServiceRoute, resolveByPubkey, startOrResumeReplacement } from '../src/protected-minors';
 
 const PUBKEY_A = 'a'.repeat(64);
 const PUBKEY_B = 'b'.repeat(64);
+const PUBKEY_C = 'c'.repeat(64);
 const ATTEMPT_A = '11111111-1111-4111-8111-111111111111';
 let mf: Miniflare;
 let DB: D1Database;
@@ -38,8 +39,8 @@ describe('protected-minor registry on real D1', () => {
   it('resolves active subjects and clear wins without deleting binding history', async () => {
     const { subjectId } = await createSubjectWithBinding(DB, 'case-a', PUBKEY_A);
     expect(await resolveByPubkey(DB, PUBKEY_A)).toEqual({ subjectRef: subjectId });
-    await expect(clearSubject(DB, PUBKEY_A, undefined, 'age_review_denied')).resolves.toEqual({ success: true });
-    await expect(clearSubject(DB, PUBKEY_A, undefined, 'age_review_denied')).resolves.toEqual({ success: true });
+    await expect(clearSubject(DB, PUBKEY_A, undefined, 'age_review_denied')).resolves.toEqual({ success: true, projectionPubkey: PUBKEY_A });
+    await expect(clearSubject(DB, PUBKEY_A, undefined, 'age_review_denied')).resolves.toEqual({ success: true, projectionPubkey: PUBKEY_A });
     expect(await resolveByPubkey(DB, PUBKEY_A)).toBeNull();
     const binding = await DB.prepare('SELECT subject_id, unbound_at FROM protected_minor_account_bindings').first();
     expect(binding).toEqual({ subject_id: subjectId, unbound_at: null });
@@ -53,6 +54,20 @@ describe('protected-minor registry on real D1', () => {
     expect(await closeBinding(DB, subjectId, PUBKEY_A, ATTEMPT_A)).toBe('closed');
     expect(await closeBinding(DB, subjectId, PUBKEY_B, ATTEMPT_A)).toBe('idempotency_conflict');
     expect(await closeBinding(DB, subjectId, PUBKEY_A, '22222222-2222-4222-8222-222222222222')).toBe('stale_binding');
+  });
+
+  it('clears through binding history and targets the current replacement projection', async () => {
+    const { subjectId } = await createSubjectWithBinding(DB, 'case-a', PUBKEY_A);
+    await closeBinding(DB, subjectId, PUBKEY_A, ATTEMPT_A);
+    await DB.prepare(`INSERT INTO protected_minor_account_bindings (id, subject_id, pubkey, bound_at)
+      VALUES (?, ?, ?, ?)`).bind(crypto.randomUUID(), subjectId, PUBKEY_B, new Date().toISOString()).run();
+
+    expect(await clearSubject(DB, PUBKEY_A, undefined, 'age_review_denied')).toEqual({
+      success: true, projectionPubkey: PUBKEY_B,
+    });
+    expect(await resolveByPubkey(DB, PUBKEY_B)).toBeNull();
+    const job = await DB.prepare('SELECT pubkey, state FROM protected_minor_projection_jobs').first();
+    expect(job).toEqual({ pubkey: PUBKEY_B, state: 'pending' });
   });
 
   it('serves the frozen resolve and close response shapes without logging the subject reference', async () => {
@@ -90,12 +105,15 @@ describe('protected-minor registry on real D1', () => {
       VALUES ('onboard-a', ?, 'cleared', 'minor_onboarding', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
              ('duplicate-a', ?, 'cleared', 'minor_onboarding', '2026-01-02T00:00:00Z', '2026-01-02T00:00:00Z'),
              ('deny-a', ?, 'denied_closed', 'report', '2026-01-03T00:00:00Z', '2026-01-04T00:00:00Z'),
-             ('onboard-b', ?, 'cleared', 'minor_onboarding', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')`)
-      .bind(PUBKEY_A, PUBKEY_A, PUBKEY_A, PUBKEY_B).run();
-    expect(await backfillProtectedMinorSubjects(DB)).toEqual({ created: 2, skippedDuplicates: 1 });
+             ('onboard-b', ?, 'cleared', 'minor_onboarding', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+             ('onboard-c', ?, 'cleared', 'minor_onboarding', '2026-01-05T00:00:00Z', '2026-01-05T00:00:00Z'),
+             ('deny-c', ?, 'denied_closed', 'report', '2026-01-05T00:00:00Z', '2026-01-05T00:00:00Z')`)
+      .bind(PUBKEY_A, PUBKEY_A, PUBKEY_A, PUBKEY_B, PUBKEY_C, PUBKEY_C).run();
+    expect(await backfillProtectedMinorSubjects(DB)).toEqual({ created: 3, skippedDuplicates: 1 });
     expect(await backfillProtectedMinorSubjects(DB)).toEqual({ created: 0, skippedDuplicates: 1 });
     expect(await resolveByPubkey(DB, PUBKEY_A)).toBeNull();
     expect(await resolveByPubkey(DB, PUBKEY_B)).not.toBeNull();
+    expect(await resolveByPubkey(DB, PUBKEY_C)).toBeNull();
     const copied = await DB.prepare(`SELECT parent_contact_email FROM age_review_cases WHERE id = 'onboard-a'`).first();
     expect(copied).toEqual({ parent_contact_email: null });
   });
@@ -119,6 +137,70 @@ describe('protected-minor registry on real D1', () => {
     const stale = await startOrResumeReplacement(env, input);
     expect(stale).toEqual({ outcome: 'conflict', code: 'classification_cleared' });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    vi.unstubAllGlobals();
+  });
+
+  it('does not provision a replacement until the old binding is closed', async () => {
+    const { subjectId } = await createSubjectWithBinding(DB, 'case-a', PUBKEY_A);
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const result = await startOrResumeReplacement(
+      { DB, KEYCAST_URL: 'https://keycast.test', KEYCAST_SERVICE_TOKEN: 'token' },
+      { subjectRef: subjectId, provisioningOperationId: '55555555-5555-4555-8555-555555555555', username: 'replacement' },
+    );
+    expect(result).toEqual({ outcome: 'conflict', code: 'stale_binding' });
+    expect(fetchMock).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects malformed replacement success and conflicting observed results', async () => {
+    const { subjectId } = await createSubjectWithBinding(DB, 'case-a', PUBKEY_A);
+    await closeBinding(DB, subjectId, PUBKEY_A, ATTEMPT_A);
+    const operationId = '77777777-7777-4777-8777-777777777777';
+    const env = { DB, KEYCAST_URL: 'https://keycast.test', KEYCAST_SERVICE_TOKEN: 'token' };
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ pubkey: PUBKEY_B }), { status: 201 })));
+    expect(await startOrResumeReplacement(env, {
+      subjectRef: subjectId, provisioningOperationId: operationId, username: 'replacement',
+    })).toEqual({ outcome: 'failed', error: 'Provisioning failed' });
+
+    const fingerprintHex = await fingerprintProvisioningRequest({ kind: 'replacement', username: 'replacement' });
+    await DB.prepare(`UPDATE protected_minor_provisioning_operations SET result_pubkey = ?, request_fingerprint = ?
+      WHERE provisioning_operation_id = ?`).bind(PUBKEY_C, fingerprintHex, operationId).run();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      pubkey: PUBKEY_B, claim_url: 'https://claim.test/replacement', expires_at: '2026-09-01T00:00:00Z',
+      account_state: 'unclaimed', replayed: true,
+    }), { status: 200 })));
+    expect(await startOrResumeReplacement(env, {
+      subjectRef: subjectId, provisioningOperationId: operationId, username: 'replacement',
+    })).toEqual({ outcome: 'conflict', code: 'provisioning_result_conflict' });
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects changed onboarding provenance and cross-kind operation reuse', async () => {
+    const operationId = '66666666-6666-4666-8666-666666666666';
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      pubkey: PUBKEY_A, claim_url: 'https://claim.test/onboard', expires_at: '2026-09-01T00:00:00Z',
+      account_state: 'unclaimed', replayed: false,
+    }), { status: 201 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const request = (ticketId: number) => new Request('https://api.test/api/age-review/create-minor-account', {
+      method: 'POST', body: JSON.stringify({
+        username: 'new-minor', zendesk_ticket_id: ticketId, provisioning_operation_id: operationId,
+      }),
+    });
+    const env = { DB, KEYCAST_URL: 'https://keycast.test', KEYCAST_SERVICE_TOKEN: 'token' };
+    expect((await handleCreateMinorAccount(request(101), env, {})).status).toBe(200);
+    expect((await handleCreateMinorAccount(request(202), env, {})).status).toBe(409);
+
+    const subject = await DB.prepare('SELECT subject_id FROM protected_minor_subjects').first<{ subject_id: string }>();
+    expect(subject).not.toBeNull();
+    await closeBinding(DB, subject!.subject_id, PUBKEY_A, ATTEMPT_A);
+    const replacement = await startOrResumeReplacement(env, {
+      subjectRef: subject!.subject_id, provisioningOperationId: operationId, username: 'new-minor',
+    });
+    expect(replacement).toEqual({ outcome: 'conflict', code: 'provisioning_operation_conflict' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     vi.unstubAllGlobals();
   });
 

--- a/worker/wrangler.prod.toml
+++ b/worker/wrangler.prod.toml
@@ -53,6 +53,11 @@ binding = "KEYCAST_SERVICE_TOKEN"
 store_id = "ef490704b12a4feb91c7feb51229c364"
 secret_name = "KEYCAST_SERVICE_TOKEN"
 
+[[secrets_store_secrets]]
+binding = "PROTECTED_MINOR_SERVICE_TOKEN"
+store_id = "ef490704b12a4feb91c7feb51229c364"
+secret_name = "PROTECTED_MINOR_SERVICE_TOKEN"
+
 # Zendesk API credentials (shared across workers)
 [[secrets_store_secrets]]
 binding = "ZENDESK_SUBDOMAIN"
@@ -113,6 +118,7 @@ ZENDESK_FIELD_AGE_REVIEW_DEADLINE = "16123853180303"
 ZENDESK_GROUP_ID = "15225535020687"
 # Keycast account suspension API
 KEYCAST_URL = "https://login.divine.video"
+PROTECTED_MINOR_REPLACEMENT_ENABLED = "false"
 
 # D1 Database for moderation decision log (production)
 [[d1_databases]]

--- a/worker/wrangler.staging.toml
+++ b/worker/wrangler.staging.toml
@@ -53,6 +53,11 @@ binding = "KEYCAST_SERVICE_TOKEN"
 store_id = "ef490704b12a4feb91c7feb51229c364"
 secret_name = "KEYCAST_SERVICE_TOKEN"
 
+[[secrets_store_secrets]]
+binding = "PROTECTED_MINOR_SERVICE_TOKEN"
+store_id = "ef490704b12a4feb91c7feb51229c364"
+secret_name = "PROTECTED_MINOR_SERVICE_TOKEN"
+
 # Zendesk API credentials (shared across workers)
 [[secrets_store_secrets]]
 binding = "ZENDESK_SUBDOMAIN"
@@ -114,6 +119,7 @@ ZENDESK_FIELD_ISSUE = "14560383908879"
 ZENDESK_FIELD_AGE_REVIEW_DEADLINE = "16123853180303"
 # Keycast account suspension API
 KEYCAST_URL = "https://login.staging.dvines.org"
+PROTECTED_MINOR_REPLACEMENT_ENABLED = "false"
 
 # D1 Database for moderation decision log (staging)
 [[d1_databases]]


### PR DESCRIPTION
Protected-minor status currently disappears when its Keycast account row is deleted, so a legitimate delete-and-replace flow can silently remove safeguards from a minor. This change makes Relay Manager retain that classification independently of any replaceable hosted account.

Relay Manager now stores an opaque protected subject, its current and historical account bindings, provisioning operations, and retryable Keycast projection jobs. Onboarding records the case, subject, binding, and completed operation together after retry-safe Keycast provisioning. Authorized denial clears the durable subject first, then converges Keycast; failed projection calls remain queued for the deadline scheduler to retry.

Funnelcake receives dedicated bearer-only resolve and idempotent binding-close endpoints with the frozen determinate response shapes. Replacement provisioning persists and reuses the caller operation ID, rejects stale or cleared subjects, and remains disabled by configuration until Keycast #385 and the retention gate are ready. The registry does not copy parent contact, identity-review evidence, credentials, usernames, or display names.

This deliberately leaves ReportWatcher reading Keycast verified_minor as the enforcement projection. It also does not enable production replacement or resolve the Cloudflare Access service-token policy; rollout ordering and rollback constraints are documented.

Validation:
- npm run test (66 files, 692 passed, 1 skipped; type-check, lint, tests, and production build)
- cd worker && npx vitest run (22 files, 644 tests)
- cd worker && npm run test:d1 (7 files, 47 tests)
- cd worker && npx tsc -p tsconfig.json --noEmit

Closes #244
Refs divinevideo/support-trust-safety#203
Refs divinevideo/divine-funnelcake#1118
Refs divinevideo/keycast#385
